### PR TITLE
fix: configure Docker Buildx to use container driver for cache support

### DIFF
--- a/.github/workflows/auth-service.yml
+++ b/.github/workflows/auth-service.yml
@@ -55,6 +55,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -57,6 +57,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,6 +52,8 @@ jobs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
 
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3

--- a/.github/workflows/company-service.yml
+++ b/.github/workflows/company-service.yml
@@ -55,6 +55,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/contact-service.yml
+++ b/.github/workflows/contact-service.yml
@@ -55,6 +55,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/user-service.yml
+++ b/.github/workflows/user-service.yml
@@ -55,6 +55,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker-container
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v3
       with:


### PR DESCRIPTION
ERROR FIXED:
- 'Cache export is not supported for the docker driver'
- GitHub Actions cache couldn't be exported with default driver

SOLUTION:
- Configure Docker Buildx to use 'docker-container' driver
- This driver supports cache export/import operations
- Enables proper layer caching in CI/CD pipeline

CHANGES:
- Add 'driver: docker-container' to all docker/setup-buildx-action steps
- Applied to all 6 workflow files for consistency

RESULT:
- Docker builds can now use GitHub Actions cache (type=gha)
- Faster subsequent builds with proper layer caching
- No more cache export errors in CI/CD pipeline