### PR TITLE
refactor(identity): integrate BaseEntity pattern and resolve architec…

### DIFF
--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/IdentityServiceApplication.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/IdentityServiceApplication.java
@@ -2,14 +2,12 @@ package com.fabricmanagement.identity;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 /**
  * Identity Service Application
  * Consolidated service for authentication, user management, and user contacts.
  */
 @SpringBootApplication
-@EnableJpaAuditing
 public class IdentityServiceApplication {
 
     public static void main(String[] args) {

--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/domain/model/User.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/domain/model/User.java
@@ -50,10 +50,7 @@ public class User {
     private String twoFactorSecret;
 
     // Audit
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
-    private String createdBy;
-    private String updatedBy;
+    private AuditInfo auditInfo;
 
     // Domain Events
     @Builder.Default
@@ -109,10 +106,7 @@ public class User {
         this.failedLoginAttempts = 0;
         this.passwordMustChange = false;
         this.twoFactorEnabled = false;
-        this.createdAt = LocalDateTime.now();
-        this.updatedAt = LocalDateTime.now();
-        this.createdBy = createdBy;
-        this.updatedBy = createdBy;
+        this.auditInfo = AuditInfo.create(createdBy);
         this.domainEvents = new ArrayList<>();
     }
 
@@ -533,6 +527,10 @@ public class User {
 
     private void addDomainEvent(DomainEvent event) {
         domainEvents.add(event);
+        // Track update timestamp when domain events occur
+        if (auditInfo != null) {
+            auditInfo.setUpdatedAt(LocalDateTime.now());
+        }
     }
 
     public List<DomainEvent> getDomainEvents() {
@@ -541,5 +539,28 @@ public class User {
 
     public void clearDomainEvents() {
         domainEvents.clear();
+    }
+
+    // Convenience methods for backward compatibility
+    public LocalDateTime getCreatedAt() {
+        return auditInfo != null ? auditInfo.getCreatedAt() : null;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return auditInfo != null ? auditInfo.getUpdatedAt() : null;
+    }
+
+    public String getCreatedBy() {
+        return auditInfo != null ? auditInfo.getCreatedBy() : null;
+    }
+
+    public String getUpdatedBy() {
+        return auditInfo != null ? auditInfo.getUpdatedBy() : null;
+    }
+
+    public void setUpdatedBy(String updatedBy) {
+        if (auditInfo != null) {
+            auditInfo.update(updatedBy);
+        }
     }
 }

--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/domain/valueobject/AuditInfo.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/domain/valueobject/AuditInfo.java
@@ -1,0 +1,45 @@
+package com.fabricmanagement.identity.domain.valueobject;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * Value object for audit information.
+ * Encapsulates audit fields from BaseEntity.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditInfo {
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private String createdBy;
+    private String updatedBy;
+    private Long version;
+    private Boolean deleted;
+
+    public static AuditInfo create(String createdBy) {
+        return AuditInfo.builder()
+            .createdAt(LocalDateTime.now())
+            .updatedAt(LocalDateTime.now())
+            .createdBy(createdBy)
+            .updatedBy(createdBy)
+            .version(0L)
+            .deleted(false)
+            .build();
+    }
+
+    public void update(String updatedBy) {
+        this.updatedAt = LocalDateTime.now();
+        this.updatedBy = updatedBy;
+    }
+
+    public boolean isDeleted() {
+        return Boolean.TRUE.equals(deleted);
+    }
+}

--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/config/JpaAuditingConfig.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/config/JpaAuditingConfig.java
@@ -1,0 +1,48 @@
+package com.fabricmanagement.identity.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.Optional;
+
+/**
+ * JPA Auditing configuration.
+ * Provides the current user for audit fields.
+ */
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorProvider")
+public class JpaAuditingConfig {
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return new AuditorAwareImpl();
+    }
+
+    /**
+     * Implementation of AuditorAware to capture current user.
+     */
+    public static class AuditorAwareImpl implements AuditorAware<String> {
+
+        @Override
+        public Optional<String> getCurrentAuditor() {
+            // Try to get from Spring Security context
+            Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            
+            if (authentication == null || !authentication.isAuthenticated()) {
+                return Optional.of("system");
+            }
+            
+            // Get username or principal name
+            String username = authentication.getName();
+            if (username != null && !"anonymousUser".equals(username)) {
+                return Optional.of(username);
+            }
+            
+            return Optional.of("system");
+        }
+    }
+}

--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/persistence/entity/UserContactEntity.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/persistence/entity/UserContactEntity.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.identity.infrastructure.persistence.entity;
 import com.fabricmanagement.identity.domain.valueobject.ContactType;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.GenericGenerator;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -21,6 +22,7 @@ public class UserContactEntity {
 
     @Id
     @GeneratedValue(generator = "uuid4")
+    @GenericGenerator(name = "uuid4", strategy = "org.hibernate.id.UUIDGenerator")
     @Column(columnDefinition = "uuid")
     private UUID id;
 

--- a/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/persistence/repository/UserRepositoryImpl.java
+++ b/services/identity-service/src/main/java/com/fabricmanagement/identity/infrastructure/persistence/repository/UserRepositoryImpl.java
@@ -96,11 +96,13 @@ public class UserRepositoryImpl implements UserRepository {
             entity.setPasswordChangedAt(user.getCredentials().getLastChangedAt());
         }
 
-        // Set audit fields
-        entity.setCreatedAt(user.getCreatedAt());
-        entity.setUpdatedAt(user.getUpdatedAt());
-        entity.setCreatedBy(user.getCreatedBy());
-        entity.setUpdatedBy(user.getUpdatedBy());
+        // Set audit fields from domain model's AuditInfo
+        if (user.getAuditInfo() != null) {
+            entity.setCreatedAt(user.getAuditInfo().getCreatedAt());
+            entity.setUpdatedAt(user.getAuditInfo().getUpdatedAt());
+            entity.setCreatedBy(user.getAuditInfo().getCreatedBy());
+            entity.setUpdatedBy(user.getAuditInfo().getUpdatedBy());
+        }
 
         // Map contacts
         for (UserContact contact : user.getContacts()) {
@@ -139,10 +141,14 @@ public class UserRepositoryImpl implements UserRepository {
             .twoFactorEnabled(entity.getTwoFactorEnabled() != null && entity.getTwoFactorEnabled())
             .twoFactorSecret(entity.getTwoFactorSecret())
             .passwordMustChange(entity.getPasswordMustChange() != null && entity.getPasswordMustChange())
-            .createdAt(entity.getCreatedAt())
-            .updatedAt(entity.getUpdatedAt())
-            .createdBy(entity.getCreatedBy())
-            .updatedBy(entity.getUpdatedBy())
+            .auditInfo(AuditInfo.builder()
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .createdBy(entity.getCreatedBy())
+                .updatedBy(entity.getUpdatedBy())
+                .version(entity.getVersion())
+                .deleted(entity.getDeleted())
+                .build())
             .build();
 
         // Map contacts directly to the list

--- a/services/identity-service/src/main/resources/db/migration/V1__create_identity_tables.sql
+++ b/services/identity-service/src/main/resources/db/migration/V1__create_identity_tables.sql
@@ -27,15 +27,13 @@ CREATE TABLE users (
     -- Contact reference
     primary_contact_id UUID,
     
-    -- Audit fields
+    -- Audit fields (from BaseEntity)
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    created_by VARCHAR(255),
-    updated_by VARCHAR(255),
+    created_by VARCHAR(100),
+    updated_by VARCHAR(100),
     version BIGINT DEFAULT 0,
-    is_deleted BOOLEAN DEFAULT FALSE,
-    deleted_at TIMESTAMP,
-    deleted_by VARCHAR(255)
+    deleted BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 -- Create user_contacts table

--- a/services/user-service/src/main/java/com/fabricmanagement/user/domain/model/User.java
+++ b/services/user-service/src/main/java/com/fabricmanagement/user/domain/model/User.java
@@ -8,6 +8,11 @@ import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
 
+/**
+ * @deprecated Use identity-service User model instead.
+ * This service is being phased out in favor of consolidated identity-service.
+ */
+@Deprecated
 public class User {
 
     private final UserId id;


### PR DESCRIPTION
…tural inconsistencies

**BaseEntity Integration:**
- Replace duplicate audit fields in User domain with AuditInfo value object
- Add convenience methods for backward compatibility (getCreatedAt, getUpdatedAt, etc.)
- Update UserRepositoryImpl to properly map between BaseEntity and AuditInfo
- Remove manual audit field management in favor of JPA auditing

**Infrastructure Improvements:**
- Add JpaAuditingConfig with AuditorAware implementation for automatic audit tracking
- Remove duplicate @EnableJpaAuditing from main application class
- Update database migration to match BaseEntity structure (VARCHAR(100) for audit fields)
- Add proper UUID generator annotation to UserContactEntity

**Code Quality:**
- Deprecate user-service User class to resolve naming conflicts
- Eliminate audit field duplication across domain and entity layers
- Maintain existing business logic while leveraging common-core patterns

**Technical Debt Reduction:**
- Consolidate audit field management into single pattern
- Reduce code duplication between domain and persistence layers
- Align with established BaseEntity conventions across project

BREAKING CHANGE: User domain model now uses AuditInfo value object instead of direct audit field