### PR TITLE
feat(procurement): enrich purchase order specs with textile parameters

### DIFF
--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/DyePurchaseOrderValidator.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/DyePurchaseOrderValidator.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.procurement.purchaseorder.app.validation;
 
+import static com.fabricmanagement.procurement.purchaseorder.app.validation.TextileValidationConstants.*;
+
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.DyePurchaseSpecs;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
@@ -10,11 +12,10 @@ import org.springframework.stereotype.Component;
 /**
  * Validates {@link DyePurchaseSpecs} for dye/finishing purchase orders.
  *
- * <p>Create phase: no strict rules (draft can be saved with partial info while lab-dip is
- * in-progress).
+ * <p>Create phase: enforces lightness target length boundaries.
  *
- * <p>Confirm phase: colorCode and approvalDocumentId are mandatory. A dye PO cannot be sent to a
- * supplier without an approved lab-dip result.
+ * <p>Confirm phase: colorCode, approvalDocumentId, and applicationMethod are mandatory. A dye PO
+ * cannot be sent to a supplier without an approved lab-dip result.
  */
 @Component
 public class DyePurchaseOrderValidator implements PurchaseOrderValidator {
@@ -26,9 +27,13 @@ public class DyePurchaseOrderValidator implements PurchaseOrderValidator {
 
   @Override
   public List<String> validateOnCreate(PurchaseOrderSpecs specs) {
-    // No create-phase rules for dye — lab-dip process is iterative,
-    // drafts are saved with partial data intentionally
-    return List.of();
+    var violations = new ArrayList<String>();
+    if (specs instanceof DyePurchaseSpecs dye) {
+      if (dye.lightnessTarget() != null && dye.lightnessTarget().length() > LIGHTNESS_MAX_LENGTH) {
+        violations.add("Lightness target must not exceed " + LIGHTNESS_MAX_LENGTH + " characters");
+      }
+    }
+    return violations;
   }
 
   @Override
@@ -46,6 +51,9 @@ public class DyePurchaseOrderValidator implements PurchaseOrderValidator {
         violations.add(
             "Approval document is required before sending dye order to supplier"
                 + " (lab-dip must be approved first)");
+      }
+      if (dye.applicationMethod() == null || dye.applicationMethod().isBlank()) {
+        violations.add("Application method is required before sending dye order to supplier");
       }
     }
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/FabricPurchaseOrderValidator.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/FabricPurchaseOrderValidator.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.procurement.purchaseorder.app.validation;
 
+import static com.fabricmanagement.procurement.purchaseorder.app.validation.TextileValidationConstants.*;
+
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.FabricPurchaseSpecs;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
@@ -10,9 +12,10 @@ import org.springframework.stereotype.Component;
 /**
  * Validates {@link FabricPurchaseSpecs} against textile domain rules.
  *
- * <p>Create phase: GSM 80-400, width 100-320 cm (AGENTS.md Textile Domain).
+ * <p>Create phase: GSM 80-400, width 100-320 cm (AGENTS.md Textile Domain). Shrinkage between -15%
+ * and +15%.
  *
- * <p>Confirm phase: construction must be specified.
+ * <p>Confirm phase: construction, composition, and fabricType must be specified.
  */
 @Component
 public class FabricPurchaseOrderValidator implements PurchaseOrderValidator {
@@ -27,11 +30,29 @@ public class FabricPurchaseOrderValidator implements PurchaseOrderValidator {
     var violations = new ArrayList<String>();
 
     if (specs instanceof FabricPurchaseSpecs fabric) {
-      if (fabric.gsm() != null && (fabric.gsm() < 80 || fabric.gsm() > 400)) {
-        violations.add("GSM must be between 80 and 400, got: " + fabric.gsm());
+      if (fabric.gsm() != null && (fabric.gsm() < GSM_MIN || fabric.gsm() > GSM_MAX)) {
+        violations.add(
+            "GSM must be between " + GSM_MIN + " and " + GSM_MAX + ", got: " + fabric.gsm());
       }
-      if (fabric.widthCm() != null && (fabric.widthCm() < 100 || fabric.widthCm() > 320)) {
-        violations.add("Width must be between 100 and 320 cm, got: " + fabric.widthCm());
+      if (fabric.widthCm() != null
+          && (fabric.widthCm() < WIDTH_CM_MIN || fabric.widthCm() > WIDTH_CM_MAX)) {
+        violations.add(
+            "Width must be between "
+                + WIDTH_CM_MIN
+                + " and "
+                + WIDTH_CM_MAX
+                + " cm, got: "
+                + fabric.widthCm());
+      }
+      if (fabric.shrinkage() != null
+          && (fabric.shrinkage() < SHRINKAGE_MIN || fabric.shrinkage() > SHRINKAGE_MAX)) {
+        violations.add(
+            "Shrinkage must be between "
+                + SHRINKAGE_MIN
+                + " and "
+                + SHRINKAGE_MAX
+                + "%, got: "
+                + fabric.shrinkage());
       }
     }
 
@@ -47,6 +68,12 @@ public class FabricPurchaseOrderValidator implements PurchaseOrderValidator {
     if (specs instanceof FabricPurchaseSpecs fabric) {
       if (fabric.construction() == null || fabric.construction().isBlank()) {
         violations.add("Fabric construction is required before sending to supplier");
+      }
+      if (fabric.composition() == null || fabric.composition().isBlank()) {
+        violations.add("Composition is required before sending to supplier");
+      }
+      if (fabric.fabricType() == null) {
+        violations.add("Fabric type is required before sending to supplier");
       }
     }
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/FiberPurchaseOrderValidator.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/FiberPurchaseOrderValidator.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.procurement.purchaseorder.app.validation;
 
+import static com.fabricmanagement.procurement.purchaseorder.app.validation.TextileValidationConstants.*;
+
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.FiberPurchaseSpecs;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
@@ -11,9 +13,10 @@ import org.springframework.stereotype.Component;
 /**
  * Validates {@link FiberPurchaseSpecs} against textile domain rules.
  *
- * <p>Create phase: grade must be A/B/C/SECOND (AGENTS.md Quality Grades), moisture 0-100%.
+ * <p>Create phase: grade must be A/B/C/SECOND (AGENTS.md Quality Grades), moisture 0-20%. Validates
+ * ranges for micronaire, strength, uniformity, and length bounds.
  *
- * <p>Confirm phase: grade is mandatory.
+ * <p>Confirm phase: grade and origin are mandatory.
  */
 @Component
 public class FiberPurchaseOrderValidator implements PurchaseOrderValidator {
@@ -34,9 +37,60 @@ public class FiberPurchaseOrderValidator implements PurchaseOrderValidator {
         violations.add("Fiber grade must be one of: A, B, C, SECOND, got: " + fiber.grade());
       }
       if (fiber.moistureContent() != null
-          && (fiber.moistureContent() < 0 || fiber.moistureContent() > 100)) {
+          && (fiber.moistureContent() < MOISTURE_MIN || fiber.moistureContent() > MOISTURE_MAX)) {
         violations.add(
-            "Moisture content must be between 0 and 100%, got: " + fiber.moistureContent());
+            "Moisture content must be between "
+                + MOISTURE_MIN
+                + " and "
+                + MOISTURE_MAX
+                + "%, got: "
+                + fiber.moistureContent());
+      }
+      if (fiber.micronaire() != null
+          && (fiber.micronaire() < MICRONAIRE_MIN || fiber.micronaire() > MICRONAIRE_MAX)) {
+        violations.add(
+            "Micronaire must be between "
+                + MICRONAIRE_MIN
+                + " and "
+                + MICRONAIRE_MAX
+                + ", got: "
+                + fiber.micronaire());
+      }
+      if (fiber.stapleLength() != null && fiber.stapleLength() <= 0) {
+        violations.add("Staple length must be greater than 0, got: " + fiber.stapleLength());
+      }
+      if (fiber.strength() != null && fiber.strength() <= 0) {
+        violations.add("Strength must be greater than 0, got: " + fiber.strength());
+      }
+      if (fiber.uniformityIndex() != null
+          && (fiber.uniformityIndex() < UNIFORMITY_MIN
+              || fiber.uniformityIndex() > UNIFORMITY_MAX)) {
+        violations.add(
+            "Uniformity index must be between "
+                + UNIFORMITY_MIN
+                + " and "
+                + UNIFORMITY_MAX
+                + "%, got: "
+                + fiber.uniformityIndex());
+      }
+      if (fiber.trashContent() != null
+          && (fiber.trashContent() < TRASH_MIN || fiber.trashContent() > TRASH_MAX)) {
+        violations.add(
+            "Trash content must be between "
+                + TRASH_MIN
+                + " and "
+                + TRASH_MAX
+                + "%, got: "
+                + fiber.trashContent());
+      }
+      if (fiber.colorGrade() != null && fiber.colorGrade().length() > COLOR_GRADE_MAX_LENGTH) {
+        violations.add("Color grade must not exceed " + COLOR_GRADE_MAX_LENGTH + " characters");
+      }
+      if (fiber.cropYear() != null && fiber.cropYear().length() > CROP_YEAR_MAX_LENGTH) {
+        violations.add("Crop year must not exceed " + CROP_YEAR_MAX_LENGTH + " characters");
+      }
+      if (fiber.origin() != null && fiber.origin().length() > ORIGIN_MAX_LENGTH) {
+        violations.add("Origin must not exceed " + ORIGIN_MAX_LENGTH + " characters");
       }
     }
 
@@ -52,6 +106,9 @@ public class FiberPurchaseOrderValidator implements PurchaseOrderValidator {
     if (specs instanceof FiberPurchaseSpecs fiber) {
       if (fiber.grade() == null || fiber.grade().isBlank()) {
         violations.add("Fiber grade is required before sending to supplier");
+      }
+      if (fiber.origin() == null || fiber.origin().isBlank()) {
+        violations.add("Origin is required before sending to supplier");
       }
     }
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/PurchaseOrderValidationEngine.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/PurchaseOrderValidationEngine.java
@@ -22,8 +22,9 @@ import org.springframework.stereotype.Component;
  * <p>Collects all {@link PurchaseOrderValidator} beans via Spring injection and dispatches
  * validation calls to the appropriate strategy based on {@link PurchaseOrderModuleType}.
  *
- * <p>If no validator is registered for a given type (e.g. GENERIC), validation passes silently
- * (Open-Closed Principle).
+ * <p>If no validator is registered for a given type (e.g., GENERIC), validation passes silently
+ * (Open-Closed Principle). GENERIC specs represent standard/miscellaneous items and intentionally
+ * have no strict technical boundaries.
  *
  * <p><b>Usage points in PurchaseOrderService:</b>
  *

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/TextileValidationConstants.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/TextileValidationConstants.java
@@ -1,0 +1,41 @@
+package com.fabricmanagement.procurement.purchaseorder.app.validation;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Constants used across module-specific PurchaseOrder validation strategies. Defines
+ * industry-standard ranges and boundaries for textile parameters.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TextileValidationConstants {
+
+  // Fiber
+  public static final double MICRONAIRE_MIN = 2.5;
+  public static final double MICRONAIRE_MAX = 6.0;
+  public static final double MOISTURE_MIN = 0.0;
+  public static final double MOISTURE_MAX = 20.0;
+  public static final double TRASH_MIN = 0.0;
+  public static final double TRASH_MAX = 10.0;
+  public static final double UNIFORMITY_MIN = 0.0;
+  public static final double UNIFORMITY_MAX = 100.0;
+
+  public static final int COLOR_GRADE_MAX_LENGTH = 20;
+  public static final int CROP_YEAR_MAX_LENGTH = 15;
+  public static final int ORIGIN_MAX_LENGTH = 50;
+
+  // Yarn
+  public static final double USTER_MIN = 0.0;
+  public static final double USTER_MAX = 100.0;
+
+  // Fabric
+  public static final int GSM_MIN = 80;
+  public static final int GSM_MAX = 400;
+  public static final int WIDTH_CM_MIN = 100;
+  public static final int WIDTH_CM_MAX = 320;
+  public static final double SHRINKAGE_MIN = -15.0;
+  public static final double SHRINKAGE_MAX = 15.0;
+
+  // Dye
+  public static final int LIGHTNESS_MAX_LENGTH = 20;
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/YarnPurchaseOrderValidator.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/validation/YarnPurchaseOrderValidator.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.procurement.purchaseorder.app.validation;
 
+import static com.fabricmanagement.procurement.purchaseorder.app.validation.TextileValidationConstants.*;
+
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.YarnPurchaseSpecs;
@@ -11,9 +13,10 @@ import org.springframework.stereotype.Component;
 /**
  * Validates {@link YarnPurchaseSpecs} against textile domain rules.
  *
- * <p>Create phase: twist direction must be S or Z.
+ * <p>Create phase: twist direction must be S or Z. Enforces positive boundaries for TPI, CSP,
+ * Uster%, and cone weight.
  *
- * <p>Confirm phase: yarnCount is mandatory.
+ * <p>Confirm phase: yarnCount and composition are mandatory.
  */
 @Component
 public class YarnPurchaseOrderValidator implements PurchaseOrderValidator {
@@ -33,6 +36,25 @@ public class YarnPurchaseOrderValidator implements PurchaseOrderValidator {
       if (yarn.twist() != null && !VALID_TWISTS.contains(yarn.twist().toUpperCase())) {
         violations.add("Twist direction must be S or Z, got: " + yarn.twist());
       }
+      if (yarn.tpi() != null && yarn.tpi() <= 0) {
+        violations.add("TPI must be greater than 0, got: " + yarn.tpi());
+      }
+      if (yarn.csp() != null && yarn.csp() <= 0) {
+        violations.add("CSP must be greater than 0, got: " + yarn.csp());
+      }
+      if (yarn.usterUPercentage() != null
+          && (yarn.usterUPercentage() < USTER_MIN || yarn.usterUPercentage() > USTER_MAX)) {
+        violations.add(
+            "Uster U% must be between "
+                + USTER_MIN
+                + " and "
+                + USTER_MAX
+                + "%, got: "
+                + yarn.usterUPercentage());
+      }
+      if (yarn.coneWeight() != null && yarn.coneWeight() <= 0) {
+        violations.add("Cone weight must be greater than 0, got: " + yarn.coneWeight());
+      }
     }
 
     return violations;
@@ -45,6 +67,9 @@ public class YarnPurchaseOrderValidator implements PurchaseOrderValidator {
     if (specs instanceof YarnPurchaseSpecs yarn) {
       if (yarn.yarnCount() == null || yarn.yarnCount().isBlank()) {
         violations.add("Yarn count is required before sending to supplier");
+      }
+      if (yarn.composition() == null || yarn.composition().isBlank()) {
+        violations.add("Composition is required before sending to supplier");
       }
     }
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/DyePurchaseSpecs.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/DyePurchaseSpecs.java
@@ -1,11 +1,17 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.specs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 import java.util.UUID;
 
 @Schema(description = "Dye/finishing-specific purchase order specifications")
 public record DyePurchaseSpecs(
     @Schema(description = "Pantone or custom color code", example = "Pantone 485") String colorCode,
     @Schema(description = "Lab dip reference number") String labDipRef,
-    @Schema(description = "Approval document ID (uploaded file)") UUID approvalDocumentId)
+    @Schema(description = "Approval document ID (uploaded file)") UUID approvalDocumentId,
+    @Schema(description = "Finish type", example = "Kalandır") String finishType,
+    @Schema(description = "Application method", example = "Pad") String applicationMethod,
+    @Schema(description = "CIELab L* target", example = "45.0") String lightnessTarget,
+    @Schema(description = "Fastness requirements", example = "[\"Yıkama 4-5\"]")
+        List<String> fastnessRequirements)
     implements PurchaseOrderSpecs {}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FabricConstructionType.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FabricConstructionType.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.procurement.purchaseorder.domain.specs;
+
+/** Fabric construction type for purchase specifications. */
+public enum FabricConstructionType {
+  WOVEN,
+  KNIT,
+  NON_WOVEN
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FabricPurchaseSpecs.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FabricPurchaseSpecs.java
@@ -4,7 +4,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Fabric-specific purchase order specifications")
 public record FabricPurchaseSpecs(
-    @Schema(description = "Weave construction", example = "2/1 twill") String construction,
+    @Schema(description = "Weave/knit construction", example = "2/1 twill") String construction,
+    // TODO: Refactoring — Integer to Double (JSONB migration required)
     @Schema(description = "GSM (80-400)", example = "120") Integer gsm,
-    @Schema(description = "Width in cm (100-320)", example = "150") Integer widthCm)
+    // TODO: Refactoring — rename "widthCm" to "width", Integer to Double (JSONB migration required)
+    @Schema(description = "Width in cm (100-320)", example = "150") Integer widthCm,
+    @Schema(description = "Fabric type") FabricConstructionType fabricType,
+    @Schema(description = "Fiber composition", example = "%100 Pamuk") String composition,
+    @Schema(description = "Weave/knit pattern", example = "Süprem") String weavePattern,
+    @Schema(description = "Color name or Pantone", example = "Pantone 7621C") String color,
+    @Schema(description = "Shrinkage tolerance (%)", example = "-3.5") Double shrinkage,
+    @Schema(description = "Finish type", example = "Enzim Yıkama") String finishType)
     implements PurchaseOrderSpecs {}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FiberPurchaseSpecs.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/FiberPurchaseSpecs.java
@@ -1,10 +1,20 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.specs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "Fiber-specific purchase order specifications")
 public record FiberPurchaseSpecs(
     @Schema(description = "Staple length (mm)", example = "28.5") Double stapleLength,
-    @Schema(description = "Fiber grade (A/B/C)", example = "A") String grade,
-    @Schema(description = "Moisture content %", example = "8.5") Double moistureContent)
+    @Schema(description = "Quality grade", example = "A") String grade,
+    @Schema(description = "Moisture content %", example = "8.5") Double moistureContent,
+    @Schema(description = "Micronaire (fineness+maturity)", example = "4.2") Double micronaire,
+    @Schema(description = "Fiber strength (g/tex)", example = "30.5") Double strength,
+    @Schema(description = "Length uniformity index (%)", example = "83.0") Double uniformityIndex,
+    @Schema(description = "Trash/foreign matter content (%)", example = "1.2") Double trashContent,
+    @Schema(description = "Color grade (Rd/+b)", example = "41-3") String colorGrade,
+    @Schema(description = "Country/region of origin", example = "Türkiye-Ege") String origin,
+    @Schema(description = "Certifications", example = "[\"BCI\",\"GOTS\"]")
+        List<String> certifications,
+    @Schema(description = "Crop year", example = "2025/2026") String cropYear)
     implements PurchaseOrderSpecs {}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/YarnPurchaseSpecs.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/specs/YarnPurchaseSpecs.java
@@ -1,10 +1,19 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.specs;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
 
 @Schema(description = "Yarn-specific purchase order specifications")
 public record YarnPurchaseSpecs(
     @Schema(description = "Yarn count (Ne)", example = "30/1") String yarnCount,
+    // TODO: Refactoring — rename "twist" to "twistDirection" (JSONB migration required)
     @Schema(description = "Twist direction (S/Z)", example = "Z") String twist,
-    @Schema(description = "Shrinkage test result") Boolean shrinkageTestPassed)
+    @Schema(description = "Shrinkage test result") Boolean shrinkageTestPassed,
+    @Schema(description = "Fiber composition", example = "%100 Pamuk") String composition,
+    @Schema(description = "Spinning method", example = "Ring Penye") String spinningMethod,
+    @Schema(description = "Turns per inch") Double tpi,
+    @Schema(description = "Count Strength Product") Double csp,
+    @Schema(description = "Uster evenness U%") Double usterUPercentage,
+    @Schema(description = "Certifications") List<String> certifications,
+    @Schema(description = "Cone weight (kg)") Double coneWeight)
     implements PurchaseOrderSpecs {}


### PR DESCRIPTION
- Add FabricConstructionType enum
- Enrich Fiber, Yarn, Fabric, and Dye specs with industry-standard fields
- Extract TextileValidationConstants for validation bounds
- Implement strict range and completeness validations in PurchaseOrderValidators
- Fix missing generic validator documentation