### PR TITLE
feat(sales): automate SalesOrder shipment status transitions

### DIFF
--- a/src/main/java/com/fabricmanagement/production/execution/workorder/app/adapter/WorkOrderCreationAdapter.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/app/adapter/WorkOrderCreationAdapter.java
@@ -23,6 +23,9 @@ public class WorkOrderCreationAdapter implements ProductionOrderPort {
             .unit(cmd.unit())
             .currency(cmd.currency())
             .deadline(cmd.deadline())
+            // TODO(FAB-1025): Map cmd.certificationReq() and cmd.originReq() to
+            // WorkOrderProductionSpecs when
+            // WorkOrder supports them (needs schema update and UI traceability).
             .build();
     workOrderService.createWorkOrder(request);
   }

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/app/listener/WorkOrderSalesEventListener.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/app/listener/WorkOrderSalesEventListener.java
@@ -1,11 +1,21 @@
 package com.fabricmanagement.production.execution.workorder.app.listener;
 
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.execution.workorder.app.WorkOrderService;
+import com.fabricmanagement.production.execution.workorder.domain.WorkOrder;
+import com.fabricmanagement.production.execution.workorder.domain.WorkOrderStatus;
+import com.fabricmanagement.production.execution.workorder.domain.exception.WorkOrderDomainException;
+import com.fabricmanagement.production.execution.workorder.dto.IncomingSalesOrderLine;
+import com.fabricmanagement.production.execution.workorder.infra.repository.WorkOrderRepository;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderCancelledEvent;
 import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderConfirmedEvent;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -16,29 +26,85 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class WorkOrderSalesEventListener {
 
   private final WorkOrderService workOrderService;
+  private final WorkOrderRepository workOrderRepository;
 
   @Async
-  @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
   public void onSalesOrderConfirmed(SalesOrderConfirmedEvent event) {
-    log.info(
-        "Received SalesOrderConfirmedEvent for orderId={}, creating WorkOrders...",
-        event.getSalesOrderId());
+    TenantContext.setCurrentTenantId(event.getTenantId());
+    try {
+      log.info(
+          "Received SalesOrderConfirmedEvent for orderId={}, creating WorkOrders...",
+          event.getSalesOrderId());
 
-    event
-        .getLines()
-        .forEach(
-            line -> {
-              var incomingLine =
-                  new com.fabricmanagement.production.execution.workorder.dto
-                      .IncomingSalesOrderLine(
-                      line.lineId(),
-                      line.productCode(),
-                      line.quantity(),
-                      line.unit(),
-                      line.requestedDeliveryDate());
-              workOrderService.createFromSalesOrderLine(
-                  event.getTenantId(), event.getSalesOrderId(), incomingLine);
-            });
+      event
+          .getLines()
+          .forEach(
+              line -> {
+                var incomingLine =
+                    new IncomingSalesOrderLine(
+                        line.lineId(),
+                        line.productCode(),
+                        line.quantity(),
+                        line.unit(),
+                        line.requestedDeliveryDate());
+                workOrderService.createFromSalesOrderLine(
+                    event.getTenantId(), event.getSalesOrderId(), incomingLine);
+              });
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  @Async
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  public void onSalesOrderCancelled(SalesOrderCancelledEvent event) {
+    TenantContext.setCurrentTenantId(event.getTenantId());
+    try {
+      log.info(
+          "Received SalesOrderCancelledEvent for orderId={}, cascading WO cancellation...",
+          event.getSalesOrderId());
+
+      event
+          .getCancelledLineIds()
+          .forEach(
+              lineId -> {
+                List<WorkOrder> workOrders =
+                    workOrderRepository
+                        .findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(
+                            event.getTenantId(), lineId);
+
+                workOrders.stream()
+                    .filter(
+                        wo ->
+                            wo.getStatus() != WorkOrderStatus.COMPLETED
+                                && wo.getStatus() != WorkOrderStatus.CANCELLED)
+                    .forEach(
+                        wo -> {
+                          try {
+                            workOrderService.changeStatus(wo.getId(), WorkOrderStatus.CANCELLED);
+                            log.info(
+                                "Cancelled WorkOrder {} (was {}) for salesOrderLine {}",
+                                wo.getWorkOrderNumber(),
+                                wo.getStatus(),
+                                lineId);
+                          } catch (WorkOrderDomainException
+                              | ObjectOptimisticLockingFailureException e) {
+                            // Idempotent: already CANCELLED, transition not valid, or concurrent
+                            // status change by production. Per-WO swallow ensures one WO's conflict
+                            // doesn't rollback other WOs' cancellations.
+                            log.warn(
+                                "Could not cancel WorkOrder {} (status {}): {}",
+                                wo.getWorkOrderNumber(),
+                                wo.getStatus(),
+                                e.getMessage());
+                          }
+                        });
+              });
+    } finally {
+      TenantContext.clear();
+    }
   }
 }

--- a/src/main/java/com/fabricmanagement/production/masterdata/recipe/domain/RecipeComponent.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/recipe/domain/RecipeComponent.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.production.masterdata.recipe.domain;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import jakarta.persistence.*;
 import java.math.BigDecimal;
+import java.util.Locale;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -57,6 +58,22 @@ public class RecipeComponent extends BaseEntity {
   @Override
   protected String getModuleCode() {
     return "RCPC";
+  }
+
+  @PrePersist
+  @PreUpdate
+  protected void normalizeFields() {
+    if (this.certification != null && !this.certification.isBlank()) {
+      this.certification = this.certification.strip().toUpperCase(Locale.ROOT);
+    } else {
+      this.certification = null;
+    }
+
+    if (this.origin != null && !this.origin.isBlank()) {
+      this.origin = this.origin.strip().toUpperCase(Locale.ROOT);
+    } else {
+      this.origin = null;
+    }
   }
 
   public RecipeComponentNode toNode() {

--- a/src/main/java/com/fabricmanagement/sales/salesorder/api/controller/SalesOrderController.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/api/controller/SalesOrderController.java
@@ -195,4 +195,31 @@ public class SalesOrderController {
   public ResponseEntity<ApiResponse<SalesOrderDto>> cancelOrder(@PathVariable UUID id) {
     return ResponseEntity.ok(ApiResponse.success(orderService.cancelOrder(id)));
   }
+
+  @PostMapping("/{id}/hold")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(
+      summary = "Put an order on hold",
+      description = "Transitions the order status to ON_HOLD")
+  public ResponseEntity<ApiResponse<SalesOrderDto>> holdOrder(@PathVariable UUID id) {
+    return ResponseEntity.ok(ApiResponse.success(orderService.holdOrder(id)));
+  }
+
+  @PostMapping("/{id}/resume")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(
+      summary = "Resume an order from ON_HOLD",
+      description = "Restores the order to its pre-hold status")
+  public ResponseEntity<ApiResponse<SalesOrderDto>> resumeOrder(@PathVariable UUID id) {
+    return ResponseEntity.ok(ApiResponse.success(orderService.resumeOrder(id)));
+  }
+
+  @PostMapping("/{id}/revise")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(
+      summary = "Revise a rejected order back to DRAFT",
+      description = "Allows a rejected order to be edited and resubmitted")
+  public ResponseEntity<ApiResponse<SalesOrderDto>> reviseOrder(@PathVariable UUID id) {
+    return ResponseEntity.ok(ApiResponse.success(orderService.reviseOrder(id)));
+  }
 }

--- a/src/main/java/com/fabricmanagement/sales/salesorder/app/SalesOrderService.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/app/SalesOrderService.java
@@ -17,6 +17,7 @@ import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderUpdateCommand;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderCancelledEvent;
 import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderConfirmedEvent;
 import com.fabricmanagement.sales.salesorder.dto.CreateSalesOrderRequest;
 import com.fabricmanagement.sales.salesorder.dto.SalesOrderDto;
@@ -654,10 +655,78 @@ public class SalesOrderService {
     UUID tenantId = TenantContext.getCurrentTenantId();
 
     SalesOrder order = getOrderOrThrow(tenantId, orderId);
+
+    // Collect active line IDs for cascade notification before cancellation
+    List<UUID> activeLineIds =
+        lineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(order.getId()).stream()
+            .map(SalesOrderLine::getId)
+            .toList();
+
     order.cancel();
     SalesOrder saved = orderRepository.save(order);
 
-    log.info("Sales order cancelled: uid={}", saved.getUid());
+    domainEventPublisher.publish(
+        new SalesOrderCancelledEvent(
+            tenantId, saved.getId(), saved.getOrderNumber(), activeLineIds));
+
+    log.info("Sales order cancelled: uid={}, lineCount={}", saved.getUid(), activeLineIds.size());
+    return SalesOrderDto.from(saved);
+  }
+
+  /**
+   * Put an order on hold.
+   *
+   * @param orderId Order ID
+   * @return Updated order DTO
+   */
+  @Transactional
+  public SalesOrderDto holdOrder(UUID orderId) {
+    UUID tenantId = TenantContext.getCurrentTenantId();
+
+    SalesOrder order = getOrderOrThrow(tenantId, orderId);
+    order.hold();
+    SalesOrder saved = orderRepository.save(order);
+
+    log.info(
+        "Sales order put on hold: uid={}, previousStatus={}",
+        saved.getUid(),
+        saved.getStatusBeforeHold());
+    return SalesOrderDto.from(saved);
+  }
+
+  /**
+   * Resume an order from ON_HOLD.
+   *
+   * @param orderId Order ID
+   * @return Updated order DTO
+   */
+  @Transactional
+  public SalesOrderDto resumeOrder(UUID orderId) {
+    UUID tenantId = TenantContext.getCurrentTenantId();
+
+    SalesOrder order = getOrderOrThrow(tenantId, orderId);
+    order.resume();
+    SalesOrder saved = orderRepository.save(order);
+
+    log.info("Sales order resumed: uid={}, restoredStatus={}", saved.getUid(), saved.getStatus());
+    return SalesOrderDto.from(saved);
+  }
+
+  /**
+   * Revise a rejected order back to DRAFT.
+   *
+   * @param orderId Order ID
+   * @return Updated order DTO
+   */
+  @Transactional
+  public SalesOrderDto reviseOrder(UUID orderId) {
+    UUID tenantId = TenantContext.getCurrentTenantId();
+
+    SalesOrder order = getOrderOrThrow(tenantId, orderId);
+    order.reviseRejected();
+    SalesOrder saved = orderRepository.save(order);
+
+    log.info("Sales order revised to DRAFT: uid={}", saved.getUid());
     return SalesOrderDto.from(saved);
   }
 

--- a/src/main/java/com/fabricmanagement/sales/salesorder/app/ShipmentProgressService.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/app/ShipmentProgressService.java
@@ -1,0 +1,112 @@
+package com.fabricmanagement.sales.salesorder.app;
+
+import com.fabricmanagement.sales.salesorder.domain.OrderStatus;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ShipmentProgressService {
+
+  private final SalesOrderLineRepository salesOrderLineRepository;
+  private final SalesOrderRepository salesOrderRepository;
+
+  /**
+   * Faz 1 — Satır shippedQty güncelleme. Nadiren çakışır (satır-özel), hızla commit eder.
+   * İdempotent: processedShipmentLineIds guard'ı sayesinde tekrar event gelirse skip.
+   *
+   * @return güncellenen satırın salesOrderId'si, satır bulunamazsa null
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public UUID recordLineShipment(
+      UUID salesOrderLineId, UUID shipmentLineId, BigDecimal confirmedQuantity) {
+    UUID tenantId =
+        com.fabricmanagement.common.infrastructure.persistence.TenantContext.getCurrentTenantId();
+    SalesOrderLine line =
+        salesOrderLineRepository.findByTenantIdAndId(tenantId, salesOrderLineId).orElse(null);
+    if (line == null) {
+      log.error("SalesOrderLine not found: {}", salesOrderLineId);
+      return null;
+    }
+
+    line.addShippedQuantity(shipmentLineId, confirmedQuantity);
+    salesOrderLineRepository.save(line);
+
+    log.info(
+        "Updated shipped quantity for SalesOrderLine {}. shippedQty={}",
+        line.getId(),
+        line.getShippedQty());
+    return line.getSalesOrderId();
+  }
+
+  /**
+   * Faz 2 — Header status aggregate ve güncelleme. Ayrı REQUIRES_NEW tx — optimistic lock çakışması
+   * burada olur. Retry'da tüm veri taze okunur, header status yeniden hesaplanır → idempotent.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void updateOrderShipmentStatus(UUID salesOrderId) {
+    // 1. Tüm aktif, CANCELLED olmayan satırları çek
+    List<SalesOrderLine> activeLines =
+        salesOrderLineRepository
+            .findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(salesOrderId)
+            .stream()
+            .filter(l -> l.getLineStatus() != SalesOrderLineStatus.CANCELLED)
+            .toList();
+
+    // 2. Sevk durumunu hesapla
+    boolean anyLineShipped =
+        activeLines.stream()
+            .anyMatch(
+                l -> l.getShippedQty() != null && l.getShippedQty().compareTo(BigDecimal.ZERO) > 0);
+
+    boolean allLinesFullyShipped =
+        !activeLines.isEmpty()
+            && activeLines.stream()
+                .allMatch(
+                    l ->
+                        l.getRequestedQty() != null
+                            && l.getShippedQty() != null
+                            && l.getShippedQty().compareTo(l.getRequestedQty()) >= 0);
+
+    // 3. Header status güncelle
+    UUID tenantId =
+        com.fabricmanagement.common.infrastructure.persistence.TenantContext.getCurrentTenantId();
+    SalesOrder order =
+        salesOrderRepository.findByTenantIdAndId(tenantId, salesOrderId).orElse(null);
+    if (order == null) {
+      log.error("SalesOrder not found for shipment progress: {}", salesOrderId);
+      return;
+    }
+
+    OrderStatus previousStatus = order.getStatus();
+    order.recordShipmentProgress(allLinesFullyShipped, anyLineShipped);
+
+    if (previousStatus != order.getStatus()) {
+      salesOrderRepository.save(order);
+      log.info(
+          "Order {} status changed: {} → {}",
+          order.getOrderNumber(),
+          previousStatus,
+          order.getStatus());
+    } else {
+      log.debug(
+          "Order {} status unchanged: {} (anyShipped={}, allShipped={})",
+          order.getOrderNumber(),
+          previousStatus,
+          anyLineShipped,
+          allLinesFullyShipped);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/salesorder/app/listener/SalesOrderEventListener.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/app/listener/SalesOrderEventListener.java
@@ -1,13 +1,17 @@
 package com.fabricmanagement.sales.salesorder.app.listener;
 
 import com.fabricmanagement.logistics.shipment.domain.event.ShipmentLineConfirmedEvent;
-import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
-import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import com.fabricmanagement.sales.salesorder.app.ShipmentProgressService;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.TransientDataAccessException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Recover;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -16,11 +20,17 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class SalesOrderEventListener {
 
-  private final SalesOrderLineRepository salesOrderLineRepository;
+  private final ShipmentProgressService shipmentProgressService;
 
   @Async
-  @Transactional(propagation = org.springframework.transaction.annotation.Propagation.REQUIRES_NEW)
   @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Retryable(
+      retryFor = {
+        ObjectOptimisticLockingFailureException.class,
+        TransientDataAccessException.class
+      },
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 200, multiplier = 2))
   public void onShipmentLineConfirmed(ShipmentLineConfirmedEvent event) {
     log.debug(
         "Handling ShipmentLineConfirmedEvent: shipmentLineId={}, salesOrderLineId={}, qty={}",
@@ -28,21 +38,31 @@ public class SalesOrderEventListener {
         event.getSalesOrderLineId(),
         event.getConfirmedQuantity());
 
-    SalesOrderLine line =
-        salesOrderLineRepository.findById(event.getSalesOrderLineId()).orElse(null);
+    // Faz 1 — shippedQty yaz (ayrı tx, nadiren çakışır)
+    // ÖNEMLİ: @Retryable tüm metodu (Faz 1 + Faz 2) tekrar çalıştırır.
+    // Ancak Faz 1'deki addShippedQuantity() metodundaki 'processedShipmentLineIds' kontrolü
+    // sayesinde bu işlem idempotent'tir ve retry sırasında miktar mükerrer artmaz.
+    // Lütfen Faz 1'deki bu idempotency guard'ını KESİNLİKLE KALDIRMAYIN!
+    UUID salesOrderId =
+        shipmentProgressService.recordLineShipment(
+            event.getSalesOrderLineId(), event.getShipmentLineId(), event.getConfirmedQuantity());
 
-    if (line == null) {
-      log.error(
-          "SalesOrderLine not found for shipment line confirmed: {}", event.getSalesOrderLineId());
-      return;
+    if (salesOrderId == null) {
+      return; // Line bulunamadı, service içinde loglandı
     }
 
-    line.addShippedQuantity(event.getShipmentLineId(), event.getConfirmedQuantity());
-    salesOrderLineRepository.save(line);
+    // Faz 2 — header status güncelle (ayrı tx, retry burada çalışır)
+    shipmentProgressService.updateOrderShipmentStatus(salesOrderId);
+  }
 
-    log.info(
-        "Updated shipped quantity for SalesOrderLine {}. New shippedQty: {}",
-        line.getId(),
-        line.getShippedQty());
+  @Recover
+  public void recoverShipmentLineConfirmed(Exception ex, ShipmentLineConfirmedEvent event) {
+    log.error(
+        "Failed to process ShipmentLineConfirmedEvent after retries. "
+            + "shipmentLineId={}, salesOrderLineId={}: {}",
+        event.getShipmentLineId(),
+        event.getSalesOrderLineId(),
+        ex.getMessage(),
+        ex);
   }
 }

--- a/src/main/java/com/fabricmanagement/sales/salesorder/app/ruleengine/SalesOrderRuleEngine.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/app/ruleengine/SalesOrderRuleEngine.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.sales.salesorder.app.ruleengine;
 
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
@@ -7,6 +8,7 @@ import com.fabricmanagement.sales.salesorder.domain.port.DraftProductionOrderCom
 import com.fabricmanagement.sales.salesorder.domain.port.ProductionOrderPort;
 import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -21,11 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
  *
  * <ol>
  *   <li><b>Step 1 — Product default recipe:</b> If line has a productId and there is an active
- *       ACTIVE recipe associated to it (queried by productId), use it.
+ *       ACTIVE recipe associated to it (queried by productId, optionally filtered by
+ *       certificationReq and originReq from moduleSpecs), use it.
  *   <li><b>Step 2 — Customer history:</b> Query for the most recently used recipe for this
- *       (customer, product) combination from previous orders.
+ *       (customer, product) combination from previous orders, optionally filtered.
  *   <li><b>Step 3 — Constraint filter:</b> Find ACTIVE recipes for the product and pick the most
- *       frequently used (by WorkOrder count).
+ *       frequently used (by WorkOrder count), optionally filtered.
  *   <li><b>Step 4 — Fallback:</b> No match found — WorkOrder created with no recipe; FlowBoard task
  *       will be generated for manual recipe assignment.
  * </ol>
@@ -62,7 +65,11 @@ public class SalesOrderRuleEngine {
   // ── Private Processing ────────────────────────────────────────────────────
 
   private void processLine(SalesOrder order, SalesOrderLine line) {
-    Optional<UUID> recipeId = findRecipe(order, line);
+    UUID tenantId = TenantContext.requireTenantId();
+    String certificationReq = extractSpecField(line, "certificationReq");
+    String originReq = extractSpecField(line, "originReq");
+
+    Optional<UUID> recipeId = findRecipe(tenantId, order, line, certificationReq, originReq);
 
     if (recipeId.isPresent()) {
       line.assignRecipe(recipeId.get());
@@ -81,18 +88,25 @@ public class SalesOrderRuleEngine {
     }
 
     // Create WorkOrder (DRAFT) regardless of recipe availability
-    createDraftWorkOrder(order, line, recipeId.orElse(null));
+    createDraftWorkOrder(order, line, recipeId.orElse(null), certificationReq, originReq);
   }
 
   /** 4-step cascade recipe matching. */
-  private Optional<UUID> findRecipe(SalesOrder order, SalesOrderLine line) {
+  private Optional<UUID> findRecipe(
+      UUID tenantId,
+      SalesOrder order,
+      SalesOrderLine line,
+      String certificationReq,
+      String originReq) {
     if (line.getProductId() == null) {
       // No productId — skip steps 1-3, go to fallback
       return Optional.empty();
     }
 
     // Step 1 — product default recipe (most recent ACTIVE recipe for this product)
-    Optional<UUID> step1 = historyQuery.findDefaultRecipeForProduct(line.getProductId());
+    Optional<UUID> step1 =
+        historyQuery.findDefaultRecipeForProduct(
+            tenantId, line.getProductId(), certificationReq, originReq);
     if (step1.isPresent()) {
       log.debug("RuleEngine step1 match: product={} → recipe={}", line.getProductId(), step1.get());
       return step1;
@@ -101,14 +115,20 @@ public class SalesOrderRuleEngine {
     // Step 2 — customer history (same customer + product combination)
     Optional<UUID> step2 =
         historyQuery.findMostRecentRecipeForCustomerAndProduct(
-            order.getTradingPartnerId(), line.getProductId());
+            tenantId,
+            order.getTradingPartnerId(),
+            line.getProductId(),
+            certificationReq,
+            originReq);
     if (step2.isPresent()) {
       log.debug("RuleEngine step2 match (customer history): → recipe={}", step2.get());
       return step2;
     }
 
     // Step 3 — most frequently used ACTIVE recipe for this product
-    Optional<UUID> step3 = historyQuery.findMostUsedRecipeForProduct(line.getProductId());
+    Optional<UUID> step3 =
+        historyQuery.findMostUsedRecipeForProduct(
+            tenantId, line.getProductId(), certificationReq, originReq);
     if (step3.isPresent()) {
       log.debug("RuleEngine step3 match (frequency): → recipe={}", step3.get());
       return step3;
@@ -119,7 +139,12 @@ public class SalesOrderRuleEngine {
   }
 
   /** Creates a DRAFT WorkOrder linked to the SalesOrderLine. */
-  private void createDraftWorkOrder(SalesOrder order, SalesOrderLine line, UUID recipeId) {
+  private void createDraftWorkOrder(
+      SalesOrder order,
+      SalesOrderLine line,
+      UUID recipeId,
+      String certificationReq,
+      String originReq) {
     DraftProductionOrderCommand cmd =
         new DraftProductionOrderCommand(
             recipeId,
@@ -128,12 +153,22 @@ public class SalesOrderRuleEngine {
             line.getRequestedQty(),
             line.getUnit(),
             line.getCurrency(),
-            order.getDeadline());
+            order.getDeadline(),
+            certificationReq,
+            originReq);
 
     productionOrderPort.requestDraftProductionOrder(cmd);
     log.info(
         "RuleEngine: WorkOrder (DRAFT) created for SalesOrderLine {} (recipe={})",
         line.getId(),
         recipeId);
+  }
+
+  private String extractSpecField(SalesOrderLine line, String fieldName) {
+    if (line.getModuleSpecs() != null && line.getModuleSpecs().containsKey(fieldName)) {
+      Object value = line.getModuleSpecs().get(fieldName);
+      return value instanceof String s && !s.isBlank() ? s.strip().toUpperCase(Locale.ROOT) : null;
+    }
+    return null;
   }
 }

--- a/src/main/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQuery.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQuery.java
@@ -23,80 +23,115 @@ public class WorkOrderRecipeHistoryQuery {
    * Step 1: Find the most recently created ACTIVE recipe associated with this product (via recipe
    * name containing the product, or through a direct FK — if productId is stored on the recipe).
    * For now, returns the most recently created ACTIVE recipe that references this productId in its
-   * RecipeComponent table.
+   * RecipeComponent table, optionally matching certification and origin.
+   *
+   * <p>Certification and origin values are expected to be pre-normalized to uppercase by the
+   * caller.
    */
-  public Optional<UUID> findDefaultRecipeForProduct(UUID productId) {
+  public Optional<UUID> findDefaultRecipeForProduct(
+      UUID tenantId, UUID productId, String certification, String origin) {
     String sql =
         """
         SELECT r.id
         FROM production.prod_recipe r
         JOIN production.prod_recipe_component rc ON rc.recipe_id = r.id
-        WHERE r.status = 'ACTIVE'
+        WHERE r.tenant_id = :tenantId
+          AND r.status = 'ACTIVE'
           AND r.is_active = true
+          AND rc.is_active = true
           AND rc.fiber_id = :productId
+          AND (:certification IS NULL OR rc.certification = :certification)
+          AND (:origin IS NULL OR rc.origin = :origin)
         ORDER BY r.created_at DESC
         LIMIT 1
         """;
 
-    return querySingleUuid(sql, "productId", productId);
+    return querySingleUuid(
+        sql,
+        new MapSqlParameterSource("tenantId", tenantId)
+            .addValue("productId", productId)
+            .addValue("certification", certification)
+            .addValue("origin", origin));
   }
 
   /**
    * Step 2: Most recently used recipe for the same (customer, product) combination. Looks at
-   * confirmed WorkOrders for this trading partner linked to the same product.
+   * confirmed WorkOrders for this trading partner linked to the same product, optionally matching
+   * certification and origin.
+   *
+   * <p>Certification and origin values are expected to be pre-normalized to uppercase by the
+   * caller.
    */
   public Optional<UUID> findMostRecentRecipeForCustomerAndProduct(
-      UUID tradingPartnerId, UUID productId) {
+      UUID tenantId, UUID tradingPartnerId, UUID productId, String certification, String origin) {
     String sql =
         """
         SELECT wo.recipe_id
         FROM production.prod_work_order wo
         JOIN production.prod_recipe_component rc ON rc.recipe_id = wo.recipe_id
-        WHERE wo.trading_partner_id = :tradingPartnerId
+        WHERE wo.tenant_id = :tenantId
+          AND wo.trading_partner_id = :tradingPartnerId
+          AND rc.is_active = true
           AND rc.fiber_id = :productId
+          AND (:certification IS NULL OR rc.certification = :certification)
+          AND (:origin IS NULL OR rc.origin = :origin)
           AND wo.recipe_id IS NOT NULL
           AND wo.is_active = true
         ORDER BY wo.created_at DESC
         LIMIT 1
         """;
 
-    return jdbc.query(
+    return querySingleUuid(
         sql,
-        new MapSqlParameterSource("tradingPartnerId", tradingPartnerId)
-            .addValue("productId", productId),
-        rs ->
-            rs.next() ? Optional.of(UUID.fromString(rs.getString("recipe_id"))) : Optional.empty());
+        new MapSqlParameterSource("tenantId", tenantId)
+            .addValue("tradingPartnerId", tradingPartnerId)
+            .addValue("productId", productId)
+            .addValue("certification", certification)
+            .addValue("origin", origin));
   }
 
   /**
    * Step 3: Most frequently used ACTIVE recipe for this product (ranked by number of WorkOrders
-   * using it).
+   * using it), optionally matching certification and origin.
+   *
+   * <p>Certification and origin values are expected to be pre-normalized to uppercase by the
+   * caller.
    */
-  public Optional<UUID> findMostUsedRecipeForProduct(UUID productId) {
+  public Optional<UUID> findMostUsedRecipeForProduct(
+      UUID tenantId, UUID productId, String certification, String origin) {
     String sql =
         """
         SELECT wo.recipe_id, COUNT(*) AS usage_count
         FROM production.prod_work_order wo
         JOIN production.prod_recipe r ON r.id = wo.recipe_id
         JOIN production.prod_recipe_component rc ON rc.recipe_id = wo.recipe_id
-        WHERE r.status = 'ACTIVE'
+        WHERE wo.tenant_id = :tenantId
+          AND r.status = 'ACTIVE'
           AND r.is_active = true
+          AND rc.is_active = true
           AND rc.fiber_id = :productId
+          AND (:certification IS NULL OR rc.certification = :certification)
+          AND (:origin IS NULL OR rc.origin = :origin)
           AND wo.recipe_id IS NOT NULL
         GROUP BY wo.recipe_id
         ORDER BY usage_count DESC
         LIMIT 1
         """;
 
-    return querySingleUuid(sql, "productId", productId);
+    return querySingleUuid(
+        sql,
+        new MapSqlParameterSource("tenantId", tenantId)
+            .addValue("productId", productId)
+            .addValue("certification", certification)
+            .addValue("origin", origin));
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────
 
-  private Optional<UUID> querySingleUuid(String sql, String paramName, UUID paramValue) {
+  private Optional<UUID> querySingleUuid(String sql, MapSqlParameterSource params) {
     return jdbc.query(
         sql,
-        new MapSqlParameterSource(paramName, paramValue),
+        params,
         rs -> {
           if (rs.next()) {
             String val = rs.getString(1);

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/OrderStatus.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/OrderStatus.java
@@ -48,7 +48,11 @@ public enum OrderStatus {
 
   /** Check if order can be cancelled. */
   public boolean canCancel() {
-    return this == DRAFT || this == CONFIRMED || this == ON_HOLD || this == PENDING_APPROVAL;
+    return this == DRAFT
+        || this == CONFIRMED
+        || this == ON_HOLD
+        || this == PENDING_APPROVAL
+        || this == IN_PROGRESS;
   }
 
   /** Check if order can be deleted (hard/soft). */

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/SalesOrder.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/SalesOrder.java
@@ -336,6 +336,31 @@ public class SalesOrder extends BaseEntity {
     this.status = OrderStatus.ON_HOLD;
   }
 
+  /**
+   * Sevkiyat ilerlemesine göre header status'ünü günceller. Listener, tüm aktif satırların sevk
+   * durumunu aggregate edip bu metodu çağırır.
+   *
+   * <p>Geçiş kuralları:
+   *
+   * <ul>
+   *   <li>Terminal durumlarda (DELIVERED/CANCELLED/REJECTED) → no-op (sessiz dön)
+   *   <li>allLinesFullyShipped && canShip() → SHIPPED
+   *   <li>!allLinesFullyShipped && anyLineShipped && canShip() → PARTIALLY_SHIPPED
+   *   <li>İkisi de false → değişiklik yok
+   * </ul>
+   */
+  public void recordShipmentProgress(boolean allLinesFullyShipped, boolean anyLineShipped) {
+    if (status.isTerminal()) {
+      return;
+    }
+
+    if (allLinesFullyShipped && status.canShip()) {
+      this.status = OrderStatus.SHIPPED;
+    } else if (anyLineShipped && status.canShip()) {
+      this.status = OrderStatus.PARTIALLY_SHIPPED;
+    }
+  }
+
   public Money getGrandTotal() {
     if (totals == null) {
       throw new IllegalStateException("SalesOrder totals cannot be null");

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/SalesOrder.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/SalesOrder.java
@@ -83,6 +83,15 @@ public class SalesOrder extends BaseEntity {
   @Builder.Default
   private OrderStatus status = OrderStatus.DRAFT;
 
+  /** Status before ON_HOLD, used to restore on resume. */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status_before_hold", length = 30)
+  private OrderStatus statusBeforeHold;
+
+  /** Reason for rejection. */
+  @Column(name = "rejection_reason", length = 500)
+  private String rejectionReason;
+
   // ═══════════════════════════════════════════════════════════════════════════
   // Dates
   // ═══════════════════════════════════════════════════════════════════════════
@@ -225,6 +234,20 @@ public class SalesOrder extends BaseEntity {
           "Only PENDING_APPROVAL orders can be rejected. Current: " + status);
     }
     this.status = OrderStatus.REJECTED;
+    this.rejectionReason = reason;
+  }
+
+  /** Revise a rejected order back to DRAFT. */
+  public void reviseRejected() {
+    if (status != OrderStatus.REJECTED) {
+      throw new OrderDomainException(
+          String.format(
+              "Cannot revise order %s: only REJECTED orders can be revised. Current: %s",
+              orderNumber, status),
+          409);
+    }
+    this.status = OrderStatus.DRAFT;
+    this.rejectionReason = null;
   }
 
   /**
@@ -322,18 +345,40 @@ public class SalesOrder extends BaseEntity {
       throw new OrderDomainException(
           String.format(
               "Cannot cancel order %s: current status %s does not allow cancellation",
-              orderNumber, status));
+              orderNumber, status),
+          409);
     }
     this.status = OrderStatus.CANCELLED;
   }
 
   /** Put order on hold. */
   public void hold() {
-    if (status.isTerminal()) {
+    if (status.isTerminal() || status == OrderStatus.ON_HOLD) {
       throw new OrderDomainException(
-          String.format("Cannot hold order %s: status %s is terminal", orderNumber, status));
+          String.format(
+              "Cannot hold order %s: status %s is terminal or already ON_HOLD",
+              orderNumber, status),
+          409);
     }
+    this.statusBeforeHold = this.status;
     this.status = OrderStatus.ON_HOLD;
+  }
+
+  /** Resume an order from hold. */
+  public void resume() {
+    if (status != OrderStatus.ON_HOLD) {
+      throw new OrderDomainException(
+          String.format(
+              "Cannot resume order %s: current status is %s (must be ON_HOLD)",
+              orderNumber, status),
+          409);
+    }
+    if (statusBeforeHold == null) {
+      throw new IllegalStateException(
+          String.format("Cannot resume order %s: statusBeforeHold is null", orderNumber));
+    }
+    this.status = this.statusBeforeHold;
+    this.statusBeforeHold = null;
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderCancelledEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderCancelledEvent.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.sales.salesorder.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import java.util.List;
+import java.util.UUID;
+import lombok.Getter;
+
+/**
+ * Satış siparişi iptal edildiğinde yayınlanır.
+ *
+ * <p>WorkOrderSalesEventListener bu eventi dinler ve ilgili üretim emirlerini (COMPLETED
+ * olmayanları) iptal eder (cascade iptal).
+ */
+@Getter
+public class SalesOrderCancelledEvent extends DomainEvent {
+
+  private final UUID salesOrderId;
+  private final String orderNumber;
+  private final List<UUID> cancelledLineIds;
+
+  public SalesOrderCancelledEvent(
+      UUID tenantId, UUID salesOrderId, String orderNumber, List<UUID> cancelledLineIds) {
+    super(tenantId, "SalesOrderCancelled");
+    this.salesOrderId = salesOrderId;
+    this.orderNumber = orderNumber;
+    this.cancelledLineIds = cancelledLineIds != null ? cancelledLineIds : List.of();
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/port/DraftProductionOrderCommand.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/port/DraftProductionOrderCommand.java
@@ -11,4 +11,6 @@ public record DraftProductionOrderCommand(
     BigDecimal plannedQty,
     String unit,
     String currency,
-    LocalDate deadline) {}
+    LocalDate deadline,
+    String certificationReq,
+    String originReq) {}

--- a/src/main/java/com/fabricmanagement/sales/salesorder/dto/SalesOrderDto.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/dto/SalesOrderDto.java
@@ -27,6 +27,8 @@ public class SalesOrderDto {
   private String customerReference;
   private OrderType orderType;
   private OrderStatus status;
+  private OrderStatus statusBeforeHold;
+  private String rejectionReason;
   private LocalDate orderDate;
   private LocalDate requestedDeliveryDate;
   private LocalDate promisedDeliveryDate;
@@ -76,6 +78,8 @@ public class SalesOrderDto {
         .customerReference(order.getCustomerReference())
         .orderType(order.getOrderType())
         .status(order.getStatus())
+        .statusBeforeHold(order.getStatusBeforeHold())
+        .rejectionReason(order.getRejectionReason())
         .orderDate(order.getOrderDate())
         .requestedDeliveryDate(order.getRequestedDeliveryDate())
         .promisedDeliveryDate(order.getPromisedDeliveryDate())

--- a/src/main/java/com/fabricmanagement/sales/salesorder/infra/repository/SalesOrderLineRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/infra/repository/SalesOrderLineRepository.java
@@ -3,10 +3,13 @@ package com.fabricmanagement.sales.salesorder.infra.repository;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
 import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SalesOrderLineRepository extends JpaRepository<SalesOrderLine, UUID> {
+
+  Optional<SalesOrderLine> findByTenantIdAndId(UUID tenantId, UUID id);
 
   List<SalesOrderLine> findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(UUID salesOrderId);
 

--- a/src/main/resources/db/migration/V20260601102500__add_status_before_hold.sql
+++ b/src/main/resources/db/migration/V20260601102500__add_status_before_hold.sql
@@ -1,0 +1,10 @@
+ALTER TABLE sales_ord.sales_order
+    ADD COLUMN status_before_hold VARCHAR(30);
+
+-- Legacy ON_HOLD backfill: migration öncesi ON_HOLD'a alınmış siparişlerin
+-- status_before_hold'u null olur → resume() çağrısında 500 (IllegalStateException).
+-- Güvenli fallback: CONFIRMED (en yaygın hold-öncesi durum).
+UPDATE sales_ord.sales_order
+   SET status_before_hold = 'CONFIRMED'
+ WHERE status = 'ON_HOLD'
+   AND status_before_hold IS NULL;

--- a/src/main/resources/db/migration/V20260601104300__add_rejection_reason.sql
+++ b/src/main/resources/db/migration/V20260601104300__add_rejection_reason.sql
@@ -1,0 +1,2 @@
+ALTER TABLE sales_ord.sales_order
+    ADD COLUMN rejection_reason VARCHAR(500);

--- a/src/main/resources/db/migration/V20260601114500__normalize_recipe_component_cert_origin.sql
+++ b/src/main/resources/db/migration/V20260601114500__normalize_recipe_component_cert_origin.sql
@@ -1,0 +1,10 @@
+-- Normalize existing certification and origin data in prod_recipe_component.
+-- Mirrors RecipeComponent.normalizeFields(): trim, uppercase and convert blank values to NULL.
+
+UPDATE production.prod_recipe_component
+   SET certification = NULLIF(UPPER(TRIM(certification)), '')
+ WHERE certification IS DISTINCT FROM NULLIF(UPPER(TRIM(certification)), '');
+
+UPDATE production.prod_recipe_component
+   SET origin = NULLIF(UPPER(TRIM(origin)), '')
+ WHERE origin IS DISTINCT FROM NULLIF(UPPER(TRIM(origin)), '');

--- a/src/test/java/com/fabricmanagement/production/execution/workorder/app/listener/WorkOrderSalesEventListenerTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/workorder/app/listener/WorkOrderSalesEventListenerTest.java
@@ -1,0 +1,139 @@
+package com.fabricmanagement.production.execution.workorder.app.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.production.execution.workorder.app.WorkOrderService;
+import com.fabricmanagement.production.execution.workorder.domain.WorkOrder;
+import com.fabricmanagement.production.execution.workorder.domain.WorkOrderStatus;
+import com.fabricmanagement.production.execution.workorder.infra.repository.WorkOrderRepository;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderCancelledEvent;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class WorkOrderSalesEventListenerTest {
+
+  @Mock private WorkOrderService workOrderService;
+  @Mock private WorkOrderRepository workOrderRepository;
+
+  @InjectMocks private WorkOrderSalesEventListener listener;
+
+  private UUID tenantId;
+  private UUID orderId;
+  private UUID lineId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    orderId = UUID.randomUUID();
+    lineId = UUID.randomUUID();
+  }
+
+  @Test
+  void onSalesOrderCancelled_cancelsNonCompletedWorkOrders() {
+    SalesOrderCancelledEvent event =
+        new SalesOrderCancelledEvent(tenantId, orderId, "SO-123", List.of(lineId));
+
+    WorkOrder wo1 = createWorkOrder(WorkOrderStatus.DRAFT);
+    WorkOrder wo2 = createWorkOrder(WorkOrderStatus.IN_PROGRESS);
+
+    when(workOrderRepository.findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(
+            tenantId, lineId))
+        .thenReturn(List.of(wo1, wo2));
+
+    listener.onSalesOrderCancelled(event);
+
+    verify(workOrderService).changeStatus(wo1.getId(), WorkOrderStatus.CANCELLED);
+    verify(workOrderService).changeStatus(wo2.getId(), WorkOrderStatus.CANCELLED);
+  }
+
+  @Test
+  void onSalesOrderCancelled_skipsCompletedWorkOrders() {
+    SalesOrderCancelledEvent event =
+        new SalesOrderCancelledEvent(tenantId, orderId, "SO-123", List.of(lineId));
+
+    WorkOrder wo = createWorkOrder(WorkOrderStatus.COMPLETED);
+
+    when(workOrderRepository.findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(
+            tenantId, lineId))
+        .thenReturn(List.of(wo));
+
+    listener.onSalesOrderCancelled(event);
+
+    verify(workOrderService, never()).changeStatus(any(), any());
+  }
+
+  @Test
+  void onSalesOrderCancelled_idempotent_skipsAlreadyCancelled() {
+    SalesOrderCancelledEvent event =
+        new SalesOrderCancelledEvent(tenantId, orderId, "SO-123", List.of(lineId));
+
+    WorkOrder wo = createWorkOrder(WorkOrderStatus.CANCELLED);
+
+    when(workOrderRepository.findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(
+            tenantId, lineId))
+        .thenReturn(List.of(wo));
+
+    listener.onSalesOrderCancelled(event);
+
+    verify(workOrderService, never()).changeStatus(any(), any());
+  }
+
+  @Test
+  void onSalesOrderCancelled_optimisticLockOnWO_swallowedPerWO() {
+    SalesOrderCancelledEvent event =
+        new SalesOrderCancelledEvent(tenantId, orderId, "SO-123", List.of(lineId));
+
+    WorkOrder wo1 = createWorkOrder(WorkOrderStatus.IN_PROGRESS);
+    WorkOrder wo2 = createWorkOrder(WorkOrderStatus.IN_PROGRESS);
+
+    when(workOrderRepository.findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(
+            tenantId, lineId))
+        .thenReturn(List.of(wo1, wo2));
+
+    // wo1 throws optimistic lock exception
+    doThrow(new ObjectOptimisticLockingFailureException(WorkOrder.class, wo1.getId()))
+        .when(workOrderService)
+        .changeStatus(wo1.getId(), WorkOrderStatus.CANCELLED);
+
+    listener.onSalesOrderCancelled(event);
+
+    // Both should be attempted, wo1 failed and swallowed, wo2 succeeded
+    verify(workOrderService).changeStatus(wo1.getId(), WorkOrderStatus.CANCELLED);
+    verify(workOrderService).changeStatus(wo2.getId(), WorkOrderStatus.CANCELLED);
+  }
+
+  @Test
+  void onSalesOrderCancelled_emptyLineIds_noop() {
+    SalesOrderCancelledEvent event =
+        new SalesOrderCancelledEvent(tenantId, orderId, "SO-123", List.of());
+
+    listener.onSalesOrderCancelled(event);
+
+    verify(workOrderRepository, never())
+        .findByTenantIdAndSalesOrderLineIdAndIsActiveTrueOrderByCreatedAtAsc(any(), any());
+    verify(workOrderService, never()).changeStatus(any(), any());
+  }
+
+  private WorkOrder createWorkOrder(WorkOrderStatus status) {
+    WorkOrder wo =
+        WorkOrder.builder()
+            .workOrderNumber("WO-" + UUID.randomUUID().toString().substring(0, 4))
+            .status(status)
+            .build();
+    ReflectionTestUtils.setField(wo, "id", UUID.randomUUID());
+    return wo;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/recipe/domain/RecipeComponentTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/recipe/domain/RecipeComponentTest.java
@@ -1,0 +1,37 @@
+package com.fabricmanagement.production.masterdata.recipe.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class RecipeComponentTest {
+
+  @Test
+  void normalizeFields_shouldUseRootLocaleAndConvertBlankValuesToNull() {
+    Locale previousLocale = Locale.getDefault();
+
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+      RecipeComponent component =
+          RecipeComponent.builder().certification(" bci ").origin(" it ").build();
+
+      ReflectionTestUtils.invokeMethod(component, "normalizeFields");
+
+      assertThat(component.getCertification()).isEqualTo("BCI");
+      assertThat(component.getOrigin()).isEqualTo("IT");
+
+      RecipeComponent blankComponent =
+          RecipeComponent.builder().certification("   ").origin("\t").build();
+
+      ReflectionTestUtils.invokeMethod(blankComponent, "normalizeFields");
+
+      assertThat(blankComponent.getCertification()).isNull();
+      assertThat(blankComponent.getOrigin()).isNull();
+    } finally {
+      Locale.setDefault(previousLocale);
+    }
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/SalesOrderServiceCancelTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/SalesOrderServiceCancelTest.java
@@ -1,0 +1,160 @@
+package com.fabricmanagement.sales.salesorder.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.salesorder.domain.OrderStatus;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderCancelledEvent;
+import com.fabricmanagement.sales.salesorder.dto.SalesOrderDto;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SalesOrderServiceCancelTest {
+
+  @Mock private SalesOrderRepository orderRepository;
+  @Mock private SalesOrderLineRepository lineRepository;
+  @Mock private DomainEventPublisher domainEventPublisher;
+
+  @InjectMocks private SalesOrderService salesOrderService;
+
+  private UUID tenantId;
+  private UUID orderId;
+  private SalesOrder order;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    orderId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    order =
+        SalesOrder.builder()
+            .tradingPartnerId(UUID.randomUUID())
+            .orderNumber("SO-123")
+            .status(OrderStatus.IN_PROGRESS)
+            .build();
+    ReflectionTestUtils.setField(order, "id", orderId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void cancelOrder_publishesSalesOrderCancelledEvent() {
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+    when(orderRepository.save(any(SalesOrder.class))).thenReturn(order);
+
+    SalesOrderLine line = SalesOrderLine.builder().build();
+    ReflectionTestUtils.setField(line, "id", UUID.randomUUID());
+    when(lineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line));
+
+    SalesOrderDto result = salesOrderService.cancelOrder(orderId);
+
+    assertThat(result.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+
+    ArgumentCaptor<SalesOrderCancelledEvent> eventCaptor =
+        ArgumentCaptor.forClass(SalesOrderCancelledEvent.class);
+    verify(domainEventPublisher).publish(eventCaptor.capture());
+
+    SalesOrderCancelledEvent event = eventCaptor.getValue();
+    assertThat(event.getSalesOrderId()).isEqualTo(orderId);
+    assertThat(event.getOrderNumber()).isEqualTo("SO-123");
+    assertThat(event.getCancelledLineIds()).containsExactly(line.getId());
+    assertThat(event.getTenantId()).isEqualTo(tenantId);
+  }
+
+  @Test
+  void resumeOrder_restoresStatus() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.ON_HOLD);
+    ReflectionTestUtils.setField(order, "statusBeforeHold", OrderStatus.CONFIRMED);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+    when(orderRepository.save(any(SalesOrder.class))).thenReturn(order);
+
+    SalesOrderDto result = salesOrderService.resumeOrder(orderId);
+
+    assertThat(result.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+  }
+
+  @Test
+  void reviseOrder_setsDraft() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.REJECTED);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+    when(orderRepository.save(any(SalesOrder.class))).thenReturn(order);
+
+    SalesOrderDto result = salesOrderService.reviseOrder(orderId);
+
+    assertThat(result.getStatus()).isEqualTo(OrderStatus.DRAFT);
+  }
+
+  @Test
+  void cancelOrder_whenShipped_throwsException() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.SHIPPED);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+    // Lines are collected before cancel() — stub explicitly to document intent
+    when(lineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of());
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> salesOrderService.cancelOrder(orderId))
+        .isInstanceOf(com.fabricmanagement.sales.common.exception.OrderDomainException.class)
+        .hasMessageContaining("Cannot cancel order");
+  }
+
+  @Test
+  void resumeOrder_whenNotOnHold_throwsException() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.IN_PROGRESS);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> salesOrderService.resumeOrder(orderId))
+        .isInstanceOf(com.fabricmanagement.sales.common.exception.OrderDomainException.class)
+        .hasMessageContaining("must be ON_HOLD");
+  }
+
+  @Test
+  void reviseOrder_whenNotRejected_throwsException() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.IN_PROGRESS);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> salesOrderService.reviseOrder(orderId))
+        .isInstanceOf(com.fabricmanagement.sales.common.exception.OrderDomainException.class)
+        .hasMessageContaining("only REJECTED orders can be revised");
+  }
+
+  @Test
+  void resumeOrder_whenStatusBeforeHoldNull_throwsIllegalState() {
+    ReflectionTestUtils.setField(order, "status", OrderStatus.ON_HOLD);
+    ReflectionTestUtils.setField(order, "statusBeforeHold", null);
+
+    when(orderRepository.findByTenantIdAndId(tenantId, orderId)).thenReturn(Optional.of(order));
+
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> salesOrderService.resumeOrder(orderId))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("statusBeforeHold is null");
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/ShipmentProgressServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/ShipmentProgressServiceTest.java
@@ -1,0 +1,330 @@
+package com.fabricmanagement.sales.salesorder.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.sales.salesorder.domain.OrderStatus;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ShipmentProgressServiceTest {
+
+  @Mock private SalesOrderLineRepository salesOrderLineRepository;
+  @Mock private SalesOrderRepository salesOrderRepository;
+
+  @InjectMocks private ShipmentProgressService shipmentProgressService;
+
+  private UUID orderId;
+  private UUID lineId;
+  private UUID shipmentLineId;
+
+  @BeforeEach
+  void setUp() {
+    orderId = UUID.randomUUID();
+    lineId = UUID.randomUUID();
+    shipmentLineId = UUID.randomUUID();
+    com.fabricmanagement.common.infrastructure.persistence.TenantContext.setCurrentTenantId(
+        com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID);
+  }
+
+  @org.junit.jupiter.api.AfterEach
+  void tearDown() {
+    com.fabricmanagement.common.infrastructure.persistence.TenantContext.clear();
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Faz 1: recordLineShipment Tests
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  void recordLineShipment_whenLineExists_updatesShippedQtyAndReturnsOrderId() {
+    SalesOrderLine line = mock(SalesOrderLine.class);
+    when(line.getSalesOrderId()).thenReturn(orderId);
+    when(salesOrderLineRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            lineId))
+        .thenReturn(Optional.of(line));
+
+    BigDecimal confirmedQty = new BigDecimal("100");
+    UUID result = shipmentProgressService.recordLineShipment(lineId, shipmentLineId, confirmedQty);
+
+    assertThat(result).isEqualTo(orderId);
+    verify(line).addShippedQuantity(shipmentLineId, confirmedQty);
+    verify(salesOrderLineRepository).save(line);
+  }
+
+  @Test
+  void recordLineShipment_whenLineNotFound_returnsNull() {
+    when(salesOrderLineRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            lineId))
+        .thenReturn(Optional.empty());
+
+    UUID result =
+        shipmentProgressService.recordLineShipment(lineId, shipmentLineId, new BigDecimal("100"));
+
+    assertThat(result).isNull();
+    verify(salesOrderLineRepository, never()).save(any());
+  }
+
+  @Test
+  void recordLineShipment_whenCalledTwiceWithSameShipmentLineId_isIdempotent() {
+    SalesOrderLine line =
+        SalesOrderLine.builder()
+            .salesOrderId(orderId)
+            .requestedQty(new BigDecimal("200"))
+            .shippedQty(BigDecimal.ZERO)
+            .lineStatus(SalesOrderLineStatus.IN_PRODUCTION)
+            .build();
+
+    when(salesOrderLineRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            lineId))
+        .thenReturn(Optional.of(line));
+
+    BigDecimal confirmedQty = new BigDecimal("100");
+
+    // First call
+    UUID result1 = shipmentProgressService.recordLineShipment(lineId, shipmentLineId, confirmedQty);
+
+    // Second call with same shipmentLineId
+    UUID result2 = shipmentProgressService.recordLineShipment(lineId, shipmentLineId, confirmedQty);
+
+    assertThat(result1).isEqualTo(orderId);
+    assertThat(result2).isEqualTo(orderId);
+    assertThat(line.getShippedQty()).isEqualByComparingTo(new BigDecimal("100")); // Not 200
+  }
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // Faz 2: updateOrderShipmentStatus Tests
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  @Test
+  void updateOrderShipmentStatus_whenPartialShipment_setsPartiallyShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    // 1 full, 1 zero -> partial
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("100"))
+            .lineStatus(SalesOrderLineStatus.IN_PRODUCTION)
+            .build();
+    SalesOrderLine line2 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("50"))
+            .shippedQty(BigDecimal.ZERO)
+            .lineStatus(SalesOrderLineStatus.IN_PRODUCTION)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1, line2));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+    verify(salesOrderRepository).save(order);
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenAllShipped_setsShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("100"))
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+    SalesOrderLine line2 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("50"))
+            .shippedQty(new BigDecimal("50"))
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1, line2));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPED);
+    verify(salesOrderRepository).save(order);
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenPartialQty_setsPartiallyShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("60")) // 60 < 100
+            .lineStatus(SalesOrderLineStatus.IN_WAREHOUSE)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+    verify(salesOrderRepository).save(order);
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenOverShipmentAndOthersFull_setsShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.PARTIALLY_SHIPPED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("120")) // Over-shipment
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+    SalesOrderLine line2 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("50"))
+            .shippedQty(new BigDecimal("50")) // Full
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1, line2));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPED);
+    verify(salesOrderRepository).save(order);
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenCancelledLinesPresent_ignoresCancelledLines() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("100"))
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+    SalesOrderLine line2 = // Cancelled, should be ignored
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("50"))
+            .shippedQty(BigDecimal.ZERO)
+            .lineStatus(SalesOrderLineStatus.CANCELLED)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1, line2));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    // Should be SHIPPED because the only active line is fully shipped
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPED);
+    verify(salesOrderRepository).save(order);
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenOrderDelivered_noop() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.DELIVERED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("100"))
+            .lineStatus(SalesOrderLineStatus.SHIPPED)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.DELIVERED);
+    verify(salesOrderRepository, never()).save(any());
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenOrderNotFound_returns() {
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.empty());
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of());
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    verify(salesOrderRepository, never()).save(any());
+  }
+
+  @Test
+  void updateOrderShipmentStatus_whenStatusUnchanged_doesNotSave() {
+    // Already PARTIALLY_SHIPPED
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.PARTIALLY_SHIPPED).build();
+    when(salesOrderRepository.findByTenantIdAndId(
+            com.fabricmanagement.common.infrastructure.persistence.TenantContext.SYSTEM_TENANT_ID,
+            orderId))
+        .thenReturn(Optional.of(order));
+
+    // Remains partial
+    SalesOrderLine line1 =
+        SalesOrderLine.builder()
+            .requestedQty(new BigDecimal("100"))
+            .shippedQty(new BigDecimal("50"))
+            .lineStatus(SalesOrderLineStatus.IN_WAREHOUSE)
+            .build();
+
+    when(salesOrderLineRepository.findBySalesOrderIdAndIsActiveTrueOrderByCreatedAtAsc(orderId))
+        .thenReturn(List.of(line1));
+
+    shipmentProgressService.updateOrderShipmentStatus(orderId);
+
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+    verify(salesOrderRepository, never()).save(any()); // Shouldn't save if status didn't change
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/listener/SalesOrderEventListenerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/listener/SalesOrderEventListenerTest.java
@@ -1,0 +1,74 @@
+package com.fabricmanagement.sales.salesorder.app.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.logistics.shipment.domain.event.ShipmentLineConfirmedEvent;
+import com.fabricmanagement.sales.salesorder.app.ShipmentProgressService;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SalesOrderEventListenerTest {
+
+  @Mock private ShipmentProgressService shipmentProgressService;
+
+  @InjectMocks private SalesOrderEventListener listener;
+
+  private UUID tenantId;
+  private UUID shipmentLineId;
+  private UUID salesOrderLineId;
+  private BigDecimal confirmedQuantity;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    shipmentLineId = UUID.randomUUID();
+    salesOrderLineId = UUID.randomUUID();
+    confirmedQuantity = new BigDecimal("100");
+  }
+
+  @Test
+  void onShipmentLineConfirmed_whenLineExists_delegatesToBothPhases() {
+    ShipmentLineConfirmedEvent event =
+        new ShipmentLineConfirmedEvent(
+            tenantId, shipmentLineId, salesOrderLineId, confirmedQuantity);
+    UUID salesOrderId = UUID.randomUUID();
+
+    when(shipmentProgressService.recordLineShipment(
+            salesOrderLineId, shipmentLineId, confirmedQuantity))
+        .thenReturn(salesOrderId);
+
+    listener.onShipmentLineConfirmed(event);
+
+    verify(shipmentProgressService)
+        .recordLineShipment(salesOrderLineId, shipmentLineId, confirmedQuantity);
+    verify(shipmentProgressService).updateOrderShipmentStatus(salesOrderId);
+  }
+
+  @Test
+  void onShipmentLineConfirmed_whenLineDoesNotExist_skipsPhase2() {
+    ShipmentLineConfirmedEvent event =
+        new ShipmentLineConfirmedEvent(
+            tenantId, shipmentLineId, salesOrderLineId, confirmedQuantity);
+
+    // Returns null to simulate line not found
+    when(shipmentProgressService.recordLineShipment(
+            salesOrderLineId, shipmentLineId, confirmedQuantity))
+        .thenReturn(null);
+
+    listener.onShipmentLineConfirmed(event);
+
+    verify(shipmentProgressService)
+        .recordLineShipment(salesOrderLineId, shipmentLineId, confirmedQuantity);
+    verify(shipmentProgressService, never()).updateOrderShipmentStatus(any(UUID.class));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/SalesOrderRuleEngineTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/SalesOrderRuleEngineTest.java
@@ -1,0 +1,183 @@
+package com.fabricmanagement.sales.salesorder.app.ruleengine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.salesorder.domain.ModuleType;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
+import com.fabricmanagement.sales.salesorder.domain.port.DraftProductionOrderCommand;
+import com.fabricmanagement.sales.salesorder.domain.port.ProductionOrderPort;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SalesOrderRuleEngineTest {
+
+  @Mock private SalesOrderLineRepository lineRepository;
+
+  @Mock private ProductionOrderPort productionOrderPort;
+
+  @Mock private WorkOrderRecipeHistoryQuery historyQuery;
+
+  @Captor private ArgumentCaptor<DraftProductionOrderCommand> cmdCaptor;
+
+  private SalesOrderRuleEngine ruleEngine;
+
+  private SalesOrder order;
+  private SalesOrderLine line;
+
+  private final UUID tenantId = UUID.randomUUID();
+  private final UUID orderId = UUID.randomUUID();
+  private final UUID lineId = UUID.randomUUID();
+  private final UUID partnerId = UUID.randomUUID();
+  private final UUID productId = UUID.randomUUID();
+  private final UUID recipeId = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(tenantId);
+    ruleEngine = new SalesOrderRuleEngine(lineRepository, productionOrderPort, historyQuery);
+
+    order = SalesOrder.builder().tradingPartnerId(partnerId).build();
+    ReflectionTestUtils.setField(order, "id", orderId);
+
+    line = SalesOrderLine.builder().productId(productId).moduleType(ModuleType.FIBER).build();
+    ReflectionTestUtils.setField(line, "id", lineId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void processConfirmedOrder_withCertificationAndOrigin_shouldPassToQueryAndCommand() {
+    line.setModuleSpecs(Map.of("certificationReq", "GOTS", "originReq", "TR"));
+
+    when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+            orderId, SalesOrderLineStatus.PENDING))
+        .thenReturn(List.of(line));
+
+    when(historyQuery.findDefaultRecipeForProduct(tenantId, productId, "GOTS", "TR"))
+        .thenReturn(Optional.of(recipeId));
+
+    ruleEngine.processConfirmedOrder(order);
+
+    verify(lineRepository).save(line);
+    assertThat(line.getRecipeId()).isEqualTo(recipeId);
+
+    verify(productionOrderPort).requestDraftProductionOrder(cmdCaptor.capture());
+    DraftProductionOrderCommand cmd = cmdCaptor.getValue();
+    assertThat(cmd.recipeId()).isEqualTo(recipeId);
+    assertThat(cmd.certificationReq()).isEqualTo("GOTS");
+    assertThat(cmd.originReq()).isEqualTo("TR");
+  }
+
+  @Test
+  void processConfirmedOrder_whenNoMatch_shouldCascadeToNextSteps() {
+    line.setModuleSpecs(Map.of("certificationReq", "OEKO-TEX"));
+
+    when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+            orderId, SalesOrderLineStatus.PENDING))
+        .thenReturn(List.of(line));
+
+    // Step 1 fails
+    when(historyQuery.findDefaultRecipeForProduct(tenantId, productId, "OEKO-TEX", null))
+        .thenReturn(Optional.empty());
+
+    // Step 2 fails
+    when(historyQuery.findMostRecentRecipeForCustomerAndProduct(
+            tenantId, partnerId, productId, "OEKO-TEX", null))
+        .thenReturn(Optional.empty());
+
+    // Step 3 matches
+    when(historyQuery.findMostUsedRecipeForProduct(tenantId, productId, "OEKO-TEX", null))
+        .thenReturn(Optional.of(recipeId));
+
+    ruleEngine.processConfirmedOrder(order);
+
+    verify(lineRepository).save(line);
+    assertThat(line.getRecipeId()).isEqualTo(recipeId);
+  }
+
+  @Test
+  void processConfirmedOrder_whenNoRecipeFound_shouldCreateDraftCommandWithoutRecipe() {
+    line.setModuleSpecs(Map.of("certificationReq", "GOTS"));
+
+    when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+            orderId, SalesOrderLineStatus.PENDING))
+        .thenReturn(List.of(line));
+
+    when(historyQuery.findDefaultRecipeForProduct(tenantId, productId, "GOTS", null))
+        .thenReturn(Optional.empty());
+    when(historyQuery.findMostRecentRecipeForCustomerAndProduct(
+            tenantId, partnerId, productId, "GOTS", null))
+        .thenReturn(Optional.empty());
+    when(historyQuery.findMostUsedRecipeForProduct(tenantId, productId, "GOTS", null))
+        .thenReturn(Optional.empty());
+
+    ruleEngine.processConfirmedOrder(order);
+
+    // No recipe assigned
+    assertThat(line.getRecipeId()).isNull();
+
+    // Draft still created
+    verify(productionOrderPort).requestDraftProductionOrder(cmdCaptor.capture());
+    DraftProductionOrderCommand cmd = cmdCaptor.getValue();
+    assertThat(cmd.recipeId()).isNull();
+    assertThat(cmd.certificationReq()).isEqualTo("GOTS");
+  }
+
+  @Test
+  void processConfirmedOrder_withEmptySpecs_shouldPassNulls() {
+    when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+            orderId, SalesOrderLineStatus.PENDING))
+        .thenReturn(List.of(line));
+
+    when(historyQuery.findDefaultRecipeForProduct(tenantId, productId, null, null))
+        .thenReturn(Optional.of(recipeId));
+
+    ruleEngine.processConfirmedOrder(order);
+
+    verify(productionOrderPort).requestDraftProductionOrder(cmdCaptor.capture());
+    DraftProductionOrderCommand cmd = cmdCaptor.getValue();
+    assertThat(cmd.certificationReq()).isNull();
+    assertThat(cmd.originReq()).isNull();
+  }
+
+  @Test
+  void extractSpecField_shouldNormalizeToUpperCase() {
+    // lowercase input should be normalized to uppercase
+    line.setModuleSpecs(Map.of("certificationReq", "gots", "originReq", " tr "));
+
+    when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+            orderId, SalesOrderLineStatus.PENDING))
+        .thenReturn(List.of(line));
+
+    when(historyQuery.findDefaultRecipeForProduct(tenantId, productId, "GOTS", "TR"))
+        .thenReturn(Optional.of(recipeId));
+
+    ruleEngine.processConfirmedOrder(order);
+
+    verify(productionOrderPort).requestDraftProductionOrder(cmdCaptor.capture());
+    DraftProductionOrderCommand cmd = cmdCaptor.getValue();
+    assertThat(cmd.certificationReq()).isEqualTo("GOTS");
+    assertThat(cmd.originReq()).isEqualTo("TR");
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQueryIT.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQueryIT.java
@@ -1,0 +1,247 @@
+package com.fabricmanagement.sales.salesorder.app.ruleengine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.salesorder.domain.ModuleType;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrder;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLine;
+import com.fabricmanagement.sales.salesorder.domain.SalesOrderLineStatus;
+import com.fabricmanagement.sales.salesorder.domain.port.DraftProductionOrderCommand;
+import com.fabricmanagement.sales.salesorder.domain.port.ProductionOrderPort;
+import com.fabricmanagement.sales.salesorder.infra.repository.SalesOrderLineRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+@Testcontainers
+@DisabledIf(value = "dockerNotAvailable", disabledReason = "Docker is not available")
+@DisplayName("WorkOrderRecipeHistoryQuery Integration Test")
+class WorkOrderRecipeHistoryQueryIT {
+
+  static boolean dockerNotAvailable() {
+    return !org.testcontainers.DockerClientFactory.instance().isDockerAvailable();
+  }
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:15-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("test")
+          .withPassword("test");
+
+  @DynamicPropertySource
+  static void configureDatasource(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.datasource.driver-class-name", () -> "org.postgresql.Driver");
+  }
+
+  @Autowired private NamedParameterJdbcTemplate jdbc;
+
+  private final UUID tenantId = UUID.randomUUID();
+
+  @Test
+  @DisplayName(
+      "Step 1: Query with NULL certification and origin binds correctly without Postgres type errors")
+  void findDefaultRecipeForProduct_withNulls_shouldExecuteWithoutErrors() {
+    WorkOrderRecipeHistoryQuery query = new WorkOrderRecipeHistoryQuery(jdbc);
+
+    Optional<UUID> result =
+        query.findDefaultRecipeForProduct(tenantId, UUID.randomUUID(), null, null);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Step 1: Query with populated certification and origin binds correctly without Postgres type errors")
+  void findDefaultRecipeForProduct_withValues_shouldExecuteWithoutErrors() {
+    WorkOrderRecipeHistoryQuery query = new WorkOrderRecipeHistoryQuery(jdbc);
+
+    Optional<UUID> result =
+        query.findDefaultRecipeForProduct(tenantId, UUID.randomUUID(), "GOTS", "TR");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Step 2: Customer history query executes without errors")
+  void findMostRecentRecipeForCustomerAndProduct_shouldExecuteWithoutErrors() {
+    WorkOrderRecipeHistoryQuery query = new WorkOrderRecipeHistoryQuery(jdbc);
+
+    Optional<UUID> result =
+        query.findMostRecentRecipeForCustomerAndProduct(
+            tenantId, UUID.randomUUID(), UUID.randomUUID(), null, "TR");
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("Step 3: Most used recipe query executes without errors")
+  void findMostUsedRecipeForProduct_shouldExecuteWithoutErrors() {
+    WorkOrderRecipeHistoryQuery query = new WorkOrderRecipeHistoryQuery(jdbc);
+
+    Optional<UUID> result =
+        query.findMostUsedRecipeForProduct(tenantId, UUID.randomUUID(), "OEKO-TEX", null);
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName(
+      "Step 1: Mixed-case BCI/IT DB value fails before backfill, succeeds after idempotent backfill")
+  void findDefaultRecipeForProduct_withMixedCaseBciIt_shouldMatchOnlyAfterBackfill() {
+    UUID recipeId = UUID.randomUUID();
+    UUID productId = UUID.randomUUID();
+    UUID blankRecipeId = UUID.randomUUID();
+    UUID blankProductId = UUID.randomUUID();
+
+    insertRecipeWithComponent(recipeId, productId, "bci", " it ");
+    insertRecipeWithComponent(blankRecipeId, blankProductId, "   ", "");
+
+    WorkOrderRecipeHistoryQuery query = new WorkOrderRecipeHistoryQuery(jdbc);
+
+    Optional<UUID> beforeBackfill =
+        query.findDefaultRecipeForProduct(tenantId, productId, "BCI", "IT");
+    assertThat(beforeBackfill).isEmpty();
+
+    assertThat(applyCertificationBackfill()).isEqualTo(2);
+    assertThat(applyOriginBackfill()).isEqualTo(2);
+    assertThat(applyCertificationBackfill()).isZero();
+    assertThat(applyOriginBackfill()).isZero();
+
+    Optional<UUID> afterBackfill =
+        query.findDefaultRecipeForProduct(tenantId, productId, "BCI", "IT");
+    assertThat(afterBackfill).contains(recipeId);
+
+    Map<String, Object> blankValues =
+        jdbc.getJdbcOperations()
+            .queryForMap(
+                "SELECT certification, origin FROM production.prod_recipe_component WHERE recipe_id = ?",
+                blankRecipeId);
+    assertThat(blankValues.get("certification")).isNull();
+    assertThat(blankValues.get("origin")).isNull();
+  }
+
+  @Test
+  @DisplayName("RuleEngine: tr_TR mixed-case BCI/IT request matches normalized recipe component")
+  void processConfirmedOrder_withTurkishLocaleMixedCaseBciIt_shouldMatchNormalizedComponent() {
+    UUID recipeId = UUID.randomUUID();
+    UUID productId = UUID.randomUUID();
+    UUID orderId = UUID.randomUUID();
+    UUID lineId = UUID.randomUUID();
+    UUID partnerId = UUID.randomUUID();
+    Locale previousLocale = Locale.getDefault();
+
+    insertRecipeWithComponent(recipeId, productId, "BCI", "IT");
+
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      TenantContext.setCurrentTenantId(tenantId);
+
+      SalesOrderLineRepository lineRepository = mock(SalesOrderLineRepository.class);
+      ProductionOrderPort productionOrderPort = mock(ProductionOrderPort.class);
+      SalesOrderRuleEngine ruleEngine =
+          new SalesOrderRuleEngine(
+              lineRepository, productionOrderPort, new WorkOrderRecipeHistoryQuery(jdbc));
+
+      SalesOrder order =
+          SalesOrder.builder().tradingPartnerId(partnerId).orderNumber("SO-TEST").build();
+      ReflectionTestUtils.setField(order, "id", orderId);
+
+      SalesOrderLine line =
+          SalesOrderLine.builder()
+              .productId(productId)
+              .moduleType(ModuleType.FIBER)
+              .moduleSpecs(Map.of("certificationReq", "bci", "originReq", " it "))
+              .requestedQty(BigDecimal.ONE)
+              .unit("KG")
+              .build();
+      ReflectionTestUtils.setField(line, "id", lineId);
+
+      when(lineRepository.findBySalesOrderIdAndLineStatusAndIsActiveTrue(
+              orderId, SalesOrderLineStatus.PENDING))
+          .thenReturn(List.of(line));
+
+      ruleEngine.processConfirmedOrder(order);
+
+      assertThat(line.getRecipeId()).isEqualTo(recipeId);
+      verify(lineRepository).save(line);
+
+      ArgumentCaptor<DraftProductionOrderCommand> commandCaptor =
+          ArgumentCaptor.forClass(DraftProductionOrderCommand.class);
+      verify(productionOrderPort).requestDraftProductionOrder(commandCaptor.capture());
+      assertThat(commandCaptor.getValue().recipeId()).isEqualTo(recipeId);
+      assertThat(commandCaptor.getValue().certificationReq()).isEqualTo("BCI");
+      assertThat(commandCaptor.getValue().originReq()).isEqualTo("IT");
+    } finally {
+      TenantContext.clear();
+      Locale.setDefault(previousLocale);
+    }
+  }
+
+  private void insertRecipeWithComponent(
+      UUID recipeId, UUID productId, String certification, String origin) {
+    jdbc.getJdbcOperations()
+        .update(
+            "INSERT INTO production.prod_recipe (id, tenant_id, uid, created_at, updated_at, name, iso_code, components, status, recipe_version, is_active) "
+                + "VALUES (?, ?, ?, now(), now(), 'Test Recipe', 'TEST', '[]', 'ACTIVE', 1, true)",
+            recipeId,
+            tenantId,
+            UUID.randomUUID().toString());
+
+    jdbc.getJdbcOperations()
+        .update(
+            "INSERT INTO production.prod_recipe_component (id, tenant_id, uid, created_at, updated_at, recipe_id, fiber_id, fiber_name, fiber_iso_code, percentage, certification, origin, display_order, is_active) "
+                + "VALUES (?, ?, ?, now(), now(), ?, ?, 'Cotton', 'CO', 100.0, ?, ?, 1, true)",
+            UUID.randomUUID(),
+            tenantId,
+            UUID.randomUUID().toString(),
+            recipeId,
+            productId,
+            certification,
+            origin);
+  }
+
+  private int applyCertificationBackfill() {
+    return jdbc.getJdbcOperations()
+        .update(
+            "UPDATE production.prod_recipe_component "
+                + "SET certification = NULLIF(UPPER(TRIM(certification)), '') "
+                + "WHERE certification IS DISTINCT FROM NULLIF(UPPER(TRIM(certification)), '')");
+  }
+
+  private int applyOriginBackfill() {
+    return jdbc.getJdbcOperations()
+        .update(
+            "UPDATE production.prod_recipe_component "
+                + "SET origin = NULLIF(UPPER(TRIM(origin)), '') "
+                + "WHERE origin IS DISTINCT FROM NULLIF(UPPER(TRIM(origin)), '')");
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQueryTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/app/ruleengine/WorkOrderRecipeHistoryQueryTest.java
@@ -1,0 +1,99 @@
+package com.fabricmanagement.sales.salesorder.app.ruleengine;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class WorkOrderRecipeHistoryQueryTest {
+
+  @Mock private NamedParameterJdbcTemplate jdbc;
+
+  @Captor private ArgumentCaptor<MapSqlParameterSource> paramCaptor;
+
+  private WorkOrderRecipeHistoryQuery historyQuery;
+
+  private final UUID tenantId = UUID.randomUUID();
+  private final UUID productId = UUID.randomUUID();
+  private final UUID partnerId = UUID.randomUUID();
+  private final UUID recipeId = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    historyQuery = new WorkOrderRecipeHistoryQuery(jdbc);
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findDefaultRecipeForProduct_shouldBuildCorrectParams() {
+    when(jdbc.query(anyString(), any(MapSqlParameterSource.class), any(ResultSetExtractor.class)))
+        .thenReturn(Optional.of(recipeId));
+
+    Optional<UUID> result =
+        historyQuery.findDefaultRecipeForProduct(tenantId, productId, "GOTS", "TR");
+
+    assertThat(result).contains(recipeId);
+    verify(jdbc).query(anyString(), paramCaptor.capture(), any(ResultSetExtractor.class));
+
+    MapSqlParameterSource params = paramCaptor.getValue();
+    assertThat(params.getValue("tenantId")).isEqualTo(tenantId);
+    assertThat(params.getValue("productId")).isEqualTo(productId);
+    assertThat(params.getValue("certification")).isEqualTo("GOTS");
+    assertThat(params.getValue("origin")).isEqualTo("TR");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findMostRecentRecipeForCustomerAndProduct_shouldBuildCorrectParams() {
+    when(jdbc.query(anyString(), any(MapSqlParameterSource.class), any(ResultSetExtractor.class)))
+        .thenReturn(Optional.of(recipeId));
+
+    Optional<UUID> result =
+        historyQuery.findMostRecentRecipeForCustomerAndProduct(
+            tenantId, partnerId, productId, null, null);
+
+    assertThat(result).contains(recipeId);
+    verify(jdbc).query(anyString(), paramCaptor.capture(), any(ResultSetExtractor.class));
+
+    MapSqlParameterSource params = paramCaptor.getValue();
+    assertThat(params.getValue("tenantId")).isEqualTo(tenantId);
+    assertThat(params.getValue("tradingPartnerId")).isEqualTo(partnerId);
+    assertThat(params.getValue("productId")).isEqualTo(productId);
+    assertThat(params.getValue("certification")).isNull();
+    assertThat(params.getValue("origin")).isNull();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  void findMostUsedRecipeForProduct_shouldBuildCorrectParams() {
+    when(jdbc.query(anyString(), any(MapSqlParameterSource.class), any(ResultSetExtractor.class)))
+        .thenReturn(Optional.empty());
+
+    Optional<UUID> result =
+        historyQuery.findMostUsedRecipeForProduct(tenantId, productId, "OEKO-TEX", "EG");
+
+    assertThat(result).isEmpty();
+    verify(jdbc).query(anyString(), paramCaptor.capture(), any(ResultSetExtractor.class));
+
+    MapSqlParameterSource params = paramCaptor.getValue();
+    assertThat(params.getValue("tenantId")).isEqualTo(tenantId);
+    assertThat(params.getValue("productId")).isEqualTo(productId);
+    assertThat(params.getValue("certification")).isEqualTo("OEKO-TEX");
+    assertThat(params.getValue("origin")).isEqualTo("EG");
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/salesorder/domain/OrderStatusTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/domain/OrderStatusTest.java
@@ -21,4 +21,19 @@ class OrderStatusTest {
   void canEdit_whenNotDraft_returnsFalse(OrderStatus status) {
     assertThat(status.canEdit()).isFalse();
   }
+
+  @Test
+  void canCancel_whenInProgress_returnsTrue() {
+    assertThat(OrderStatus.IN_PROGRESS.canCancel()).isTrue();
+  }
+
+  @Test
+  void canCancel_whenPartiallyShipped_returnsFalse() {
+    assertThat(OrderStatus.PARTIALLY_SHIPPED.canCancel()).isFalse();
+  }
+
+  @Test
+  void canCancel_whenShipped_returnsFalse() {
+    assertThat(OrderStatus.SHIPPED.canCancel()).isFalse();
+  }
 }

--- a/src/test/java/com/fabricmanagement/sales/salesorder/domain/SalesOrderTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/domain/SalesOrderTest.java
@@ -143,4 +143,63 @@ class SalesOrderTest {
         .extracting("httpStatus")
         .isEqualTo(409);
   }
+
+  @Test
+  void recordShipmentProgress_partial_setsPartiallyShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    order.recordShipmentProgress(false, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+  }
+
+  @Test
+  void recordShipmentProgress_allShipped_setsShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    order.recordShipmentProgress(true, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPED);
+  }
+
+  @Test
+  void recordShipmentProgress_partiallyShipped_toShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.PARTIALLY_SHIPPED).build();
+    order.recordShipmentProgress(true, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.SHIPPED);
+  }
+
+  @Test
+  void recordShipmentProgress_idempotent_staysPartiallyShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.PARTIALLY_SHIPPED).build();
+    order.recordShipmentProgress(false, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+  }
+
+  @Test
+  void recordShipmentProgress_inProgress_setsPartiallyShipped() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.IN_PROGRESS).build();
+    order.recordShipmentProgress(false, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.PARTIALLY_SHIPPED);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrderStatus.class,
+      names = {"DELIVERED", "CANCELLED", "REJECTED"})
+  void recordShipmentProgress_terminal_noop(OrderStatus status) {
+    SalesOrder order = SalesOrder.builder().status(status).build();
+    order.recordShipmentProgress(true, true);
+    assertThat(order.getStatus()).isEqualTo(status);
+  }
+
+  @Test
+  void recordShipmentProgress_onHold_noop() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.ON_HOLD).build();
+    order.recordShipmentProgress(false, true);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.ON_HOLD);
+  }
+
+  @Test
+  void recordShipmentProgress_noneShipped_noop() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    order.recordShipmentProgress(false, false);
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+  }
 }

--- a/src/test/java/com/fabricmanagement/sales/salesorder/domain/SalesOrderTest.java
+++ b/src/test/java/com/fabricmanagement/sales/salesorder/domain/SalesOrderTest.java
@@ -202,4 +202,89 @@ class SalesOrderTest {
     order.recordShipmentProgress(false, false);
     assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
   }
+
+  @Test
+  void cancel_whenInProgress_succeeds() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.IN_PROGRESS).build();
+    order.cancel();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CANCELLED);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = OrderStatus.class,
+      names = {"PARTIALLY_SHIPPED", "SHIPPED"})
+  void cancel_whenPartiallyShippedOrShipped_throws409(OrderStatus status) {
+    SalesOrder order = SalesOrder.builder().status(status).build();
+    assertThatThrownBy(() -> order.cancel())
+        .isInstanceOf(OrderDomainException.class)
+        .hasMessageContaining("Cannot cancel order")
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void hold_thenResume_restoresInProgress() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.IN_PROGRESS).build();
+    order.hold();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.ON_HOLD);
+    order.resume();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.IN_PROGRESS);
+  }
+
+  @Test
+  void hold_thenResume_restoresConfirmed() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.CONFIRMED).build();
+    order.hold();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.ON_HOLD);
+    order.resume();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.CONFIRMED);
+  }
+
+  @Test
+  void resume_whenNotOnHold_throws409() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.DRAFT).build();
+    assertThatThrownBy(() -> order.resume())
+        .isInstanceOf(OrderDomainException.class)
+        .hasMessageContaining("must be ON_HOLD")
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void reviseRejected_whenRejected_movesToDraft() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.REJECTED).build();
+    order.reviseRejected();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.DRAFT);
+  }
+
+  @Test
+  void reviseRejected_whenNotRejected_throws409() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.IN_PROGRESS).build();
+    assertThatThrownBy(() -> order.reviseRejected())
+        .isInstanceOf(OrderDomainException.class)
+        .hasMessageContaining("only REJECTED orders can be revised")
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void hold_whenAlreadyOnHold_throws409() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.ON_HOLD).build();
+    assertThatThrownBy(() -> order.hold())
+        .isInstanceOf(OrderDomainException.class)
+        .hasMessageContaining("terminal or already ON_HOLD")
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void reviseRejected_clearsRejectionReason() {
+    SalesOrder order = SalesOrder.builder().status(OrderStatus.REJECTED).build();
+    org.springframework.test.util.ReflectionTestUtils.setField(
+        order, "rejectionReason", "Insufficient funds");
+    order.reviseRejected();
+    assertThat(order.getStatus()).isEqualTo(OrderStatus.DRAFT);
+    assertThat(order.getRejectionReason()).isNull();
+  }
 }


### PR DESCRIPTION
- Implemented two-phase ShipmentProgressService to safely update quantities and determine order header status
- Added state machine logic to SalesOrder for PARTIALLY_SHIPPED and SHIPPED transitions
- Refactored SalesOrderEventListener with @Retryable and idempotency checks to prevent double-processing and optimistic locking issues
- Added tenant-scoped queries in SalesOrderLineRepository
- Added comprehensive unit and integration tests