### PR TITLE
test: add test-only default JWT secret to fix CI integration tests

### DIFF
--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -9,6 +9,8 @@ spring:
 # Testcontainers uses the same superuser for all roles — this prevents
 # the CR-4 fail-fast guard from rejecting empty credentials at startup.
 application:
+  jwt:
+    secret: ${JWT_SECRET:test-only-jwt-secret-key-not-for-production-min-256-bits-long}
   system-datasource:
     enabled: true
     username: ${spring.datasource.username:test}


### PR DESCRIPTION
- Added a fallback JWT secret to the test profile configuration.
- Resolves integration test failures caused by the lack of the JWT_SECRET environment variable in the CI pipeline after prod hygiene cleanup.