### PR TITLE
chore: sync openapi.yaml with springdoc 2.8.17 and fix export test

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: 3.1.0
 info:
   contact:
     name: Fabric Management Team
@@ -215,7 +215,7 @@ paths:
           description: Tenant created successfully; welcome email sent to admin
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -230,37 +230,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -279,7 +279,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -294,37 +294,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -350,7 +350,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -365,37 +365,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -420,7 +420,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -435,37 +435,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -490,7 +490,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -505,37 +505,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -566,7 +566,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -581,37 +581,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -642,7 +642,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -657,37 +657,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -712,7 +712,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -727,37 +727,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -782,7 +782,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -797,37 +797,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -852,7 +852,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -867,37 +867,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -928,7 +928,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -943,37 +943,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -991,7 +991,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1006,37 +1006,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1060,7 +1060,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1075,37 +1075,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1136,7 +1136,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1151,37 +1151,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1213,7 +1213,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1228,37 +1228,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1289,7 +1289,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1304,37 +1304,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1355,7 +1355,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1370,37 +1370,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1421,7 +1421,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1436,37 +1436,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1492,7 +1492,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1507,37 +1507,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1570,7 +1570,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1585,37 +1585,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1636,7 +1636,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1651,37 +1651,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1708,7 +1708,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1723,37 +1723,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1777,7 +1777,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1792,37 +1792,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1840,7 +1840,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1855,37 +1855,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1909,7 +1909,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1924,37 +1924,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -1972,7 +1972,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -1987,37 +1987,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2035,7 +2035,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2050,37 +2050,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2104,7 +2104,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2119,37 +2119,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2167,7 +2167,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2182,37 +2182,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2236,7 +2236,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2251,37 +2251,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2305,7 +2305,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2320,37 +2320,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2374,7 +2374,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2389,37 +2389,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2437,7 +2437,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2452,37 +2452,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2506,7 +2506,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2521,37 +2521,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2575,7 +2575,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2590,37 +2590,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2638,7 +2638,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2653,37 +2653,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2700,7 +2700,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2715,37 +2715,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2770,7 +2770,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2785,37 +2785,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2839,7 +2839,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2854,37 +2854,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2908,7 +2908,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2923,37 +2923,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -2977,7 +2977,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -2992,37 +2992,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3046,7 +3046,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3061,37 +3061,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3120,7 +3120,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3135,37 +3135,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3199,7 +3199,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3214,37 +3214,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3273,7 +3273,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3288,37 +3288,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3342,7 +3342,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3357,37 +3357,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3411,7 +3411,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3426,37 +3426,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3481,7 +3481,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3496,37 +3496,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3551,7 +3551,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3566,37 +3566,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3620,7 +3620,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3635,37 +3635,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3695,7 +3695,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3710,37 +3710,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3764,7 +3764,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3779,37 +3779,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3833,7 +3833,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3848,37 +3848,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3907,7 +3907,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3922,37 +3922,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -3982,7 +3982,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -3997,37 +3997,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4045,7 +4045,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4060,37 +4060,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4108,7 +4108,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4123,37 +4123,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4177,7 +4177,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4192,37 +4192,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4237,6 +4237,7 @@ paths:
         required: true
         schema:
           type: string
+          minLength: 1
       responses:
         "200":
           content:
@@ -4246,7 +4247,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4261,37 +4262,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4306,6 +4307,7 @@ paths:
         required: true
         schema:
           type: string
+          minLength: 1
       responses:
         "200":
           content:
@@ -4315,7 +4317,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4330,37 +4332,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4384,7 +4386,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4399,37 +4401,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4454,7 +4456,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4469,37 +4471,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4523,7 +4525,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4538,37 +4540,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4593,7 +4595,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4608,37 +4610,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4656,7 +4658,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4671,37 +4673,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4726,7 +4728,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4741,37 +4743,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4796,7 +4798,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4811,37 +4813,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4870,7 +4872,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4885,37 +4887,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4929,7 +4931,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -4944,37 +4946,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -4992,7 +4994,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5007,37 +5009,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5058,7 +5060,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5073,37 +5075,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5121,7 +5123,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5136,37 +5138,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5189,7 +5191,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5204,37 +5206,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5252,7 +5254,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5267,37 +5269,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5321,7 +5323,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5336,37 +5338,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5391,7 +5393,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5406,37 +5408,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5460,7 +5462,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5475,37 +5477,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5544,7 +5546,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5559,37 +5561,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5614,7 +5616,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5629,37 +5631,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5684,7 +5686,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5699,37 +5701,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5759,7 +5761,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5774,37 +5776,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5847,7 +5849,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5862,37 +5864,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5917,7 +5919,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -5932,37 +5934,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -5987,7 +5989,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6002,37 +6004,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6063,7 +6065,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6078,37 +6080,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6139,7 +6141,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6154,37 +6156,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6215,7 +6217,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6230,37 +6232,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6291,7 +6293,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6306,37 +6308,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6363,7 +6365,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6378,37 +6380,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6441,7 +6443,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6456,37 +6458,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6521,7 +6523,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6536,37 +6538,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6600,7 +6602,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6615,37 +6617,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6685,7 +6687,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6700,37 +6702,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6756,7 +6758,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6771,37 +6773,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6831,7 +6833,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6846,37 +6848,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6918,7 +6920,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -6933,37 +6935,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -6988,7 +6990,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7003,37 +7005,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7064,7 +7066,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7079,37 +7081,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7145,7 +7147,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7160,37 +7162,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7221,7 +7223,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7236,37 +7238,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7303,7 +7305,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7318,37 +7320,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7373,7 +7375,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7388,37 +7390,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7441,7 +7443,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7456,37 +7458,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7511,7 +7513,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7526,37 +7528,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7581,7 +7583,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7596,37 +7598,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7655,7 +7657,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7670,37 +7672,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7723,7 +7725,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7738,37 +7740,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7793,7 +7795,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7808,37 +7810,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7868,7 +7870,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7883,37 +7885,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7931,7 +7933,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -7946,37 +7948,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -7999,7 +8001,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8014,37 +8016,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8069,7 +8071,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8084,37 +8086,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8138,7 +8140,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8153,37 +8155,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8213,7 +8215,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8228,37 +8230,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8283,7 +8285,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8298,37 +8300,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8353,7 +8355,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8368,37 +8370,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8416,7 +8418,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8431,37 +8433,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8484,7 +8486,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8499,37 +8501,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8553,7 +8555,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8568,37 +8570,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8623,7 +8625,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8638,37 +8640,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8692,7 +8694,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8707,37 +8709,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8767,7 +8769,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8782,37 +8784,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8830,7 +8832,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8845,37 +8847,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8900,7 +8902,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8915,37 +8917,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -8963,7 +8965,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -8978,37 +8980,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9033,7 +9035,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9048,37 +9050,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9108,7 +9110,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9123,37 +9125,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9178,7 +9180,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9193,37 +9195,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9248,7 +9250,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9263,37 +9265,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9318,7 +9320,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9333,37 +9335,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9393,7 +9395,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9408,37 +9410,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9456,7 +9458,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9471,37 +9473,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9519,7 +9521,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9534,37 +9536,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9582,7 +9584,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9597,37 +9599,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9650,7 +9652,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9665,37 +9667,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9714,7 +9716,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9729,37 +9731,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9786,7 +9788,7 @@ paths:
           description: Partner created successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Invalid request
@@ -9801,37 +9803,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9851,7 +9853,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9866,37 +9868,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9916,7 +9918,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -9931,37 +9933,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -9988,7 +9990,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10003,37 +10005,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10053,7 +10055,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10068,37 +10070,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10135,7 +10137,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10150,37 +10152,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10207,7 +10209,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10222,37 +10224,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10280,7 +10282,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10295,37 +10297,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10360,7 +10362,7 @@ paths:
           description: Partner updated successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10375,37 +10377,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Partner not found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10432,7 +10434,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10447,37 +10449,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10504,7 +10506,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10519,37 +10521,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10576,7 +10578,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10591,37 +10593,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10649,7 +10651,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10664,37 +10666,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10727,7 +10729,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10742,37 +10744,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10807,7 +10809,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10822,37 +10824,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10886,7 +10888,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10901,37 +10903,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -10971,7 +10973,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -10986,37 +10988,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11043,7 +11045,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11058,37 +11060,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11121,7 +11123,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11136,37 +11138,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11198,7 +11200,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11213,37 +11215,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11275,7 +11277,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11290,37 +11292,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11358,7 +11360,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11373,37 +11375,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11435,7 +11437,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11450,37 +11452,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11499,7 +11501,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11514,37 +11516,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11579,7 +11581,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11594,37 +11596,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11648,7 +11650,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11663,37 +11665,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11711,7 +11713,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11726,37 +11728,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11774,7 +11776,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11789,37 +11791,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11843,7 +11845,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11858,37 +11860,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11906,7 +11908,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11921,37 +11923,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -11975,7 +11977,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -11990,37 +11992,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12038,7 +12040,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12053,37 +12055,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12107,7 +12109,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12122,37 +12124,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12170,7 +12172,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12185,37 +12187,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12238,7 +12240,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12253,37 +12255,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12307,7 +12309,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12322,37 +12324,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12370,7 +12372,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12385,37 +12387,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12433,7 +12435,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12448,37 +12450,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12503,7 +12505,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12518,37 +12520,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12566,7 +12568,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12581,37 +12583,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12636,7 +12638,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12651,37 +12653,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12705,7 +12707,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12720,37 +12722,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12780,7 +12782,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12795,37 +12797,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12850,7 +12852,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12865,37 +12867,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -12925,7 +12927,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -12940,37 +12942,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13001,7 +13003,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13016,37 +13018,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13083,7 +13085,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13098,37 +13100,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13165,7 +13167,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13180,37 +13182,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13235,7 +13237,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13250,37 +13252,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13310,7 +13312,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13325,37 +13327,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13398,7 +13400,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13413,37 +13415,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13468,7 +13470,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13483,37 +13485,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13538,7 +13540,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13553,37 +13555,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13614,7 +13616,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13629,37 +13631,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13690,7 +13692,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13705,37 +13707,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13760,7 +13762,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13775,37 +13777,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13835,7 +13837,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13850,37 +13852,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13905,7 +13907,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -13920,37 +13922,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -13987,7 +13989,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14002,37 +14004,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14057,7 +14059,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14072,37 +14074,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14133,7 +14135,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14148,37 +14150,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14209,7 +14211,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14224,37 +14226,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14279,7 +14281,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14294,37 +14296,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14354,7 +14356,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14369,37 +14371,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14424,7 +14426,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14439,37 +14441,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14500,7 +14502,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14515,37 +14517,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14576,7 +14578,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14591,37 +14593,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14646,7 +14648,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14661,37 +14663,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14721,7 +14723,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14736,37 +14738,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14791,7 +14793,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14806,37 +14808,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14867,7 +14869,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14882,37 +14884,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -14943,7 +14945,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -14958,37 +14960,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15012,7 +15014,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15027,37 +15029,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15081,7 +15083,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15096,37 +15098,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15150,7 +15152,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15165,37 +15167,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15220,7 +15222,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15235,37 +15237,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15300,7 +15302,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15315,37 +15317,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15369,7 +15371,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15384,37 +15386,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15439,7 +15441,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15454,37 +15456,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15507,7 +15509,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15522,37 +15524,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15577,7 +15579,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15592,37 +15594,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15646,7 +15648,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15661,37 +15663,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15714,7 +15716,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15729,37 +15731,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15783,7 +15785,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15798,37 +15800,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15852,7 +15854,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15867,37 +15869,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15921,7 +15923,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -15936,37 +15938,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -15990,7 +15992,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16005,37 +16007,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16065,7 +16067,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16080,37 +16082,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16140,7 +16142,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16155,37 +16157,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16224,7 +16226,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16239,37 +16241,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16290,7 +16292,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16305,37 +16307,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16359,7 +16361,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16374,37 +16376,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16434,7 +16436,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16449,37 +16451,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16504,7 +16506,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16519,37 +16521,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16574,7 +16576,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16589,37 +16591,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16644,7 +16646,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16659,37 +16661,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16720,7 +16722,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16735,37 +16737,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16790,7 +16792,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16805,37 +16807,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16860,7 +16862,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16875,37 +16877,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -16930,7 +16932,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -16945,37 +16947,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17000,7 +17002,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17015,37 +17017,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17069,7 +17071,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17084,37 +17086,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17140,7 +17142,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17155,37 +17157,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17216,7 +17218,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17231,37 +17233,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17292,7 +17294,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17307,37 +17309,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17356,7 +17358,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17371,37 +17373,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17425,7 +17427,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17440,37 +17442,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17489,7 +17491,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17504,37 +17506,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17560,7 +17562,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17575,37 +17577,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17631,7 +17633,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17646,37 +17648,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17702,7 +17704,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17717,37 +17719,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17806,7 +17808,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17821,37 +17823,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17915,7 +17917,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -17930,37 +17932,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -17986,7 +17988,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18001,37 +18003,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18053,6 +18055,7 @@ paths:
           application/json:
             schema:
               type: string
+              minLength: 1
         required: true
       responses:
         "200":
@@ -18063,7 +18066,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18078,37 +18081,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18133,7 +18136,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18148,37 +18151,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18208,7 +18211,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18223,37 +18226,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18278,7 +18281,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18293,37 +18296,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18349,7 +18352,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18364,37 +18367,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18419,7 +18422,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18434,37 +18437,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18486,7 +18489,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18501,37 +18504,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18556,7 +18559,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18571,37 +18574,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18643,7 +18646,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18658,37 +18661,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18714,7 +18717,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18729,37 +18732,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18791,7 +18794,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18806,37 +18809,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18862,7 +18865,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18877,37 +18880,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -18938,7 +18941,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -18953,37 +18956,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19015,7 +19018,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19030,37 +19033,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19081,7 +19084,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19096,37 +19099,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19149,7 +19152,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19164,37 +19167,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19215,7 +19218,7 @@ paths:
           description: No Content
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19230,37 +19233,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19284,7 +19287,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19299,37 +19302,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19359,7 +19362,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19374,37 +19377,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19429,7 +19432,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19444,37 +19447,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19490,12 +19493,11 @@ paths:
             '*/*':
               schema:
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: {}
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19510,37 +19512,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19558,7 +19560,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19573,37 +19575,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19621,7 +19623,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19636,37 +19638,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19684,7 +19686,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19699,37 +19701,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19753,7 +19755,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19768,37 +19770,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19817,7 +19819,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19832,37 +19834,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19892,7 +19894,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19907,37 +19909,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -19953,12 +19955,11 @@ paths:
             '*/*':
               schema:
                 type: object
-                additionalProperties:
-                  type: object
+                additionalProperties: {}
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -19973,37 +19974,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20021,7 +20022,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20036,37 +20037,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20089,7 +20090,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20104,37 +20105,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20171,7 +20172,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20186,37 +20187,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20270,7 +20271,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20285,37 +20286,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20333,7 +20334,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20348,37 +20349,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20402,7 +20403,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20417,37 +20418,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20477,7 +20478,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20492,37 +20493,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20540,7 +20541,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20555,37 +20556,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20617,7 +20618,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20632,37 +20633,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20683,7 +20684,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20698,37 +20699,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20752,7 +20753,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20767,37 +20768,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20827,7 +20828,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20842,37 +20843,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20907,7 +20908,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20922,37 +20923,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -20977,7 +20978,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -20992,37 +20993,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21053,7 +21054,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21068,37 +21069,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21123,7 +21124,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21138,37 +21139,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21192,7 +21193,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21207,37 +21208,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21270,7 +21271,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21285,37 +21286,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21337,7 +21338,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21352,37 +21353,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21404,7 +21405,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21419,37 +21420,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21483,7 +21484,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21498,37 +21499,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21549,7 +21550,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21564,37 +21565,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21613,7 +21614,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21628,37 +21629,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21677,7 +21678,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21692,37 +21693,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21748,7 +21749,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21763,37 +21764,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21823,7 +21824,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21838,37 +21839,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21893,7 +21894,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21908,37 +21909,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -21963,7 +21964,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -21978,37 +21979,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22039,7 +22040,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22054,37 +22055,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22108,7 +22109,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22123,37 +22124,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22182,7 +22183,7 @@ paths:
           description: Persona switched successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22200,31 +22201,31 @@ paths:
           description: Not a valid playground session or user outside playground
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22255,7 +22256,7 @@ paths:
           description: Playground initialized successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22270,25 +22271,25 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
@@ -22297,7 +22298,7 @@ paths:
           description: Rate limit exceeded for initialization
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22320,7 +22321,7 @@ paths:
           description: List of personas retrieved successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22338,31 +22339,31 @@ paths:
           description: Not a valid playground session
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22413,7 +22414,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22428,37 +22429,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22482,7 +22483,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22497,37 +22498,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22553,7 +22554,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22568,37 +22569,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22639,7 +22640,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22654,37 +22655,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22709,7 +22710,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22724,37 +22725,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22785,7 +22786,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22800,37 +22801,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22861,7 +22862,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22876,37 +22877,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -22931,7 +22932,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -22946,37 +22947,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23000,7 +23001,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23015,37 +23016,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23070,7 +23071,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23085,37 +23086,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23145,7 +23146,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23160,37 +23161,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23233,7 +23234,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23248,37 +23249,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23325,7 +23326,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23340,37 +23341,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23394,7 +23395,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23409,37 +23410,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23465,7 +23466,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23480,37 +23481,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23536,7 +23537,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23551,37 +23552,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23607,7 +23608,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23622,37 +23623,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23684,7 +23685,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23699,37 +23700,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23755,7 +23756,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23770,37 +23771,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23826,7 +23827,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23841,37 +23842,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23891,7 +23892,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23906,37 +23907,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -23962,7 +23963,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -23977,37 +23978,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24032,7 +24033,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24047,37 +24048,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24119,7 +24120,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24134,37 +24135,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24189,7 +24190,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24204,37 +24205,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24257,7 +24258,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24272,37 +24273,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24327,7 +24328,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24342,37 +24343,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24397,7 +24398,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24412,37 +24413,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24467,7 +24468,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24482,37 +24483,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24537,7 +24538,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24552,37 +24553,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24607,7 +24608,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24622,37 +24623,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24677,7 +24678,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24692,37 +24693,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24748,7 +24749,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24763,37 +24764,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24812,7 +24813,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24827,37 +24828,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24883,7 +24884,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24898,37 +24899,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -24961,7 +24962,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -24976,37 +24977,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25033,7 +25034,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25048,37 +25049,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25110,7 +25111,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25125,37 +25126,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25184,7 +25185,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25199,37 +25200,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25256,7 +25257,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25271,37 +25272,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25336,7 +25337,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25351,37 +25352,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25419,7 +25420,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25434,37 +25435,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25496,7 +25497,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25511,37 +25512,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25584,7 +25585,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25599,37 +25600,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25662,7 +25663,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25677,37 +25678,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25741,7 +25742,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25756,37 +25757,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25813,7 +25814,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25828,37 +25829,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25892,7 +25893,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25907,37 +25908,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -25970,7 +25971,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -25985,37 +25986,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26049,7 +26050,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26064,37 +26065,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26128,7 +26129,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26143,37 +26144,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26206,7 +26207,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26221,37 +26222,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26284,7 +26285,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26299,37 +26300,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26362,7 +26363,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26377,37 +26378,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26433,7 +26434,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26448,37 +26449,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26507,7 +26508,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26522,37 +26523,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26583,7 +26584,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26598,37 +26599,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26660,7 +26661,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26675,37 +26676,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26724,7 +26725,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26739,37 +26740,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26792,7 +26793,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26807,37 +26808,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26862,7 +26863,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26877,37 +26878,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -26932,7 +26933,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -26947,37 +26948,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27007,7 +27008,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27022,37 +27023,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27076,7 +27077,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27091,37 +27092,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27144,7 +27145,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27159,37 +27160,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27214,7 +27215,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27229,37 +27230,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27277,7 +27278,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27292,37 +27293,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27345,7 +27346,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27360,37 +27361,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27408,7 +27409,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27423,37 +27424,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27471,7 +27472,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27486,37 +27487,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27534,7 +27535,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27549,37 +27550,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27604,7 +27605,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27619,37 +27620,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27674,7 +27675,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27689,37 +27690,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27743,7 +27744,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27758,37 +27759,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27813,7 +27814,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27828,37 +27829,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27882,7 +27883,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27897,37 +27898,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -27957,7 +27958,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -27972,37 +27973,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28026,7 +28027,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28041,37 +28042,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28096,7 +28097,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28111,37 +28112,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28166,7 +28167,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28181,37 +28182,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28241,7 +28242,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28256,37 +28257,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28317,7 +28318,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28332,37 +28333,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28392,7 +28393,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28407,37 +28408,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28461,7 +28462,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28476,37 +28477,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28536,7 +28537,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28551,37 +28552,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28633,7 +28634,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28648,37 +28649,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28708,7 +28709,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28723,37 +28724,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28778,7 +28779,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28793,37 +28794,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28846,7 +28847,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28861,37 +28862,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28916,7 +28917,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -28931,37 +28932,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -28986,7 +28987,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29001,37 +29002,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29062,7 +29063,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29077,37 +29078,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29138,7 +29139,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29153,37 +29154,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29201,7 +29202,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29216,37 +29217,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29270,7 +29271,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29285,37 +29286,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29341,7 +29342,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29356,37 +29357,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29418,7 +29419,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29433,37 +29434,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29490,7 +29491,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29505,37 +29506,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29561,7 +29562,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29576,37 +29577,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29637,7 +29638,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29652,37 +29653,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29706,7 +29707,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29721,37 +29722,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29773,7 +29774,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29788,37 +29789,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29843,7 +29844,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29858,37 +29859,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29919,7 +29920,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29934,37 +29935,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -29983,7 +29984,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -29998,37 +29999,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30051,7 +30052,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30066,37 +30067,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30121,7 +30122,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30136,37 +30137,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30195,7 +30196,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30210,37 +30211,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30265,7 +30266,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30280,37 +30281,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30335,7 +30336,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30350,37 +30351,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30411,7 +30412,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30426,37 +30427,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30480,7 +30481,7 @@ paths:
           description: Created
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30495,37 +30496,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30546,7 +30547,7 @@ paths:
           description: No Content
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30561,37 +30562,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30615,7 +30616,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30630,37 +30631,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30690,7 +30691,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30705,37 +30706,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30759,7 +30760,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30774,37 +30775,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30829,7 +30830,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30844,37 +30845,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30900,7 +30901,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30915,37 +30916,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -30976,7 +30977,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -30991,37 +30992,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31053,7 +31054,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31068,37 +31069,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31130,7 +31131,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31145,37 +31146,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31207,7 +31208,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31222,37 +31223,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31284,7 +31285,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31299,37 +31300,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31361,7 +31362,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31376,37 +31377,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31438,7 +31439,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31453,37 +31454,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31515,7 +31516,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31530,37 +31531,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31592,7 +31593,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31607,37 +31608,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31663,7 +31664,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31678,37 +31679,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31734,7 +31735,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31749,37 +31750,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31811,7 +31812,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31826,37 +31827,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31888,7 +31889,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31903,37 +31904,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -31965,7 +31966,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -31980,37 +31981,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32120,7 +32121,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32135,37 +32136,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32189,7 +32190,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32204,37 +32205,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32254,7 +32255,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32269,37 +32270,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32325,7 +32326,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32340,37 +32341,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32395,7 +32396,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32410,37 +32411,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32471,7 +32472,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32486,37 +32487,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32541,7 +32542,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32556,37 +32557,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32616,7 +32617,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32631,37 +32632,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32686,7 +32687,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32701,37 +32702,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32761,7 +32762,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32776,37 +32777,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32837,7 +32838,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32852,37 +32853,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32912,7 +32913,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -32927,37 +32928,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -32987,7 +32988,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33002,37 +33003,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33057,7 +33058,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33072,37 +33073,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33127,7 +33128,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33142,37 +33143,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33199,7 +33200,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33214,37 +33215,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33276,7 +33277,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33291,37 +33292,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33360,7 +33361,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33375,37 +33376,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33430,7 +33431,7 @@ paths:
           description: Registration initiated; user should check email for setup link
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33445,37 +33446,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33500,7 +33501,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33515,37 +33516,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33569,7 +33570,7 @@ paths:
           description: Order created successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33584,37 +33585,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33639,7 +33640,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33654,37 +33655,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33703,7 +33704,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33718,37 +33719,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33767,7 +33768,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33782,37 +33783,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33838,7 +33839,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33853,37 +33854,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33919,7 +33920,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -33934,37 +33935,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -33990,7 +33991,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34005,37 +34006,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34060,7 +34061,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34075,37 +34076,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34139,7 +34140,7 @@ paths:
           description: Order updated successfully
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34154,37 +34155,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Optimistic locking conflict or order not in DRAFT status
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34210,7 +34211,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34225,37 +34226,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34281,7 +34282,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34296,37 +34297,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34358,7 +34359,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34373,37 +34374,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34430,7 +34431,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34445,37 +34446,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34501,7 +34502,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34516,37 +34517,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34573,7 +34574,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34588,37 +34589,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34645,7 +34646,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34660,37 +34661,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34716,7 +34717,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34731,37 +34732,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34786,7 +34787,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34801,37 +34802,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34854,7 +34855,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34869,37 +34870,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34924,7 +34925,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -34939,37 +34940,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -34994,7 +34995,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35009,37 +35010,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35063,7 +35064,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35078,37 +35079,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35132,7 +35133,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35147,37 +35148,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35202,7 +35203,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35217,37 +35218,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35273,7 +35274,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35288,37 +35289,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35350,7 +35351,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35365,37 +35366,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35421,7 +35422,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35436,37 +35437,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35492,7 +35493,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35507,37 +35508,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35569,7 +35570,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35584,37 +35585,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35639,7 +35640,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35654,37 +35655,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35716,7 +35717,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35731,37 +35732,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35786,7 +35787,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35801,37 +35802,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35857,7 +35858,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35872,37 +35873,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -35934,7 +35935,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -35949,37 +35950,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36004,7 +36005,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36019,37 +36020,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36073,7 +36074,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36088,37 +36089,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36137,7 +36138,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36152,37 +36153,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36201,7 +36202,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36216,37 +36217,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36265,7 +36266,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36280,37 +36281,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36335,7 +36336,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36350,37 +36351,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36399,7 +36400,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36414,37 +36415,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36470,7 +36471,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36485,37 +36486,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36541,7 +36542,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36556,37 +36557,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36605,7 +36606,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36620,37 +36621,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36686,7 +36687,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36701,37 +36702,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36756,7 +36757,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36771,37 +36772,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36827,7 +36828,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36842,37 +36843,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36897,7 +36898,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36912,37 +36913,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -36968,7 +36969,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -36983,37 +36984,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37049,7 +37050,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37064,37 +37065,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37125,7 +37126,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37140,37 +37141,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37196,7 +37197,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37211,37 +37212,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37267,7 +37268,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37282,37 +37283,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37348,7 +37349,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37363,37 +37364,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37419,7 +37420,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37434,37 +37435,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37490,7 +37491,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37505,37 +37506,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37571,7 +37572,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37586,37 +37587,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37641,7 +37642,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37656,37 +37657,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37715,7 +37716,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37730,37 +37731,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37796,7 +37797,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37811,37 +37812,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37862,7 +37863,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37877,37 +37878,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -37937,7 +37938,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -37952,37 +37953,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38020,7 +38021,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38035,37 +38036,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38088,7 +38089,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38103,37 +38104,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38151,7 +38152,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38166,37 +38167,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38219,7 +38220,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38234,37 +38235,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38294,7 +38295,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38309,37 +38310,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38363,7 +38364,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38378,37 +38379,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38438,7 +38439,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38453,37 +38454,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38513,7 +38514,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38528,37 +38529,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38588,7 +38589,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38603,37 +38604,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38663,7 +38664,7 @@ paths:
           description: OK
         "400":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Bad Request
@@ -38678,37 +38679,37 @@ paths:
           description: Unauthorized
         "403":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Forbidden
         "404":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Not Found
         "409":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Conflict
         "422":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Unprocessable Entity
         "429":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Too Many Requests
         "500":
           content:
-            '*/*':
+            application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
@@ -38831,17 +38832,16 @@ components:
       properties:
         offeredPrice:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0001
         productId:
           type: string
           format: uuid
         requestedQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         unit:
           type: string
+          minLength: 1
       required:
       - offeredPrice
       - productId
@@ -38864,6 +38864,7 @@ components:
       properties:
         moduleSpecs:
           $ref: "#/components/schemas/SupplierRFQSpecs"
+          description: Module-specific requirements
         productDesc:
           type: string
           description: Product description
@@ -38874,11 +38875,11 @@ components:
         requestedQty:
           type: number
           description: Requested quantity
-          exclusiveMinimum: false
           minimum: 0.001
         unit:
           type: string
           description: Unit of measure
+          minLength: 1
       required:
       - requestedQty
       - unit
@@ -38925,6 +38926,7 @@ components:
           minimum: 0
         title:
           type: string
+          minLength: 1
         type:
           type: string
           enum:
@@ -39088,6 +39090,7 @@ components:
           type: number
         reason:
           type: string
+          minLength: 1
         remarks:
           type: string
         version:
@@ -39107,7 +39110,6 @@ components:
           type: string
           format: uuid
     ApiProblemDetail:
-      type: object
       properties:
         args:
           type: array
@@ -40297,8 +40299,7 @@ components:
       properties:
         data:
           type: array
-          items:
-            type: object
+          items: {}
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -41179,8 +41180,7 @@ components:
       properties:
         data:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: {}
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -42511,8 +42511,7 @@ components:
     ApiResponseVoid:
       type: object
       properties:
-        data:
-          type: object
+        data: {}
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -42774,9 +42773,11 @@ components:
       properties:
         countryCode:
           type: string
+          minLength: 1
           pattern: "^[A-Z]{2,8}$"
         packCode:
           type: string
+          minLength: 1
           pattern: "^[A-Z0-9_-]{2,100}$"
       required:
       - countryCode
@@ -42879,8 +42880,7 @@ components:
       properties:
         actionConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         actionType:
           type: string
           enum:
@@ -42899,16 +42899,15 @@ components:
           format: uuid
         conditionConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         description:
           type: string
         name:
           type: string
+          minLength: 1
         triggerConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         triggerType:
           type: string
           enum:
@@ -42932,8 +42931,7 @@ components:
       properties:
         actionConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         actionType:
           type: string
           enum:
@@ -42952,8 +42950,7 @@ components:
           format: uuid
         conditionConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         createdAt:
           type: string
           format: date-time
@@ -42974,8 +42971,7 @@ components:
           type: string
         triggerConfig:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         triggerType:
           type: string
           enum:
@@ -43125,10 +43121,7 @@ components:
       properties:
         attributes:
           type: object
-          additionalProperties:
-            type: object
-            description: Raw JSONB attributes map. Prefer using fiberSpecs/yarnSpecs
-              when available.
+          additionalProperties: true
           description: Raw JSONB attributes map. Prefer using fiberSpecs/yarnSpecs
             when available.
         availableQuantity:
@@ -43143,8 +43136,6 @@ components:
           type: object
           additionalProperties:
             type: number
-            description: Resolved composition. Map of Base Fiber ID to percentage.
-              Empty for pure fibers.
           description: Resolved composition. Map of Base Fiber ID to percentage. Empty
             for pure fibers.
         consumedQuantity:
@@ -43160,6 +43151,8 @@ components:
           description: Expiration date if applicable
         fiberSpecs:
           $ref: "#/components/schemas/FiberAttributes"
+          description: Detailed specifications for FIBER batches. Null for other product
+            types.
         id:
           type: string
           format: uuid
@@ -43254,6 +43247,8 @@ components:
           description: Quantity declared as waste
         yarnSpecs:
           $ref: "#/components/schemas/YarnAttributes"
+          description: Detailed specifications for YARN batches. Null for other product
+            types.
     BatchLineageDetailDto:
       type: object
       properties:
@@ -43365,8 +43360,6 @@ components:
           type: number
         consumptionPercentage:
           type: number
-          exclusiveMaximum: false
-          exclusiveMinimum: false
           maximum: 100
           minimum: 0.01
         parentBatchId:
@@ -43469,6 +43462,7 @@ components:
           format: uuid
         reason:
           type: string
+          minLength: 1
       required:
       - newGradeId
       - reason
@@ -43498,8 +43492,7 @@ components:
       properties:
         context:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         conversationId:
           type: string
           format: uuid
@@ -43565,6 +43558,7 @@ components:
           minLength: 0
         companyEmail:
           type: string
+          format: email
           maxLength: 254
           minLength: 0
         companyPhone:
@@ -43649,6 +43643,7 @@ components:
           format: uuid
         moduleType:
           type: string
+          minLength: 1
         productId:
           type: string
           format: uuid
@@ -43665,6 +43660,7 @@ components:
       properties:
         moduleType:
           type: string
+          minLength: 1
         productId:
           type: string
           format: uuid
@@ -43686,6 +43682,7 @@ components:
       properties:
         moduleType:
           type: string
+          minLength: 1
         plannedQuantityKg:
           type: number
         productId:
@@ -43936,20 +43933,24 @@ components:
           - REMOTE
         city:
           type: string
+          minLength: 1
         country:
           type: string
+          minLength: 1
         countryCode:
           type: string
         district:
           type: string
         label:
           type: string
+          minLength: 1
         postalCode:
           type: string
         state:
           type: string
         streetAddress:
           type: string
+          minLength: 1
       required:
       - addressType
       - city
@@ -43967,11 +43968,9 @@ components:
           format: date-time
         consumedQuantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         consumptionPercentage:
           type: number
-          exclusiveMinimum: false
           minimum: 0.01
         parentBatchId:
           type: string
@@ -43982,6 +43981,7 @@ components:
           type: string
         unit:
           type: string
+          minLength: 1
         version:
           type: integer
           format: int64
@@ -43998,12 +43998,11 @@ components:
           type: string
           description: Internal unique batch code/lot number
           example: B-2026-001
+          minLength: 1
         composition:
           type: object
           additionalProperties:
             type: number
-            description: Batch-level composition override (FIBER only). Map of Base
-              Fiber ID to percentage. Overrides Product default.
           description: Batch-level composition override (FIBER only). Map of Base
             Fiber ID to percentage. Overrides Product default.
         expiryDate:
@@ -44012,6 +44011,8 @@ components:
           description: Expiration date if applicable
         fiberSpecs:
           $ref: "#/components/schemas/FiberAttributes"
+          description: Detailed specifications. REQUIRED if productType is FIBER.
+            Ignored otherwise.
         locationId:
           type: string
           format: uuid
@@ -44042,7 +44043,6 @@ components:
           type: number
           description: Initial quantity of the batch
           example: 1500.5
-          exclusiveMinimum: false
           minimum: 0.01
         remarks:
           type: string
@@ -44070,12 +44070,15 @@ components:
           type: string
           description: "Unit of measure (e.g., KG, MTR)"
           example: KG
+          minLength: 1
         version:
           type: integer
           format: int64
           description: Optimistic locking version
         yarnSpecs:
           $ref: "#/components/schemas/YarnAttributes"
+          description: Detailed specifications. REQUIRED if productType is YARN. Ignored
+            otherwise.
       required:
       - batchCode
       - productId
@@ -44087,6 +44090,7 @@ components:
       properties:
         batchCode:
           type: string
+          minLength: 1
         locationId:
           type: string
           format: uuid
@@ -44109,7 +44113,6 @@ components:
           - CONSUMABLE
         quantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         remarks:
           type: string
@@ -44127,6 +44130,7 @@ components:
           - INITIAL_STOCK
         unit:
           type: string
+          minLength: 1
       required:
       - batchCode
       - locationId
@@ -44182,6 +44186,7 @@ components:
           - SOCIAL_MEDIA
         contactValue:
           type: string
+          minLength: 1
         isPersonal:
           type: boolean
         label:
@@ -44213,7 +44218,6 @@ components:
           minLength: 0
         department:
           type: string
-          deprecated: true
         firstName:
           type: string
           maxLength: 100
@@ -44320,6 +44324,7 @@ components:
           format: uuid
         fiberName:
           type: string
+          minLength: 1
         productId:
           type: string
           format: uuid
@@ -44409,6 +44414,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/GoodsReceiptItemRequest"
+          minItems: 1
         netWeight:
           type: number
         packageCount:
@@ -44447,6 +44453,7 @@ components:
             $ref: "#/components/schemas/PolicyBindingRequest"
         countryCode:
           type: string
+          minLength: 1
           pattern: "^[A-Z]{2,8}$"
         description:
           type: string
@@ -44457,13 +44464,16 @@ components:
           - PARTIAL
         name:
           type: string
+          minLength: 1
         packCode:
           type: string
+          minLength: 1
           pattern: "^[A-Z0-9_-]{2,100}$"
         parentPackCode:
           type: string
         payload:
           type: string
+          minLength: 1
         regionCode:
           type: string
         ruleVersions:
@@ -44564,6 +44574,7 @@ components:
       properties:
         description:
           type: string
+          minLength: 1
         discountRate:
           type: number
         notes:
@@ -44572,7 +44583,6 @@ components:
           type: string
         quantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0001
         taxRate:
           type: number
@@ -44580,7 +44590,6 @@ components:
           type: string
         unitPrice:
           type: number
-          exclusiveMinimum: false
           minimum: 0
       required:
       - description
@@ -44595,7 +44604,6 @@ components:
           type: string
         discountAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         dueDate:
           type: string
@@ -44620,17 +44628,14 @@ components:
           format: uuid
         subtotal:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         taxAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         taxRate:
           type: number
         totalAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         tradingPartnerId:
           type: string
@@ -44675,6 +44680,7 @@ components:
       properties:
         action:
           type: string
+          minLength: 1
         dataScope:
           type: string
           enum:
@@ -44689,6 +44695,7 @@ components:
           type: string
         resource:
           type: string
+          minLength: 1
         userId:
           type: string
           format: uuid
@@ -44701,6 +44708,7 @@ components:
       properties:
         action:
           type: string
+          minLength: 1
         dataScope:
           type: string
           enum:
@@ -44712,8 +44720,10 @@ components:
           type: string
         resource:
           type: string
+          minLength: 1
         roleCode:
           type: string
+          minLength: 1
       required:
       - action
       - dataScope
@@ -44724,10 +44734,10 @@ components:
       properties:
         action:
           type: string
+          minLength: 1
         conditions:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         description:
           type: string
         effect:
@@ -44737,11 +44747,13 @@ components:
           - DENY
         policyId:
           type: string
+          minLength: 1
         priority:
           type: integer
           format: int32
         resource:
           type: string
+          minLength: 1
       required:
       - action
       - effect
@@ -44753,10 +44765,13 @@ components:
       properties:
         currency:
           type: string
+          minLength: 1
         moduleType:
           type: string
+          minLength: 1
         name:
           type: string
+          minLength: 1
         seasonTag:
           type: string
         validFrom:
@@ -44783,6 +44798,7 @@ components:
           - CONSUMABLE
         unit:
           type: string
+          minLength: 1
         version:
           type: integer
           format: int64
@@ -44842,6 +44858,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/PurchaseOrderLineRequest"
+          minItems: 1
         moduleSpecs:
           $ref: "#/components/schemas/PurchaseOrderSpecs"
         moduleType:
@@ -44888,8 +44905,6 @@ components:
           minLength: 0
         priceFactor:
           type: number
-          exclusiveMaximum: false
-          exclusiveMinimum: false
           maximum: 9.999
           minimum: 0.000
         productType:
@@ -44924,6 +44939,7 @@ components:
           format: uuid
         lotNumber:
           type: string
+          minLength: 1
         productId:
           type: string
           format: uuid
@@ -44963,6 +44979,7 @@ components:
           type: string
         currency:
           type: string
+          minLength: 1
           pattern: "[A-Z]{3}"
         customerReference:
           type: string
@@ -44977,8 +44994,7 @@ components:
             $ref: "#/components/schemas/SalesOrderLineRequest"
         metadata:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
           deprecated: true
@@ -45037,18 +45053,18 @@ components:
       properties:
         currency:
           type: string
+          minLength: 1
         leadTimeDays:
           type: integer
           format: int32
         listPrice:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0
         moduleType:
           type: string
+          minLength: 1
         moq:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0
         moqUnit:
           type: string
@@ -45085,13 +45101,13 @@ components:
           format: uuid
         requestedQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0
         salesOrderId:
           type: string
           format: uuid
         unit:
           type: string
+          minLength: 1
       required:
       - customerId
       - deliveryMethod
@@ -45109,13 +45125,13 @@ components:
           type: string
         destinationAddress:
           type: string
+          minLength: 1
         estimatedDeliveryDate:
           type: string
           format: date
         metadata:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         notes:
           type: string
         orderReference:
@@ -45204,6 +45220,7 @@ components:
           - RETURN
         unit:
           type: string
+          minLength: 1
       required:
       - barcode
       - batchId
@@ -45222,7 +45239,6 @@ components:
           type: string
         expectedOutputQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         expectedReturnDate:
           type: string
@@ -45237,7 +45253,6 @@ components:
           format: uuid
         productSentQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         tradingPartnerId:
           type: string
@@ -45257,6 +45272,7 @@ components:
           type: string
           description: Currency code
           example: TRY
+          minLength: 1
         entryMethod:
           type: string
           description: Entry method
@@ -45421,6 +45437,7 @@ components:
           type: number
         eventType:
           type: string
+          minLength: 1
         labels:
           type: array
           items:
@@ -45435,6 +45452,7 @@ components:
           - GENERAL
         name:
           type: string
+          minLength: 1
         taskType:
           type: string
           enum:
@@ -45454,6 +45472,7 @@ components:
           - GENERAL
         titleTemplate:
           type: string
+          minLength: 1
       required:
       - defaultAssigneeRole
       - defaultPriority
@@ -45489,8 +45508,7 @@ components:
           - PARENT_COMPANY
         relationshipMeta:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         taxId:
           type: string
           maxLength: 50
@@ -45563,6 +45581,7 @@ components:
           type: string
         token:
           type: string
+          minLength: 1
         userAgent:
           type: string
       required:
@@ -45679,7 +45698,6 @@ components:
       required:
       - deliveryMethod
     DyePurchaseSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/PurchaseOrderSpecs"
       - type: object
@@ -45703,8 +45721,6 @@ components:
             - Yıkama 4-5
             items:
               type: string
-              description: Fastness requirements
-              example: "[\"Yıkama 4-5\"]"
           finishType:
             type: string
             description: Finish type
@@ -45718,7 +45734,6 @@ components:
             example: "45.0"
       description: Dye/finishing-specific purchase order specifications
     DyeRFQSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
       - type: object
@@ -45740,7 +45755,6 @@ components:
             description: Required Dyeing process type
       description: Dyeing and finishing specific RFQ specifications
     DyeingProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -45765,8 +45779,6 @@ components:
             - Rub 4
             items:
               type: string
-              description: "Fastness targets (e.g., Wash 4-5, Rub 4)"
-              example: "[\"Wash 4-5\",\"Rub 4\"]"
           labDipRef:
             type: string
             description: Lab dip reference
@@ -45917,8 +45929,7 @@ components:
           type: string
         message:
           type: string
-        rejectedValue:
-          type: object
+        rejectedValue: {}
     ExchangeRateResponse:
       type: object
       properties:
@@ -45938,6 +45949,7 @@ components:
       properties:
         baseCurrency:
           type: string
+          minLength: 1
           pattern: "^[A-Z]{3}$"
         rate:
           type: number
@@ -45946,13 +45958,13 @@ components:
           format: date
         targetCurrency:
           type: string
+          minLength: 1
           pattern: "^[A-Z]{3}$"
       required:
       - baseCurrency
       - rate
       - targetCurrency
     FabricPurchaseSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/PurchaseOrderSpecs"
       - type: object
@@ -46001,7 +46013,6 @@ components:
             example: 150
       description: Fabric-specific purchase order specifications
     FabricRFQSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
       - type: object
@@ -46193,7 +46204,6 @@ components:
         isoCode:
           type: string
     FiberPurchaseSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/PurchaseOrderSpecs"
       - type: object
@@ -46206,8 +46216,6 @@ components:
             - GOTS
             items:
               type: string
-              description: Certifications
-              example: "[\"BCI\",\"GOTS\"]"
           colorGrade:
             type: string
             description: Color grade (Rd/+b)
@@ -46349,7 +46357,6 @@ components:
           items:
             $ref: "#/components/schemas/FiberQualityStandardDto"
     FiberRFQSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
       - type: object
@@ -46476,7 +46483,6 @@ components:
           type: integer
           format: int64
     FinishingProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -46489,8 +46495,6 @@ components:
             - Water repellent
             items:
               type: string
-              description: Chemical applications applied
-              example: "[\"Anti-pilling\",\"Water repellent\"]"
           compactingPressure:
             type: number
             format: double
@@ -46548,7 +46552,6 @@ components:
       required:
       - channel
     GenericProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -46557,7 +46560,6 @@ components:
             type: string
             description: General production notes or process instructions
     GenericPurchaseSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/PurchaseOrderSpecs"
       - type: object
@@ -46567,7 +46569,6 @@ components:
             description: Free-text description for untyped POs
       description: Generic purchase order specifications for unclassified items
     GenericRFQSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
       - type: object
@@ -46837,12 +46838,17 @@ components:
       properties:
         email:
           type: string
+          format: email
+          minLength: 1
         firstName:
           type: string
+          minLength: 1
         lastName:
           type: string
+          minLength: 1
         partnerRoleCode:
           type: string
+          minLength: 1
       required:
       - email
       - firstName
@@ -46947,10 +46953,8 @@ components:
           type: string
         unitPrice:
           type: number
-    JsonNode:
-      type: object
+    JsonNode: {}
     KnittingProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -47023,8 +47027,7 @@ components:
       properties:
         attributes:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         availableQuantity:
           type: number
         batchCode:
@@ -47078,8 +47081,10 @@ components:
       properties:
         contactValue:
           type: string
+          minLength: 1
         password:
           type: string
+          minLength: 1
         trustedDeviceToken:
           type: string
       required:
@@ -47140,6 +47145,7 @@ components:
           type: string
         recipientName:
           type: string
+          minLength: 1
       required:
       - recipientName
     MaskedContactInfo:
@@ -47194,6 +47200,7 @@ components:
           type: string
           description: 6-digit verification code
           example: "123456"
+          minLength: 1
           pattern: "^\\d{6}$"
       required:
       - code
@@ -48057,10 +48064,10 @@ components:
       properties:
         acceptedQuantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.01
         reason:
           type: string
+          minLength: 1
         rejectedStatus:
           type: string
           enum:
@@ -48115,6 +48122,7 @@ components:
           format: uuid
         contactType:
           type: string
+          minLength: 1
           pattern: EMAIL|PHONE
       required:
       - authUserId
@@ -48127,6 +48135,7 @@ components:
           format: uuid
         code:
           type: string
+          minLength: 1
           pattern: "^\\d{6}$"
         newPassword:
           type: string
@@ -48145,6 +48154,7 @@ components:
           minLength: 8
         token:
           type: string
+          minLength: 1
       required:
       - password
       - token
@@ -48343,8 +48353,10 @@ components:
           type: string
         policyInterface:
           type: string
+          minLength: 1
         strategyBean:
           type: string
+          minLength: 1
       required:
       - policyInterface
       - strategyBean
@@ -48355,8 +48367,7 @@ components:
           type: string
         conditions:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         createdAt:
           type: string
           format: date-time
@@ -48515,6 +48526,7 @@ components:
           description: Active WO count (excludes COMPLETED and CANCELLED)
         costSummary:
           $ref: "#/components/schemas/CostSummary"
+          description: Planned vs actual cost comparison
         overdueCount:
           type: integer
           format: int64
@@ -48524,11 +48536,10 @@ components:
           additionalProperties:
             type: integer
             format: int64
-            description: "WorkOrder count per status (all statuses included, 0 if\
-              \ none)"
           description: "WorkOrder count per status (all statuses included, 0 if none)"
         yieldSummary:
           $ref: "#/components/schemas/YieldSummary"
+          description: Yield performance for completed WOs. Null if no completions.
     ProductionLotResponse:
       type: object
       properties:
@@ -48795,7 +48806,6 @@ components:
           format: uuid
         qty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         rfqLineId:
           type: string
@@ -48804,7 +48814,6 @@ components:
           type: string
         unitPrice:
           type: number
-          exclusiveMinimum: false
           minimum: 0.0001
       required:
       - currency
@@ -48894,7 +48903,6 @@ components:
           type: string
           format: uuid
     PurchaseOrderSpecs:
-      type: object
       description: "Module-specific purchase order specs, discriminated by specType"
       discriminator:
         propertyName: specType
@@ -49002,6 +49010,7 @@ components:
           format: int32
         moduleType:
           type: string
+          minLength: 1
         notes:
           type: string
         offlineCreatedAt:
@@ -49014,6 +49023,7 @@ components:
           type: string
         quoteNumber:
           type: string
+          minLength: 1
         validUntil:
           type: string
           format: date
@@ -49131,8 +49141,6 @@ components:
           type: string
         percentage:
           type: number
-          exclusiveMaximum: false
-          exclusiveMinimum: false
           maximum: 100.00
           minimum: 0.01
       required:
@@ -49163,6 +49171,7 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RecipeComponentDto"
+          minItems: 1
       required:
       - components
     RecipeResponse:
@@ -49219,7 +49228,6 @@ components:
       properties:
         amount:
           type: number
-          exclusiveMinimum: false
           minimum: 0.01
       required:
       - amount
@@ -49238,7 +49246,6 @@ components:
       properties:
         quantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         reason:
           type: string
@@ -49329,6 +49336,7 @@ components:
       properties:
         contactValue:
           type: string
+          minLength: 1
       required:
       - contactValue
     RejectFiberRequestRequest:
@@ -49345,6 +49353,7 @@ components:
       properties:
         reason:
           type: string
+          minLength: 1
       required:
       - reason
     ReserveRequest:
@@ -49352,13 +49361,13 @@ components:
       properties:
         quantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         referenceId:
           type: string
           format: uuid
         referenceType:
           type: string
+          minLength: 1
         remarks:
           type: string
         version:
@@ -49382,6 +49391,7 @@ components:
           type: number
         reason:
           type: string
+          minLength: 1
       required:
       - amount
       - reason
@@ -49390,6 +49400,7 @@ components:
       properties:
         reviewComment:
           type: string
+          minLength: 1
       required:
       - reviewComment
     RfqLineResponse:
@@ -49402,6 +49413,7 @@ components:
           description: Line ID
         moduleSpecs:
           $ref: "#/components/schemas/SupplierRFQSpecs"
+          description: Module Specifications
         productDesc:
           type: string
           description: Product Description
@@ -49454,8 +49466,10 @@ components:
       properties:
         payload:
           type: string
+          minLength: 1
         ruleType:
           type: string
+          minLength: 1
       required:
       - payload
       - ruleType
@@ -49518,10 +49532,10 @@ components:
             $ref: "#/components/schemas/SalesOrderLineResponse"
         metadata:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
+          deprecated: true
           enum:
           - FIBER
           - YARN
@@ -49608,10 +49622,10 @@ components:
           type: string
         moduleSpecs:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
+          deprecated: true
           enum:
           - FIBER
           - YARN
@@ -49626,7 +49640,6 @@ components:
           type: boolean
         requestedQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         unit:
           type: string
@@ -49655,10 +49668,10 @@ components:
           - CANCELLED
         moduleSpecs:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
+          deprecated: true
           enum:
           - FIBER
           - YARN
@@ -49800,12 +49813,17 @@ components:
           type: boolean
         email:
           type: string
+          format: email
+          minLength: 1
         firstName:
           type: string
+          minLength: 1
         lastName:
           type: string
+          minLength: 1
         organizationName:
           type: string
+          minLength: 1
         organizationType:
           type: string
           enum:
@@ -49822,6 +49840,7 @@ components:
             type: string
         taxId:
           type: string
+          minLength: 1
       required:
       - email
       - firstName
@@ -49867,8 +49886,7 @@ components:
             $ref: "#/components/schemas/ShipmentLineDto"
         metadata:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         notes:
           type: string
         orderReference:
@@ -49985,7 +50003,6 @@ components:
           - PIECE
           - ROLL
     SpinningProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -50039,10 +50056,10 @@ components:
       properties:
         acceptedQuantity:
           type: number
-          exclusiveMinimum: false
           minimum: 0.01
         reason:
           type: string
+          minLength: 1
         rejectedStatus:
           type: string
           enum:
@@ -50070,7 +50087,9 @@ components:
       type: object
       properties:
         timeout:
-          type: integer
+          type:
+          - integer
+          - "null"
           format: int64
     StartProductionRequest:
       type: object
@@ -50526,7 +50545,6 @@ components:
           type: string
           format: uuid
     SupplierRFQSpecs:
-      type: object
       description: "Module-specific RFQ specs, discriminated by specType"
       discriminator:
         propertyName: specType
@@ -50562,8 +50580,7 @@ components:
           type: object
           additionalProperties:
             type: array
-            items:
-              type: object
+            items: {}
     SyncPushRequest:
       type: object
       properties:
@@ -50582,8 +50599,7 @@ components:
           format: uuid
         payload:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
       required:
       - deviceId
       - entityType
@@ -50868,10 +50884,14 @@ components:
           type: string
         adminContact:
           type: string
+          format: email
+          minLength: 1
         adminFirstName:
           type: string
+          minLength: 1
         adminLastName:
           type: string
+          minLength: 1
         city:
           type: string
         country:
@@ -50880,8 +50900,10 @@ components:
           type: string
         organizationEmail:
           type: string
+          format: email
         organizationName:
           type: string
+          minLength: 1
         organizationType:
           type: string
           enum:
@@ -50904,6 +50926,7 @@ components:
           type: string
         taxId:
           type: string
+          minLength: 1
         trialDays:
           type: integer
           format: int32
@@ -51046,8 +51069,7 @@ components:
       properties:
         attributes:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         batchCode:
           type: string
         batchId:
@@ -51177,8 +51199,7 @@ components:
           format: uuid
         relationshipMeta:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         status:
           type: string
           enum:
@@ -51376,6 +51397,7 @@ components:
             type: number
         fiberName:
           type: string
+          minLength: 1
         remarks:
           type: string
         version:
@@ -51400,10 +51422,12 @@ components:
           - PARTIAL
         name:
           type: string
+          minLength: 1
         parentPackCode:
           type: string
         payload:
           type: string
+          minLength: 1
         regionCode:
           type: string
         ruleVersions:
@@ -51420,7 +51444,6 @@ components:
           type: string
         discountAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         dueDate:
           type: string
@@ -51436,17 +51459,14 @@ components:
           type: string
         subtotal:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         taxAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
         taxRate:
           type: number
         totalAmount:
           type: number
-          exclusiveMinimum: false
           minimum: 0
     UpdateLocalePreferenceRequest:
       type: object
@@ -51455,6 +51475,7 @@ components:
           type: string
         locale:
           type: string
+          minLength: 1
           pattern: ^(TR|EN|DE|FR|AR)$
         timezone:
           type: string
@@ -51477,6 +51498,7 @@ components:
           type: boolean
         eventType:
           type: string
+          minLength: 1
         inApp:
           type: boolean
         push:
@@ -51509,6 +51531,7 @@ components:
       properties:
         partnerRoleCode:
           type: string
+          minLength: 1
       required:
       - partnerRoleCode
     UpdatePermissionTemplateRequest:
@@ -51533,8 +51556,7 @@ components:
           type: string
         conditions:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         description:
           type: string
         effect:
@@ -51563,8 +51585,6 @@ components:
           minLength: 0
         priceFactor:
           type: number
-          exclusiveMaximum: false
-          exclusiveMinimum: false
           maximum: 9.999
           minimum: 0.000
         rank:
@@ -51588,10 +51608,10 @@ components:
           format: uuid
         moduleSpecs:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
+          deprecated: true
           enum:
           - FIBER
           - YARN
@@ -51606,7 +51626,6 @@ components:
           type: boolean
         requestedQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         unit:
           type: string
@@ -51622,6 +51641,7 @@ components:
           type: string
         currency:
           type: string
+          minLength: 1
           pattern: "[A-Z]{3}"
         customerReference:
           type: string
@@ -51636,8 +51656,7 @@ components:
             $ref: "#/components/schemas/UpdateSalesOrderLineRequest"
         metadata:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
         moduleType:
           type: string
           deprecated: true
@@ -51680,7 +51699,6 @@ components:
           type: string
         expectedOutputQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.001
         expectedReturnDate:
           type: string
@@ -51745,6 +51763,7 @@ components:
           type: number
         eventType:
           type: string
+          minLength: 1
         labels:
           type: array
           items:
@@ -51759,6 +51778,7 @@ components:
           - GENERAL
         name:
           type: string
+          minLength: 1
         taskType:
           type: string
           enum:
@@ -51778,6 +51798,7 @@ components:
           - GENERAL
         titleTemplate:
           type: string
+          minLength: 1
       required:
       - defaultAssigneeRole
       - defaultPriority
@@ -51874,8 +51895,7 @@ components:
           - PARENT_COMPANY
         relationshipMeta:
           type: object
-          additionalProperties:
-            type: object
+          additionalProperties: true
     UpdateUserProfileRequest:
       type: object
       properties:
@@ -51948,8 +51968,10 @@ components:
           type: string
         firstName:
           type: string
+          minLength: 1
         lastName:
           type: string
+          minLength: 1
       required:
       - firstName
       - lastName
@@ -52310,6 +52332,7 @@ components:
       properties:
         payload:
           type: string
+          minLength: 1
       required:
       - payload
     ValidateHrPolicyPackResponse:
@@ -52356,6 +52379,7 @@ components:
           minLength: 6
         contactValue:
           type: string
+          minLength: 1
         password:
           type: string
           maxLength: 2147483647
@@ -52369,8 +52393,10 @@ components:
       properties:
         code:
           type: string
+          minLength: 1
         mfaToken:
           type: string
+          minLength: 1
         rememberDevice:
           type: boolean
       required:
@@ -52543,7 +52569,6 @@ components:
           type: integer
           format: int64
     WeavingProductionSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/WorkOrderProductionSpecs"
       - type: object
@@ -52689,8 +52714,6 @@ components:
           type: string
           format: uuid
     WorkOrderProductionSpecs:
-      type: object
-      description: Module-specific production specifications
       discriminator:
         propertyName: specType
       properties:
@@ -52705,8 +52728,7 @@ components:
           type: array
           items:
             type: object
-            additionalProperties:
-              type: object
+            additionalProperties: {}
         certificationReq:
           type: string
           description: "Customer-required certification standard (e.g. GOTS, OEKO-TEX,\
@@ -52744,9 +52766,9 @@ components:
           description: Output product UUID
         plannedQty:
           type: number
-          exclusiveMinimum: false
           minimum: 0.01
         productionSpecs:
+          description: Module-specific production specifications
           oneOf:
           - $ref: "#/components/schemas/DyeingProductionSpecs"
           - $ref: "#/components/schemas/FinishingProductionSpecs"
@@ -52765,6 +52787,7 @@ components:
           format: uuid
         unit:
           type: string
+          minLength: 1
         unitCost:
           type: number
       required:
@@ -52787,8 +52810,7 @@ components:
           type: array
           items:
             type: object
-            additionalProperties:
-              type: object
+            additionalProperties: {}
         certificationReq:
           type: string
           description: "Customer-required certification standard (e.g. GOTS, OEKO-TEX,\
@@ -52924,7 +52946,6 @@ components:
           description: Twist direction (Z or S)
           example: Z
     YarnPurchaseSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/PurchaseOrderSpecs"
       - type: object
@@ -52934,7 +52955,6 @@ components:
             description: Certifications
             items:
               type: string
-              description: Certifications
           composition:
             type: string
             description: Fiber composition
@@ -52972,7 +52992,6 @@ components:
             example: 30/1
       description: Yarn-specific purchase order specifications
     YarnRFQSpecs:
-      type: object
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
       - type: object

--- a/src/test/java/com/fabricmanagement/architecture/OpenApiExportIT.java
+++ b/src/test/java/com/fabricmanagement/architecture/OpenApiExportIT.java
@@ -59,7 +59,7 @@ public class OpenApiExportIT {
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     String generatedSpec = response.getBody();
     assertThat(generatedSpec).isNotNull();
-    assertThat(generatedSpec).contains("openapi: 3.0");
+    assertThat(generatedSpec).contains("openapi: 3.");
 
     // 2. Define the target spec file location
     File specFile = new File("api/openapi.yaml");


### PR DESCRIPTION
- Updated OpenApiExportIT to support OpenAPI 3.1.x output by changing strict 3.0 assertion.
- Regenerated api/openapi.yaml with Spring Boot 3.5.14 and springdoc 2.8.17.
- This introduces standard additionalProperties: true mapping and stricter validations.