### PR TITLE
feat(procurement): expose supplier RFQ read endpoints

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -24482,6 +24482,97 @@ paths:
       tags:
       - Purchase Order
   /api/v1/procurement/rfqs:
+    get:
+      operationId: listRfqs
+      parameters:
+      - in: query
+        name: status
+        required: false
+        schema:
+          type: string
+          enum:
+          - DRAFT
+          - SENT
+          - PARTIALLY_RECEIVED
+          - COMPLETED
+          - CANCELLED
+      - in: query
+        name: moduleType
+        required: false
+        schema:
+          type: string
+          enum:
+          - FIBER
+          - YARN
+          - FABRIC
+          - DYE_FINISHING
+          - GENERIC
+      - in: query
+        name: pageable
+        required: true
+        schema:
+          $ref: "#/components/schemas/Pageable"
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseSupplierRFQResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List Supplier RFQs
+      tags:
+      - Supplier R F Q
     post:
       operationId: createRfq
       requestBody:
@@ -24548,6 +24639,77 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
+      tags:
+      - Supplier R F Q
+  /api/v1/procurement/rfqs/{id}:
+    get:
+      operationId: getRfq
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseSupplierRFQResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get Supplier RFQ by ID
       tags:
       - Supplier R F Q
   /api/v1/procurement/rfqs/{rfqId}/lines:
@@ -43593,6 +43755,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponsePagedResponseSupplierRFQResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseSupplierRFQResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponsePagedResponseTaskResponse:
       type: object
       properties:
@@ -44264,6 +44444,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/SupplierQuoteResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseSupplierRFQResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/SupplierRFQResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -50758,6 +50956,29 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/SupplierQuoteResponse"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    PagedResponseSupplierRFQResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/SupplierRFQResponse"
         first:
           type: boolean
         last:

--- a/src/main/java/com/fabricmanagement/procurement/rfq/api/controller/SupplierRFQController.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/api/controller/SupplierRFQController.java
@@ -1,20 +1,29 @@
 package com.fabricmanagement.procurement.rfq.api.controller;
 
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.procurement.rfq.app.SupplierRFQService;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQModuleType;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQStatus;
 import com.fabricmanagement.procurement.rfq.dto.AddRecipientRequest;
 import com.fabricmanagement.procurement.rfq.dto.AddRfqLineRequest;
 import com.fabricmanagement.procurement.rfq.dto.CreateSupplierRFQRequest;
 import com.fabricmanagement.procurement.rfq.dto.SupplierRFQResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +39,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class SupplierRFQController {
 
   private final SupplierRFQService rfqService;
+
+  @GetMapping("/{id}")
+  @PreAuthorize("@auth.can(authentication, 'procurement', 'read')")
+  @Operation(summary = "Get Supplier RFQ by ID")
+  public ResponseEntity<ApiResponse<SupplierRFQResponse>> getRfq(@PathVariable UUID id) {
+    return ResponseEntity.ok(ApiResponse.success(rfqService.getRfq(id)));
+  }
+
+  @GetMapping
+  @PreAuthorize("@auth.can(authentication, 'procurement', 'read')")
+  @Operation(summary = "List Supplier RFQs")
+  public ResponseEntity<ApiResponse<PagedResponse<SupplierRFQResponse>>> listRfqs(
+      @RequestParam(required = false) SupplierRFQStatus status,
+      @RequestParam(required = false) SupplierRFQModuleType moduleType,
+      Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(rfqService.listRfqs(status, moduleType, pageable)));
+  }
 
   @PostMapping
   @ResponseStatus(HttpStatus.CREATED)

--- a/src/main/java/com/fabricmanagement/procurement/rfq/app/SupplierRFQService.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/app/SupplierRFQService.java
@@ -2,16 +2,20 @@ package com.fabricmanagement.procurement.rfq.app;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
 import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.rfq.domain.RfqRecipientStatus;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQModuleType;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQRecipient;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQStatus;
 import com.fabricmanagement.procurement.rfq.domain.event.RfqSentEvent;
 import com.fabricmanagement.procurement.rfq.dto.AddRecipientRequest;
 import com.fabricmanagement.procurement.rfq.dto.AddRfqLineRequest;
 import com.fabricmanagement.procurement.rfq.dto.CreateSupplierRFQRequest;
+import com.fabricmanagement.procurement.rfq.dto.SupplierRFQResponse;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -20,6 +24,9 @@ import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +38,38 @@ public class SupplierRFQService {
 
   private final SupplierRFQRepository rfqRepository;
   private final DomainEventPublisher eventPublisher;
+
+  public SupplierRFQResponse getRfq(UUID id) {
+    return rfqRepository
+        .findById(id)
+        .map(SupplierRFQResponse::from)
+        .orElseThrow(() -> new NotFoundException("SupplierRFQ not found with id: " + id));
+  }
+
+  public PagedResponse<SupplierRFQResponse> listRfqs(
+      SupplierRFQStatus status, SupplierRFQModuleType moduleType, Pageable pageable) {
+    UUID tenantId = TenantContext.requireTenantId();
+
+    Specification<SupplierRFQ> spec =
+        (root, query, cb) -> {
+          var predicates = new java.util.ArrayList<jakarta.persistence.criteria.Predicate>();
+          predicates.add(cb.equal(root.get("tenantId"), tenantId));
+          predicates.add(cb.isTrue(root.get("isActive")));
+
+          if (status != null) {
+            predicates.add(cb.equal(root.get("status"), status));
+          }
+          if (moduleType != null) {
+            predicates.add(cb.equal(root.get("moduleType"), moduleType));
+          }
+
+          return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
+        };
+
+    Page<SupplierRFQ> rfqPage = rfqRepository.findAll(spec, pageable);
+
+    return PagedResponse.from(rfqPage, SupplierRFQResponse::from);
+  }
 
   @Transactional
   public SupplierRFQ createRfq(CreateSupplierRFQRequest req) {

--- a/src/main/java/com/fabricmanagement/procurement/rfq/infra/repository/SupplierRFQRepository.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/infra/repository/SupplierRFQRepository.java
@@ -4,9 +4,11 @@ import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface SupplierRFQRepository extends JpaRepository<SupplierRFQ, UUID> {
+public interface SupplierRFQRepository
+    extends JpaRepository<SupplierRFQ, UUID>, JpaSpecificationExecutor<SupplierRFQ> {
   Optional<SupplierRFQ> findByTenantIdAndIdAndIsActiveTrue(UUID tenantId, UUID id);
 }

--- a/src/test/java/com/fabricmanagement/procurement/rfq/api/controller/SupplierRFQControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/rfq/api/controller/SupplierRFQControllerSecurityTest.java
@@ -1,0 +1,125 @@
+package com.fabricmanagement.procurement.rfq.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.procurement.rfq.app.SupplierRFQService;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQModuleType;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQStatus;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQType;
+import com.fabricmanagement.procurement.rfq.dto.SupplierRFQResponse;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SupplierRFQController.class)
+@EnableMethodSecurity
+class SupplierRFQControllerSecurityTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private SupplierRFQService rfqService;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  @Test
+  void shouldReturn401WhenUnauthenticated() throws Exception {
+    mockMvc.perform(get("/api/v1/procurement/rfqs")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturn403WhenMissingProcurementReadPermission() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("procurement"), eq("read")))
+        .thenReturn(false);
+
+    mockMvc.perform(get("/api/v1/procurement/rfqs")).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnRfqDetailWhenUserHasProcurementRead() throws Exception {
+    UUID rfqId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("procurement"), eq("read")))
+        .thenReturn(true);
+    when(rfqService.getRfq(rfqId)).thenReturn(response(rfqId, SupplierRFQStatus.DRAFT));
+
+    mockMvc
+        .perform(get("/api/v1/procurement/rfqs/{id}", rfqId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.id").value(rfqId.toString()))
+        .andExpect(jsonPath("$.data.status").value("DRAFT"));
+  }
+
+  @Test
+  @WithMockUser
+  void shouldReturnPagedRfqsAndBindStatusFilter() throws Exception {
+    UUID rfqId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("procurement"), eq("read")))
+        .thenReturn(true);
+    when(rfqService.listRfqs(eq(SupplierRFQStatus.SENT), eq(SupplierRFQModuleType.FIBER), any()))
+        .thenReturn(
+            PagedResponse.<SupplierRFQResponse>builder()
+                .content(List.of(response(rfqId, SupplierRFQStatus.SENT)))
+                .page(0)
+                .size(10)
+                .totalElements(1)
+                .totalPages(1)
+                .first(true)
+                .last(true)
+                .build());
+
+    mockMvc
+        .perform(
+            get("/api/v1/procurement/rfqs")
+                .param("status", "SENT")
+                .param("moduleType", "FIBER")
+                .param("page", "0")
+                .param("size", "10"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.success").value(true))
+        .andExpect(jsonPath("$.data.content[0].id").value(rfqId.toString()))
+        .andExpect(jsonPath("$.data.content[0].status").value("SENT"))
+        .andExpect(jsonPath("$.data.totalElements").value(1));
+
+    verify(rfqService)
+        .listRfqs(eq(SupplierRFQStatus.SENT), eq(SupplierRFQModuleType.FIBER), any(Pageable.class));
+  }
+
+  private SupplierRFQResponse response(UUID id, SupplierRFQStatus status) {
+    return SupplierRFQResponse.builder()
+        .id(id)
+        .rfqNumber("RFQ-2026-TEST")
+        .workOrderId(UUID.randomUUID())
+        .moduleType(SupplierRFQModuleType.FIBER)
+        .rfqType(SupplierRFQType.PURCHASE)
+        .status(status)
+        .deadline(Instant.now())
+        .lines(List.of())
+        .recipients(List.of())
+        .createdAt(Instant.now())
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/rfq/app/SupplierRFQServiceTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/rfq/app/SupplierRFQServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
 import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.rfq.domain.RfqRecipientStatus;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
@@ -19,10 +21,17 @@ import com.fabricmanagement.procurement.rfq.domain.SupplierRFQType;
 import com.fabricmanagement.procurement.rfq.dto.AddRecipientRequest;
 import com.fabricmanagement.procurement.rfq.dto.AddRfqLineRequest;
 import com.fabricmanagement.procurement.rfq.dto.CreateSupplierRFQRequest;
+import com.fabricmanagement.procurement.rfq.dto.SupplierRFQResponse;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -30,9 +39,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @ExtendWith(MockitoExtension.class)
 class SupplierRFQServiceTest {
@@ -57,11 +71,91 @@ class SupplierRFQServiceTest {
     mockRfq.setTenantId(tenantId);
     mockRfq.setRfqNumber("RFQ-2026-TEST");
     mockRfq.setStatus(SupplierRFQStatus.DRAFT);
+    mockRfq.setModuleType(SupplierRFQModuleType.FIBER);
+    mockRfq.setRfqType(SupplierRFQType.PURCHASE);
+    mockRfq.setDeadline(Instant.now().plus(7, ChronoUnit.DAYS));
   }
 
   @AfterEach
   void tearDown() {
     TenantContext.clear();
+  }
+
+  @Test
+  @DisplayName("Should get RFQ by id")
+  void shouldGetRfqById() {
+    when(rfqRepository.findById(rfqId)).thenReturn(Optional.of(mockRfq));
+
+    SupplierRFQResponse response = rfqService.getRfq(rfqId);
+
+    assertEquals(rfqId, response.getId());
+    assertEquals("RFQ-2026-TEST", response.getRfqNumber());
+    verify(rfqRepository).findById(rfqId);
+  }
+
+  @Test
+  @DisplayName("Should throw when RFQ is not found")
+  void shouldThrowWhenRfqNotFound() {
+    when(rfqRepository.findById(rfqId)).thenReturn(Optional.empty());
+
+    NotFoundException ex = assertThrows(NotFoundException.class, () -> rfqService.getRfq(rfqId));
+
+    assertEquals("SupplierRFQ not found with id: " + rfqId, ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("Should list RFQs as a paged response")
+  void shouldListRfqs() {
+    Pageable pageable = PageRequest.of(0, 20);
+    when(rfqRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(mockRfq), pageable, 1));
+
+    PagedResponse<SupplierRFQResponse> response =
+        rfqService.listRfqs(null, SupplierRFQModuleType.FIBER, pageable);
+
+    assertEquals(1, response.getContent().size());
+    assertEquals(SupplierRFQModuleType.FIBER, response.getContent().get(0).getModuleType());
+    assertEquals(0, response.getPage());
+    assertEquals(20, response.getSize());
+  }
+
+  @Test
+  @DisplayName("Should build status filter when listing RFQs")
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void shouldBuildStatusFilterWhenListingRfqs() {
+    Pageable pageable = PageRequest.of(0, 20);
+    when(rfqRepository.findAll(any(Specification.class), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of(mockRfq), pageable, 1));
+
+    rfqService.listRfqs(SupplierRFQStatus.SENT, null, pageable);
+
+    ArgumentCaptor<Specification<SupplierRFQ>> specCaptor =
+        ArgumentCaptor.forClass(Specification.class);
+    verify(rfqRepository).findAll(specCaptor.capture(), any(Pageable.class));
+
+    Root root = org.mockito.Mockito.mock(Root.class);
+    CriteriaQuery query = org.mockito.Mockito.mock(CriteriaQuery.class);
+    CriteriaBuilder cb = org.mockito.Mockito.mock(CriteriaBuilder.class);
+    Path tenantPath = org.mockito.Mockito.mock(Path.class);
+    Path activePath = org.mockito.Mockito.mock(Path.class);
+    Path statusPath = org.mockito.Mockito.mock(Path.class);
+    Predicate tenantPredicate = org.mockito.Mockito.mock(Predicate.class);
+    Predicate activePredicate = org.mockito.Mockito.mock(Predicate.class);
+    Predicate statusPredicate = org.mockito.Mockito.mock(Predicate.class);
+    Predicate combinedPredicate = org.mockito.Mockito.mock(Predicate.class);
+
+    when(root.get("tenantId")).thenReturn(tenantPath);
+    when(root.get("isActive")).thenReturn(activePath);
+    when(root.get("status")).thenReturn(statusPath);
+    when(cb.equal(tenantPath, tenantId)).thenReturn(tenantPredicate);
+    when(cb.isTrue(activePath)).thenReturn(activePredicate);
+    when(cb.equal(statusPath, SupplierRFQStatus.SENT)).thenReturn(statusPredicate);
+    when(cb.and(any(Predicate[].class))).thenReturn(combinedPredicate);
+
+    Predicate predicate = specCaptor.getValue().toPredicate(root, query, cb);
+
+    assertEquals(combinedPredicate, predicate);
+    verify(cb).equal(statusPath, SupplierRFQStatus.SENT);
   }
 
   @Test


### PR DESCRIPTION
Add ApiResponse-wrapped supplier RFQ detail and paged list endpoints gated by procurement:read.

Back the list with tenant-scoped Specification filtering for status and moduleType, enable JpaSpecificationExecutor on the RFQ repository, and return SupplierRFQResponse DTOs from the new read service methods.

Add RFQ service and controller security coverage, and regenerate the OpenAPI contract with listRfqs and getRfq.