### PR TITLE
fix(auth): derive access-cookie Max-Age from token lifetime

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/AuthCookieSupport.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/AuthCookieSupport.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.common.infrastructure.security;
 
+import com.fabricmanagement.platform.auth.app.JwtService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,7 +19,7 @@ public class AuthCookieSupport {
   /** Cookie name for refresh token (sent only to /api/auth). */
   public static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 
-  /** Access token cookie Max-Age in seconds (15 minutes). */
+  /** Access token cookie Max-Age fallback in seconds (15 minutes). */
   private static final int ACCESS_TOKEN_MAX_AGE_SECONDS = 900;
 
   /** Refresh token cookie Max-Age in seconds (7 days). */
@@ -26,6 +27,12 @@ public class AuthCookieSupport {
 
   @Value("${application.auth.cookie.secure:true}")
   private boolean secureCookie;
+
+  private final JwtService jwtService;
+
+  public AuthCookieSupport(JwtService jwtService) {
+    this.jwtService = jwtService;
+  }
 
   /**
    * Add access_token and refresh_token cookies to the response. Skips any token that is null or
@@ -38,7 +45,7 @@ public class AuthCookieSupport {
       accessCookie.setHttpOnly(true);
       accessCookie.setSecure(secureCookie);
       accessCookie.setPath("/api/v1");
-      accessCookie.setMaxAge(ACCESS_TOKEN_MAX_AGE_SECONDS);
+      accessCookie.setMaxAge(resolveAccessTokenMaxAge(accessToken));
       accessCookie.setAttribute("SameSite", "Strict");
       response.addCookie(accessCookie);
     }
@@ -73,5 +80,13 @@ public class AuthCookieSupport {
     refreshCookie.setMaxAge(0);
     refreshCookie.setAttribute("SameSite", "Strict");
     response.addCookie(refreshCookie);
+  }
+
+  private int resolveAccessTokenMaxAge(String accessToken) {
+    long secondsUntilExpiry = jwtService.secondsUntilExpiry(accessToken);
+    if (secondsUntilExpiry <= 0) {
+      return ACCESS_TOKEN_MAX_AGE_SECONDS;
+    }
+    return (int) Math.min(Integer.MAX_VALUE, secondsUntilExpiry);
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
@@ -8,6 +8,7 @@ import com.fabricmanagement.platform.organization.infra.repository.OrganizationR
 import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
@@ -332,6 +333,23 @@ public class JwtService {
     } catch (Exception e) {
       log.trace("Invalid JWT token: {}", e.getMessage());
       return false;
+    }
+  }
+
+  /** Seconds from now until this token's exp claim; 0 if expired, invalid, or no exp. */
+  public long secondsUntilExpiry(String token) {
+    try {
+      Claims claims = extractClaims(token);
+      Date expiration = claims.getExpiration();
+      if (expiration == null) {
+        return 0;
+      }
+      long secondsRemaining =
+          expiration.toInstant().getEpochSecond() - Instant.now().getEpochSecond();
+      return Math.max(0, secondsRemaining);
+    } catch (JwtException | IllegalArgumentException e) {
+      log.trace("Could not read JWT expiry: {}", e.getMessage());
+      return 0;
     }
   }
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/security/AuthCookieSupportTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/security/AuthCookieSupportTest.java
@@ -1,0 +1,68 @@
+package com.fabricmanagement.common.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.auth.app.JwtService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("AuthCookieSupport")
+class AuthCookieSupportTest {
+
+  private static final String ACCESS_TOKEN = "access-token";
+  private static final String REFRESH_TOKEN = "refresh-token";
+
+  @Mock private JwtService jwtService;
+
+  @Test
+  @DisplayName("uses token lifetime for playground access cookie")
+  void addAuthCookies_usesPlaygroundTokenLifetimeForAccessCookie() {
+    AuthCookieSupport authCookieSupport = new AuthCookieSupport(jwtService);
+    when(jwtService.secondsUntilExpiry(ACCESS_TOKEN)).thenReturn(7_775_999L);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    authCookieSupport.addAuthCookies(response, ACCESS_TOKEN, null);
+
+    Cookie accessCookie = response.getCookie(JwtTokenExtractor.ACCESS_TOKEN_COOKIE_NAME);
+    assertThat(accessCookie).isNotNull();
+    assertThat(accessCookie.getMaxAge()).isEqualTo(7_775_999);
+  }
+
+  @Test
+  @DisplayName("uses token lifetime for regular login access cookie and refresh constant")
+  void addAuthCookies_usesLoginTokenLifetimeAndRefreshCookieConstant() {
+    AuthCookieSupport authCookieSupport = new AuthCookieSupport(jwtService);
+    when(jwtService.secondsUntilExpiry(ACCESS_TOKEN)).thenReturn(899L);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    authCookieSupport.addAuthCookies(response, ACCESS_TOKEN, REFRESH_TOKEN);
+
+    Cookie accessCookie = response.getCookie(JwtTokenExtractor.ACCESS_TOKEN_COOKIE_NAME);
+    Cookie refreshCookie = response.getCookie(AuthCookieSupport.REFRESH_TOKEN_COOKIE_NAME);
+    assertThat(accessCookie).isNotNull();
+    assertThat(accessCookie.getMaxAge()).isEqualTo(899);
+    assertThat(refreshCookie).isNotNull();
+    assertThat(refreshCookie.getMaxAge()).isEqualTo(604800);
+  }
+
+  @Test
+  @DisplayName("falls back to 15 minute access cookie when token expiry cannot be read")
+  void addAuthCookies_fallsBackToDefaultAccessCookieLifetimeWhenExpiryIsZero() {
+    AuthCookieSupport authCookieSupport = new AuthCookieSupport(jwtService);
+    when(jwtService.secondsUntilExpiry(ACCESS_TOKEN)).thenReturn(0L);
+    MockHttpServletResponse response = new MockHttpServletResponse();
+
+    authCookieSupport.addAuthCookies(response, ACCESS_TOKEN, null);
+
+    Cookie accessCookie = response.getCookie(JwtTokenExtractor.ACCESS_TOKEN_COOKIE_NAME);
+    assertThat(accessCookie).isNotNull();
+    assertThat(accessCookie.getMaxAge()).isEqualTo(900);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
@@ -14,6 +14,8 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import javax.crypto.SecretKey;
@@ -68,6 +70,63 @@ class JwtServiceTest {
     assertTokenTtl(claims, PLAYGROUND_TOKEN_EXPIRATION);
     assertThat(claims.get("is_playground", Boolean.class)).isTrue();
     assertThat(claims.get("guest_id", String.class)).isEqualTo("guest-123");
+  }
+
+  @Test
+  @DisplayName("secondsUntilExpiry returns remaining regular access token lifetime")
+  void secondsUntilExpiry_returnsRegularAccessTokenLifetime() {
+    User user = buildUser();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+    when(organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId()))
+        .thenReturn(Optional.empty());
+
+    long secondsUntilExpiry = jwtService.secondsUntilExpiry(jwtService.generateAccessToken(user));
+
+    assertThat(secondsUntilExpiry).isBetween(895L, 900L);
+  }
+
+  @Test
+  @DisplayName("secondsUntilExpiry returns remaining playground access token lifetime")
+  void secondsUntilExpiry_returnsPlaygroundAccessTokenLifetime() {
+    User user = buildUser();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+
+    long secondsUntilExpiry =
+        jwtService.secondsUntilExpiry(
+            jwtService.generatePlaygroundAccessToken(user, "guest-123", "guest@example.com"));
+
+    assertThat(secondsUntilExpiry).isBetween(7_775_995L, 7_776_000L);
+  }
+
+  @Test
+  @DisplayName("secondsUntilExpiry returns zero for expired token")
+  void secondsUntilExpiry_returnsZeroForExpiredToken() {
+    String expiredToken =
+        Jwts.builder()
+            .subject("guest@example.com")
+            .issuedAt(Date.from(Instant.now().minusSeconds(120)))
+            .expiration(Date.from(Instant.now().minusSeconds(60)))
+            .signWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)))
+            .compact();
+
+    assertThat(jwtService.secondsUntilExpiry(expiredToken)).isZero();
+  }
+
+  @Test
+  @DisplayName("secondsUntilExpiry returns zero for token without exp")
+  void secondsUntilExpiry_returnsZeroForTokenWithoutExpiration() {
+    String tokenWithoutExpiration =
+        Jwts.builder()
+            .subject("guest@example.com")
+            .issuedAt(Date.from(Instant.now()))
+            .signWith(Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8)))
+            .compact();
+
+    assertThat(jwtService.secondsUntilExpiry(tokenWithoutExpiration)).isZero();
   }
 
   private static void assertTokenTtl(Claims claims, long expectedMillis) {


### PR DESCRIPTION
The access_token cookie hardcoded Max-Age=900s (15 min) regardless of the JWT inside it. Playground tokens live 90 days but the browser dropped the cookie at 15 min → 401 → forced logout with no refresh cookie to recover, losing unsaved work.

AuthCookieSupport now derives the access-cookie Max-Age from the token's own exp claim via new JwtService.secondsUntilExpiry(token), falling back to the 900s constant when the expiry can't be read. Login keeps its ~15-min access cookie (renewed by the 7-day refresh cookie); the playground cookie now lives as long as its 90-day token. Refresh cookie and clearAuthCookies unchanged; PlaygroundAuthController untouched.

Tests: JwtService.secondsUntilExpiry (login/playground/expired/no-exp) and AuthCookieSupport Max-Age (playground large / login 899 + refresh 604800 / fallback 900).