### PR TITLE
refactor(auth): remove dead auth.jwt.* config decoy

### DIFF
--- a/src/main/java/com/fabricmanagement/platform/auth/config/AuthProperties.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/config/AuthProperties.java
@@ -9,7 +9,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
 /**
- * Auth module configuration (lockout, verification, JWT, password).
+ * Auth module configuration (lockout, verification, password).
  *
  * <p>Bind with prefix "auth". Example: auth.lockout.max-attempts=5
  */
@@ -21,8 +21,6 @@ public class AuthProperties {
   @Valid private LockoutProperties lockout = new LockoutProperties();
 
   @Valid private VerificationProperties verification = new VerificationProperties();
-
-  @Valid private JwtProperties jwt = new JwtProperties();
 
   @Valid private PasswordProperties password = new PasswordProperties();
 
@@ -51,12 +49,6 @@ public class AuthProperties {
     @Min(1)
     @Max(5)
     private int maxAttempts = 3;
-  }
-
-  @Data
-  public static class JwtProperties {
-    private Duration accessTokenExpiry = Duration.ofMinutes(15);
-    private Duration refreshTokenExpiry = Duration.ofDays(7);
   }
 
   @Data

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -108,7 +108,7 @@ logging:
     # Reduce log noise from background jobs
     com.fabricmanagement.platform.communication.app.EmailOutboxService: INFO
 
-# Auth module configuration (lockout, verification, JWT)
+# Auth module configuration (lockout, verification, password)
 auth:
   lockout:
     max-attempts: ${AUTH_LOCKOUT_MAX_ATTEMPTS:5}
@@ -117,9 +117,6 @@ auth:
     code-length: ${AUTH_VERIFICATION_CODE_LENGTH:6}
     code-expiry: ${AUTH_VERIFICATION_CODE_EXPIRY:10m}
     max-attempts: ${AUTH_VERIFICATION_MAX_ATTEMPTS:3}
-  jwt:
-    access-token-expiry: ${AUTH_JWT_ACCESS_EXPIRY:15m}
-    refresh-token-expiry: ${AUTH_JWT_REFRESH_EXPIRY:7d}
   password:
     bcrypt-strength: ${AUTH_BCRYPT_STRENGTH:10}
   mfa:


### PR DESCRIPTION
auth.jwt.access-token-expiry/refresh-token-expiry bound to AuthProperties.JwtProperties, but getJwt() was never consumed — only auth.lockout is read. Editing auth.jwt.* changed nothing (the real knobs are application.jwt.*), a footgun that masked the earlier 'extend the session to 3 months' attempt.

Remove the JwtProperties nested class + jwt field from AuthProperties and the auth.jwt block from application.yml. Lockout/verification/password and the real application.jwt.* config are untouched; no behavior change.