### PR TITLE
feat(onboarding): capture registering user's own mobile

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload Checkstyle results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: checkstyle-results
           path: target/checkstyle-result.xml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload SpotBugs results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: spotbugs-results
           path: target/spotbugsXml.xml
@@ -102,10 +102,10 @@ jobs:
     needs: code-quality
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: "21"
           distribution: "temurin"
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: |
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload JaCoCo coverage
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-coverage
           path: target/site/jacoco

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -45849,6 +45849,9 @@ components:
           format: uuid
         isActive:
           type: boolean
+        lastActivityAt:
+          type: string
+          format: date-time
         name:
           type: string
         wipLimitDefault:
@@ -54510,11 +54513,15 @@ components:
           enum:
           - TRIAL
           - ACTIVE
+          - EXPIRED
           - SUSPENDED
           - CANCELLED
         subscriptionPlan:
           type: string
         trialEndsAt:
+          type: string
+          format: date-time
+        trialStartedAt:
           type: string
           format: date-time
         type:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -46103,6 +46103,11 @@ components:
           type: string
           maxLength: 20
           minLength: 0
+        mobilePhone:
+          type: string
+          maxLength: 20
+          minLength: 0
+          pattern: "^\\+[1-9]\\d{1,14}$|^$"
         country:
           type: string
           maxLength: 100

--- a/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TenantAccessPort.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TenantAccessPort.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.common.infrastructure.tenant;
+
+import java.util.UUID;
+
+/** Cross-module access decision port for tenant lifecycle gates. */
+public interface TenantAccessPort {
+
+  /**
+   * Returns whether the tenant can perform write operations.
+   *
+   * <p>Implementations fail open for unresolved tenants.
+   */
+  boolean isWritable(UUID tenantId);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TrialLifecyclePort.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TrialLifecyclePort.java
@@ -1,0 +1,11 @@
+package com.fabricmanagement.common.infrastructure.tenant;
+
+import java.util.UUID;
+
+/** Cross-module port for tenant trial lifecycle side effects. */
+public interface TrialLifecyclePort {
+
+  int startSelfServiceTrialIfNeeded(UUID tenantId);
+
+  void touchTenantActivity(UUID tenantId);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/JwtContextInterceptor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/JwtContextInterceptor.java
@@ -3,9 +3,11 @@ package com.fabricmanagement.common.infrastructure.web;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.security.JwtTokenExtractor;
 import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
 import com.fabricmanagement.platform.auth.app.JwtService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -58,6 +60,7 @@ public class JwtContextInterceptor implements HandlerInterceptor {
 
   private final JwtService jwtService;
   private final TenantQueryPort tenantQueryPort;
+  private final Optional<TrialLifecyclePort> trialLifecyclePort;
 
   /** Extract JWT token and set TenantContext before handler execution. */
   @Override
@@ -74,12 +77,20 @@ public class JwtContextInterceptor implements HandlerInterceptor {
 
     if (token != null && jwtService.validateToken(token)) {
       try {
-        UUID userId = jwtService.getUserIdFromToken(token);
-        UUID tenantId = jwtService.getTenantIdFromToken(token);
+        JwtService.AuthTokenClaims authContext = jwtService.extractAuthContext(token);
+        UUID userId = authContext.userId();
+        UUID tenantId = authContext.tenantId();
+        if (userId == null || tenantId == null) {
+          throw new IllegalArgumentException("JWT token missing user_id or tenant_id");
+        }
 
         // Set TenantContext for this request thread
         TenantContext.setCurrentTenantId(tenantId);
         TenantContext.setCurrentUserId(userId);
+
+        if (shouldTouchTrialActivity(authContext)) {
+          trialLifecyclePort.ifPresent(port -> port.touchTenantActivity(tenantId));
+        }
 
         // Load tenant UID from JWT token (no DB query needed)
         // ⚠️ Performance: JWT already contains tenant_uid claim, no need for DB query
@@ -171,5 +182,18 @@ public class JwtContextInterceptor implements HandlerInterceptor {
       }
     }
     return false;
+  }
+
+  private boolean shouldTouchTrialActivity(JwtService.AuthTokenClaims authContext) {
+    if (authContext == null || authContext.tenantId() == null || authContext.userId() == null) {
+      return false;
+    }
+    if (authContext.isPlayground()) {
+      return false;
+    }
+    if (authContext.partnerId() != null) {
+      return false;
+    }
+    return authContext.userType() == null || !"PARTNER".equalsIgnoreCase(authContext.userType());
   }
 }

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
@@ -1,0 +1,72 @@
+package com.fabricmanagement.common.infrastructure.web;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.common.infrastructure.web.exception.TenantReadOnlyException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/** Central write guard for read-only expired tenants. */
+@Component
+@RequiredArgsConstructor
+public class TenantWriteGuardInterceptor implements HandlerInterceptor {
+
+  private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+  private static final List<String> DEFAULT_ALLOW_PATHS =
+      List.of(
+          "/api/v1/auth/**",
+          "/api/v1/public/**",
+          "/api/v1/subscriptions/*/activate",
+          "/api/v1/subscriptions/**/activate");
+
+  private final Optional<TenantAccessPort> tenantAccessPort;
+  private final Optional<TrialReadOnlyProperties> trialReadOnlyProperties;
+
+  @Override
+  public boolean preHandle(
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull Object handler) {
+    if (isSafeMethod(request.getMethod())) {
+      return true;
+    }
+
+    UUID tenantId = TenantContext.getCurrentTenantIdOrNull();
+    if (tenantId == null) {
+      return true;
+    }
+
+    if (isAllowedPath(request.getRequestURI())) {
+      return true;
+    }
+
+    boolean writable = tenantAccessPort.map(port -> port.isWritable(tenantId)).orElse(true);
+    if (!writable) {
+      throw new TenantReadOnlyException();
+    }
+    return true;
+  }
+
+  private boolean isSafeMethod(String method) {
+    return "GET".equalsIgnoreCase(method)
+        || "HEAD".equalsIgnoreCase(method)
+        || "OPTIONS".equalsIgnoreCase(method);
+  }
+
+  private boolean isAllowedPath(String path) {
+    return DEFAULT_ALLOW_PATHS.stream().anyMatch(pattern -> PATH_MATCHER.match(pattern, path))
+        || trialReadOnlyProperties
+            .map(TrialReadOnlyProperties::getAllowPaths)
+            .orElse(List.of())
+            .stream()
+            .anyMatch(pattern -> PATH_MATCHER.match(pattern, path));
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/TrialReadOnlyProperties.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/TrialReadOnlyProperties.java
@@ -1,0 +1,22 @@
+package com.fabricmanagement.common.infrastructure.web;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/** Configuration for read-only tenant write-guard escape hatches. */
+@Component
+@ConfigurationProperties(prefix = "application.trial.read-only")
+public class TrialReadOnlyProperties {
+
+  private List<String> allowPaths = new ArrayList<>();
+
+  public List<String> getAllowPaths() {
+    return allowPaths;
+  }
+
+  public void setAllowPaths(List<String> allowPaths) {
+    this.allowPaths = allowPaths != null ? new ArrayList<>(allowPaths) : new ArrayList<>();
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/WebMvcConfig.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/WebMvcConfig.java
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebMvcConfig implements WebMvcConfigurer {
 
   private final JwtContextInterceptor jwtContextInterceptor;
+  private final TenantWriteGuardInterceptor tenantWriteGuardInterceptor;
   private final PlaygroundQuotaInterceptor playgroundQuotaInterceptor;
 
   /**
@@ -45,6 +46,24 @@ public class WebMvcConfig implements WebMvcConfigurer {
             "/actuator/**");
 
     log.info("✅ JwtContextInterceptor registered globally (with public endpoint exclusions)");
+
+    registry
+        .addInterceptor(tenantWriteGuardInterceptor)
+        .addPathPatterns("/api/v1/**")
+        .excludePathPatterns(
+            // Public endpoints - no JWT required
+            "/api/v1/health",
+            "/api/v1/info",
+            "/api/v1/public/**",
+            "/api/v1/auth/**",
+            // Swagger/OpenAPI docs
+            "/api-docs/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            // Actuator (monitoring)
+            "/actuator/**");
+
+    log.info("✅ TenantWriteGuardInterceptor registered globally");
 
     registry
         .addInterceptor(playgroundQuotaInterceptor)

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -66,6 +66,18 @@ public class GlobalExceptionHandler {
     return ResponseEntity.status(status).body(pd);
   }
 
+  @ExceptionHandler(TenantReadOnlyException.class)
+  @ResponseStatus(HttpStatus.FORBIDDEN)
+  public ApiProblemDetail handleTenantReadOnly(TenantReadOnlyException ex, HttpServletRequest req) {
+    log.info("Read-only tenant write rejected: {}", req.getRequestURI());
+    return buildProblemDetail(
+        HttpStatus.FORBIDDEN,
+        "Forbidden",
+        TenantReadOnlyException.CODE,
+        ex.getMessage(),
+        req.getRequestURI());
+  }
+
   @ExceptionHandler(TaxIdAlreadyExistsException.class)
   @ResponseStatus(HttpStatus.BAD_REQUEST)
   public ApiProblemDetail handleTaxIdAlreadyExists(

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyException.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyException.java
@@ -1,0 +1,13 @@
+package com.fabricmanagement.common.infrastructure.web.exception;
+
+/** Raised when an expired tenant attempts a write operation. */
+public class TenantReadOnlyException extends DomainException {
+
+  public static final String CODE = "TENANT_READ_ONLY";
+  public static final String MESSAGE =
+      "Your trial has ended — subscribe to continue. The workspace is read-only.";
+
+  public TenantReadOnlyException() {
+    super(MESSAGE, CODE, 403);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
@@ -66,7 +66,7 @@ public class JwtService {
       OrganizationRepository organizationRepository,
       @Value("${application.jwt.secret}") String secret,
       @Value("${application.jwt.expiration:900000}") long accessTokenExpiration,
-      @Value("${application.jwt.playground-expiration:7776000000}")
+      @Value("${application.jwt.playground-expiration:1209600000}")
           long playgroundTokenExpiration) {
     this.tenantQueryPort = tenantQueryPort;
     this.organizationRepository = organizationRepository;

--- a/src/main/java/com/fabricmanagement/platform/auth/app/PasswordSetupService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/PasswordSetupService.java
@@ -4,10 +4,12 @@ import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
 import com.fabricmanagement.common.util.PiiMaskingUtil;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
 import com.fabricmanagement.platform.auth.domain.RefreshToken;
 import com.fabricmanagement.platform.auth.domain.RegistrationToken;
+import com.fabricmanagement.platform.auth.domain.RegistrationTokenType;
 import com.fabricmanagement.platform.auth.domain.event.UserLoginEvent;
 import com.fabricmanagement.platform.auth.domain.event.UserRegisteredEvent;
 import com.fabricmanagement.platform.auth.dto.LoginResponse;
@@ -76,6 +78,7 @@ public class PasswordSetupService {
   private final OrganizationAddressRepository organizationAddressRepository;
   private final TenantQueryPort tenantQueryPort;
   private final EmployeeProjectionPort employeeProjectionPort;
+  private final TrialLifecyclePort trialLifecyclePort;
 
   @Value("${application.jwt.refresh-expiration:604800000}")
   private long refreshTokenExpiration;
@@ -134,6 +137,9 @@ public class PasswordSetupService {
                 () ->
                     new IllegalStateException(
                         "Tenant not found or not active. Password setup is not allowed."));
+    if (tenantRef != null && token.getTokenType() == RegistrationTokenType.SELF_SERVICE) {
+      trialLifecyclePort.startSelfServiceTrialIfNeeded(user.getTenantId());
+    }
 
     // Reload User entity with contacts/departments for JWT generation
     com.fabricmanagement.platform.user.domain.User userEntity =

--- a/src/main/java/com/fabricmanagement/platform/auth/app/TenantOnboardingService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/TenantOnboardingService.java
@@ -29,7 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TenantOnboardingService {
 
   /** Default trial days for self-service signups. */
-  private static final int DEFAULT_SELF_SERVICE_TRIAL_DAYS = 14;
+  private static final int DEFAULT_SELF_SERVICE_TRIAL_DAYS = 90;
 
   /** Default trial days for sales-led onboarding when not specified. */
   private static final int DEFAULT_SALES_LED_TRIAL_DAYS = 90;

--- a/src/main/java/com/fabricmanagement/platform/auth/app/onboarding/CreateSubscriptionsStep.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/onboarding/CreateSubscriptionsStep.java
@@ -29,7 +29,7 @@ public class CreateSubscriptionsStep implements OnboardingStep {
       return;
     }
     List<String> selectedOS = context.getSelectedOS();
-    int trialDays = context.isSalesLed() ? context.getTrialDays() : 14;
+    int trialDays = context.getTrialDays();
     if (selectedOS == null || selectedOS.isEmpty()) {
       selectedOS = List.of("FabricOS");
     }

--- a/src/main/java/com/fabricmanagement/platform/auth/app/onboarding/CreateTenantStep.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/onboarding/CreateTenantStep.java
@@ -40,6 +40,7 @@ public class CreateTenantStep implements OnboardingStep {
             .billingEmail(context.getOrganizationEmail())
             .country(context.getCountry())
             .trialDays(context.getTrialDays())
+            .deferTrialActivation(!context.isSalesLed())
             .build();
 
     TenantDto tenant = tenantFacade.createTenant(request);

--- a/src/main/java/com/fabricmanagement/platform/subscription/domain/Subscription.java
+++ b/src/main/java/com/fabricmanagement/platform/subscription/domain/Subscription.java
@@ -36,7 +36,7 @@ import org.hibernate.annotations.Type;
  *     .osName("Yarn Production OS")
  *     .status(SubscriptionStatus.TRIAL)
  *     .startDate(Instant.now())
- *     .trialEndsAt(Instant.now().plus(14, ChronoUnit.DAYS))
+ *     .trialEndsAt(Instant.now().plus(90, ChronoUnit.DAYS))
  *     .pricingTier("Professional")
  *     .build();
  * }</pre>

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/PlaygroundTTLReaperService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/PlaygroundTTLReaperService.java
@@ -24,6 +24,11 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class PlaygroundTTLReaperService {
 
+  static final String REAP_EXPIRED_PLAYGROUNDS_SQL =
+      "UPDATE common_tenant.common_tenant "
+          + "SET is_active = false, updated_at = now(), version = version + 1 "
+          + "WHERE type = 'PLAYGROUND' AND is_active = true AND created_at < ?";
+
   private final SystemTransactionExecutor systemExecutor;
 
   @Value("${playground.ttl.days:14}")
@@ -46,12 +51,7 @@ public class PlaygroundTTLReaperService {
 
     int affected =
         systemExecutor.executeInTransaction(
-            jdbc ->
-                jdbc.update(
-                    "UPDATE common_tenant.common_tenant "
-                        + "SET is_active = false, updated_at = now(), version = version + 1 "
-                        + "WHERE type = 'PLAYGROUND' AND is_active = true AND created_at < ?",
-                    java.sql.Timestamp.from(threshold)));
+            jdbc -> jdbc.update(REAP_EXPIRED_PLAYGROUNDS_SQL, java.sql.Timestamp.from(threshold)));
 
     if (affected == 0) {
       log.info("No expired playgrounds found.");

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantSystemService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantSystemService.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -308,6 +309,7 @@ public class TenantSystemService {
    * @param plan Subscription plan name
    * @return Updated tenant
    */
+  @CacheEvict(value = "tenant-writable", key = "#tenantId.toString()")
   public TenantDto activate(UUID tenantId, String plan) {
     return updateStatusSystem(tenantId, TenantStatus.ACTIVE, "Subscription activated: " + plan);
   }
@@ -319,6 +321,7 @@ public class TenantSystemService {
    * @param reason Suspension reason
    * @return Updated tenant
    */
+  @CacheEvict(value = "tenant-writable", key = "#tenantId.toString()")
   public TenantDto suspend(UUID tenantId, String reason) {
     return updateStatusSystem(tenantId, TenantStatus.SUSPENDED, reason);
   }
@@ -330,6 +333,7 @@ public class TenantSystemService {
    * @param reason Cancellation reason
    * @return Updated tenant
    */
+  @CacheEvict(value = "tenant-writable", key = "#tenantId.toString()")
   public TenantDto cancel(UUID tenantId, String reason) {
     return updateStatusSystem(tenantId, TenantStatus.CANCELLED, reason);
   }

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantSystemService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantSystemService.java
@@ -90,7 +90,7 @@ public class TenantSystemService {
     TenantType type = request.getType() != null ? request.getType() : TenantType.REGULAR;
     TenantStatus status = request.getTrialDays() > 0 ? TenantStatus.TRIAL : TenantStatus.ACTIVE;
     Instant trialEndsAt =
-        request.getTrialDays() > 0
+        request.getTrialDays() > 0 && !request.isDeferTrialActivation()
             ? Instant.now().plus(java.time.Duration.ofDays(request.getTrialDays()))
             : null;
     String settingsJson = serializeSettings(settings);

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
@@ -1,0 +1,156 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+/**
+ * Activation-based trial lifecycle.
+ *
+ * <p>Uses the system datasource because trial maintenance runs across tenants and must bypass
+ * tenant self-row RLS.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TrialLifecycleService implements TrialLifecyclePort {
+
+  private final SystemTransactionExecutor systemExecutor;
+
+  @Value("${application.trial.base-days:90}")
+  private int baseDays;
+
+  @Value("${application.trial.dormancy-window-days:90}")
+  private int dormancyWindowDays;
+
+  @Value("${application.trial.hard-cap-months:18}")
+  private int hardCapMonths;
+
+  @Override
+  public int startSelfServiceTrialIfNeeded(UUID tenantId) {
+    if (tenantId == null) {
+      return 0;
+    }
+    Instant now = Instant.now();
+    Instant trialEndsAt = now.plus(baseDays, ChronoUnit.DAYS);
+    return systemExecutor.executeUpdate(
+        """
+        UPDATE common_tenant.common_tenant
+        SET trial_started_at = ?,
+            last_activity_at = ?,
+            trial_ends_at = ?,
+            updated_at = now(),
+            version = version + 1
+        WHERE id = ?
+          AND type = 'REGULAR'
+          AND status = 'TRIAL'
+          AND trial_started_at IS NULL
+          AND is_active = true
+        """,
+        Timestamp.from(now),
+        Timestamp.from(now),
+        Timestamp.from(trialEndsAt),
+        tenantId);
+  }
+
+  @Async
+  @Override
+  public void touchTenantActivity(UUID tenantId) {
+    if (tenantId == null) {
+      return;
+    }
+    Instant now = Instant.now();
+    Instant todayStart = LocalDate.now(ZoneOffset.UTC).atStartOfDay().toInstant(ZoneOffset.UTC);
+
+    int affected =
+        systemExecutor.executeUpdate(
+            """
+            UPDATE common_tenant.common_tenant
+            SET last_activity_at = ?,
+                updated_at = now(),
+                version = version + 1
+            WHERE id = ?
+              AND type = 'REGULAR'
+              AND status = 'TRIAL'
+              AND trial_started_at IS NOT NULL
+              AND is_active = true
+              AND (last_activity_at IS NULL OR last_activity_at < ?)
+            """,
+            Timestamp.from(now),
+            tenantId,
+            Timestamp.from(todayStart));
+    log.trace("Trial activity touch: tenantId={}, affected={}", tenantId, affected);
+  }
+
+  @Scheduled(cron = "${application.trial.lifecycle-cron:0 15 3 * * ?}")
+  public void refreshTrialWindows() {
+    Instant now = Instant.now();
+    int updated =
+        systemExecutor.executeInTransaction(
+            jdbc -> {
+              var rows =
+                  jdbc.query(
+                      """
+                      SELECT id, trial_started_at, last_activity_at
+                      FROM common_tenant.common_tenant
+                      WHERE type = 'REGULAR'
+                        AND status = 'TRIAL'
+                        AND trial_started_at IS NOT NULL
+                        AND is_active = true
+                      """,
+                      (rs, rowNum) ->
+                          new TrialWindow(
+                              rs.getObject("id", UUID.class),
+                              rs.getTimestamp("trial_started_at").toInstant(),
+                              rs.getTimestamp("last_activity_at") != null
+                                  ? rs.getTimestamp("last_activity_at").toInstant()
+                                  : null));
+              int count = 0;
+              for (TrialWindow row : rows) {
+                TrialDecision decision = evaluate(row, now);
+                count +=
+                    jdbc.update(
+                        """
+                        UPDATE common_tenant.common_tenant
+                        SET status = ?,
+                            trial_ends_at = ?,
+                            updated_at = now(),
+                            version = version + 1
+                        WHERE id = ?
+                        """,
+                        decision.status().name(),
+                        Timestamp.from(decision.effectiveExpiry()),
+                        row.tenantId());
+              }
+              return count;
+            });
+    log.info("Trial lifecycle refresh completed: {} tenant(s) updated", updated);
+  }
+
+  TrialDecision evaluate(TrialWindow row, Instant now) {
+    Instant lastActivity =
+        row.lastActivityAt() != null ? row.lastActivityAt() : row.trialStartedAt();
+    Instant dormancyExpiry = lastActivity.plus(dormancyWindowDays, ChronoUnit.DAYS);
+    Instant hardCapAt =
+        row.trialStartedAt().atOffset(ZoneOffset.UTC).plusMonths(hardCapMonths).toInstant();
+    Instant effectiveExpiry = dormancyExpiry.isBefore(hardCapAt) ? dormancyExpiry : hardCapAt;
+    TenantStatus status = now.isAfter(effectiveExpiry) ? TenantStatus.EXPIRED : TenantStatus.TRIAL;
+    return new TrialDecision(status, effectiveExpiry);
+  }
+
+  record TrialWindow(UUID tenantId, Instant trialStartedAt, Instant lastActivityAt) {}
+
+  record TrialDecision(TenantStatus status, Instant effectiveExpiry) {}
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,10 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class TrialLifecycleService implements TrialLifecyclePort {
 
+  private static final String TENANT_WRITABLE_CACHE = "tenant-writable";
+
   private final SystemTransactionExecutor systemExecutor;
+  private final CacheManager cacheManager;
 
   @Value("${application.trial.base-days:90}")
   private int baseDays;
@@ -133,6 +137,9 @@ public class TrialLifecycleService implements TrialLifecyclePort {
                         decision.status().name(),
                         Timestamp.from(decision.effectiveExpiry()),
                         row.tenantId());
+                if (decision.status() == TenantStatus.EXPIRED) {
+                  evictWritableCache(row.tenantId());
+                }
               }
               return count;
             });
@@ -148,6 +155,13 @@ public class TrialLifecycleService implements TrialLifecyclePort {
     Instant effectiveExpiry = dormancyExpiry.isBefore(hardCapAt) ? dormancyExpiry : hardCapAt;
     TenantStatus status = now.isAfter(effectiveExpiry) ? TenantStatus.EXPIRED : TenantStatus.TRIAL;
     return new TrialDecision(status, effectiveExpiry);
+  }
+
+  private void evictWritableCache(UUID tenantId) {
+    var cache = cacheManager.getCache(TENANT_WRITABLE_CACHE);
+    if (cache != null) {
+      cache.evict(tenantId.toString());
+    }
   }
 
   record TrialWindow(UUID tenantId, Instant trialStartedAt, Instant lastActivityAt) {}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/adapter/TenantAccessAdapter.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/adapter/TenantAccessAdapter.java
@@ -1,0 +1,36 @@
+package com.fabricmanagement.platform.tenant.app.adapter;
+
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.platform.tenant.app.TenantSystemService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+/** Tenant lifecycle access decisions for common infrastructure guards. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class TenantAccessAdapter implements TenantAccessPort {
+
+  private final TenantSystemService tenantSystemService;
+
+  @Override
+  @Cacheable(value = "tenant-writable", key = "#tenantId.toString()")
+  public boolean isWritable(UUID tenantId) {
+    if (tenantId == null) {
+      log.warn("Tenant write decision requested with null tenantId; failing open");
+      return true;
+    }
+    return tenantSystemService
+        .findById(tenantId)
+        .map(tenant -> tenant.getStatus() == null || tenant.getStatus().canWrite())
+        .orElseGet(
+            () -> {
+              log.warn(
+                  "Tenant {} could not be resolved for write decision; failing open", tenantId);
+              return true;
+            });
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/domain/Tenant.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/domain/Tenant.java
@@ -145,6 +145,14 @@ public class Tenant implements Serializable {
   @Column(name = "trial_ends_at")
   private Instant trialEndsAt;
 
+  /** Trial activation timestamp. Null until a self-service trial is activated. */
+  @Column(name = "trial_started_at")
+  private Instant trialStartedAt;
+
+  /** Last meaningful authenticated tenant activity. */
+  @Column(name = "last_activity_at")
+  private Instant lastActivityAt;
+
   /** Subscription plan identifier (e.g., "professional", "enterprise") */
   @Column(name = "subscription_plan", length = 50)
   private String subscriptionPlan;
@@ -297,6 +305,23 @@ public class Tenant implements Serializable {
   public void startTrial(int trialDays) {
     this.status = TenantStatus.TRIAL;
     this.trialEndsAt = Instant.now().plusSeconds(trialDays * 24L * 60 * 60);
+  }
+
+  /** Start the activation-based trial clock now. */
+  public void startTrialNow(int baseDays) {
+    Instant now = Instant.now();
+    this.status = TenantStatus.TRIAL;
+    this.trialStartedAt = now;
+    this.lastActivityAt = now;
+    this.trialEndsAt = now.plusSeconds(baseDays * 24L * 60 * 60);
+  }
+
+  /** Mark the trial retained read-only after expiry. */
+  public void expireTrial() {
+    if (this.status != TenantStatus.TRIAL) {
+      throw new IllegalStateException("Only trial tenants can expire");
+    }
+    this.status = TenantStatus.EXPIRED;
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/platform/tenant/domain/TenantStatus.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/domain/TenantStatus.java
@@ -9,7 +9,7 @@ package com.fabricmanagement.platform.tenant.domain;
  *
  * <pre>
  * TRIAL → ACTIVE (payment received)
- * TRIAL → SUSPENDED (trial expired, no payment)
+ * TRIAL → EXPIRED (trial expired, retained read-only)
  * ACTIVE → SUSPENDED (payment failed / policy violation)
  * SUSPENDED → ACTIVE (payment received / issue resolved)
  * SUSPENDED → CANCELLED (prolonged non-payment / user request)
@@ -20,7 +20,7 @@ public enum TenantStatus {
   /**
    * Trial period - limited time, full features.
    *
-   * <p>Default status for new tenants. Transitions to ACTIVE after payment or SUSPENDED after trial
+   * <p>Default status for new tenants. Transitions to ACTIVE after payment or EXPIRED after trial
    * expiry.
    */
   TRIAL,
@@ -31,6 +31,13 @@ public enum TenantStatus {
    * <p>Tenant has full access to subscribed features.
    */
   ACTIVE,
+
+  /**
+   * Expired trial - retained read-only.
+   *
+   * <p>Tenant can still log in and view retained data, but write access is disabled by policy.
+   */
+  EXPIRED,
 
   /**
    * Suspended - temporarily disabled.
@@ -54,6 +61,16 @@ public enum TenantStatus {
    * @return true if tenant has platform access
    */
   public boolean hasAccess() {
+    return canLogin();
+  }
+
+  /** Check if tenant can log in. */
+  public boolean canLogin() {
+    return this == TRIAL || this == ACTIVE || this == EXPIRED;
+  }
+
+  /** Check if tenant can mutate tenant data. Enforcement is added in TRIAL-10. */
+  public boolean canWrite() {
     return this == TRIAL || this == ACTIVE;
   }
 

--- a/src/main/java/com/fabricmanagement/platform/tenant/dto/CreateTenantRequest.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/dto/CreateTenantRequest.java
@@ -33,8 +33,11 @@ public class CreateTenantRequest {
   /** Custom settings (optional - uses defaults if not provided) */
   private TenantSettings settings;
 
-  /** Trial period in days (default: 14) */
-  @Builder.Default private int trialDays = 14;
+  /** Trial period in days (default: 90) */
+  @Builder.Default private int trialDays = 90;
+
+  /** Whether trial dates should stay null until password setup activation. */
+  @Builder.Default private boolean deferTrialActivation = false;
 
   /** Country code for locale defaults (ISO 3166-1 alpha-2) */
   private String country;

--- a/src/main/java/com/fabricmanagement/platform/tenant/dto/TenantDto.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/dto/TenantDto.java
@@ -30,6 +30,8 @@ public class TenantDto {
   private TenantType type;
   private TenantStatus status;
   private Instant trialEndsAt;
+  private Instant trialStartedAt;
+  private Instant lastActivityAt;
   private String subscriptionPlan;
   private TenantSettings settings;
   private Instant createdAt;
@@ -54,6 +56,8 @@ public class TenantDto {
         .type(tenant.getType())
         .status(tenant.getStatus())
         .trialEndsAt(tenant.getTrialEndsAt())
+        .trialStartedAt(tenant.getTrialStartedAt())
+        .lastActivityAt(tenant.getLastActivityAt())
         .subscriptionPlan(tenant.getSubscriptionPlan())
         .settings(tenant.getSettings())
         .createdAt(tenant.getCreatedAt())

--- a/src/main/java/com/fabricmanagement/platform/tenant/mapper/TenantRowMapper.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/mapper/TenantRowMapper.java
@@ -31,6 +31,18 @@ public class TenantRowMapper implements RowMapper<TenantDto> {
         .type(
             TenantType.valueOf(Objects.requireNonNull(rs.getString("type"), "type column is NULL")))
         .billingEmail(rs.getString("billing_email"))
+        .trialStartedAt(
+            rs.getTimestamp("trial_started_at") != null
+                ? rs.getTimestamp("trial_started_at").toInstant()
+                : null)
+        .lastActivityAt(
+            rs.getTimestamp("last_activity_at") != null
+                ? rs.getTimestamp("last_activity_at").toInstant()
+                : null)
+        .trialEndsAt(
+            rs.getTimestamp("trial_ends_at") != null
+                ? rs.getTimestamp("trial_ends_at").toInstant()
+                : null)
         .isActive(rs.getBoolean("is_active"))
         .build();
   }

--- a/src/main/java/com/fabricmanagement/platform/user/api/controller/UserOnboardingController.java
+++ b/src/main/java/com/fabricmanagement/platform/user/api/controller/UserOnboardingController.java
@@ -51,8 +51,9 @@ public class UserOnboardingController {
    * Complete onboarding for current user.
    *
    * <p>Accepts an optional {@link CompleteOnboardingRequest} body with company enrichment data
-   * (legalName, industry, address, etc.). If the body is absent or null, onboarding is still marked
-   * complete and no enrichment is performed — existing callers remain unaffected.
+   * (legalName, industry, address, etc.) and the current user's personal mobile. If the body is
+   * absent or null, onboarding is still marked complete and no enrichment is performed — existing
+   * callers remain unaffected.
    */
   @PostMapping("/onboarding/complete")
   public ResponseEntity<ApiResponse<UserDto>> completeOnboarding(

--- a/src/main/java/com/fabricmanagement/platform/user/app/UserOnboardingService.java
+++ b/src/main/java/com/fabricmanagement/platform/user/app/UserOnboardingService.java
@@ -51,6 +51,7 @@ public class UserOnboardingService {
   private final ContactService contactService;
   private final OrganizationAddressAssignmentService addressAssignmentService;
   private final OrganizationContactAssignmentService contactAssignmentService;
+  private final UserProfileService userProfileService;
 
   @Transactional(readOnly = true)
   public OnboardingStatusResponse getStatus(UUID userId) {
@@ -91,13 +92,13 @@ public class UserOnboardingService {
     if (user.getOnboardingCompletedAt() != null) {
       log.debug("User already completed onboarding: userId={}", userId);
       if (request != null) {
-        applyEnrichment(tenantId, request);
+        applyEnrichment(tenantId, userId, request);
       }
       return UserDto.from(user, employeeProjectionPort.findByUserId(tenantId, userId).orElse(null));
     }
 
     if (request != null) {
-      applyEnrichment(tenantId, request);
+      applyEnrichment(tenantId, userId, request);
     }
 
     user.completeOnboarding();
@@ -132,10 +133,11 @@ public class UserOnboardingService {
    *   <li>Company contacts (email and/or phone)
    * </ol>
    */
-  private void applyEnrichment(UUID tenantId, CompleteOnboardingRequest request) {
+  private void applyEnrichment(UUID tenantId, UUID userId, CompleteOnboardingRequest request) {
     log.debug("Applying onboarding enrichment: tenantId={}", tenantId);
 
     organizationService.enrichRootOrganization(tenantId, request);
+    saveUserMobile(userId, request);
 
     OrganizationDto rootOrg = organizationService.getRootOrganization().orElse(null);
     if (rootOrg == null) {
@@ -146,6 +148,15 @@ public class UserOnboardingService {
 
     saveHqAddress(orgId, request);
     saveContacts(orgId, request);
+  }
+
+  private void saveUserMobile(UUID userId, CompleteOnboardingRequest request) {
+    if (request.getMobilePhone() == null || request.getMobilePhone().isBlank()) {
+      return;
+    }
+    userProfileService.updatePersonalContact(
+        userId, request.getMobilePhone().trim(), ContactType.MOBILE);
+    log.debug("saveUserMobile: personal mobile assigned, userId={}", userId);
   }
 
   private void saveHqAddress(UUID orgId, CompleteOnboardingRequest req) {

--- a/src/main/java/com/fabricmanagement/platform/user/app/UserProfileService.java
+++ b/src/main/java/com/fabricmanagement/platform/user/app/UserProfileService.java
@@ -187,7 +187,8 @@ public class UserProfileService {
     userContactAssignmentService.assignContact(userId, contact.getId(), false);
   }
 
-  private void updatePersonalContact(UUID userId, String contactValue, ContactType contactType) {
+  @Transactional
+  public void updatePersonalContact(UUID userId, String contactValue, ContactType contactType) {
     Contact contact =
         contactService
             .findByValueAndType(contactValue, contactType)

--- a/src/main/java/com/fabricmanagement/platform/user/dto/CompleteOnboardingRequest.java
+++ b/src/main/java/com/fabricmanagement/platform/user/dto/CompleteOnboardingRequest.java
@@ -118,6 +118,11 @@ public class CompleteOnboardingRequest {
   @Size(max = 20, message = "Phone must not exceed 20 characters")
   private String companyPhone;
 
+  /** Registering user's own mobile phone number (E.164 recommended). */
+  @Size(max = 20, message = "Mobile phone must not exceed 20 characters")
+  @Pattern(regexp = "^\\+[1-9]\\d{1,14}$|^$", message = "Invalid mobile phone format")
+  private String mobilePhone;
+
   // ── Platform modules ─────────────────────────────────────────────────────────
 
   /** Selected OS module codes (e.g. ["FabricOS", "LogiOS"]). */

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -71,7 +71,7 @@ application:
     base-url: ${FRONTEND_URL:${APP_BASE_URL:http://localhost:3000}}
 
   jwt:
-    playground-expiration: ${JWT_PLAYGROUND_EXPIRATION:7776000000} # 90 days
+    playground-expiration: ${JWT_PLAYGROUND_EXPIRATION:1209600000} # 14 days
 
   # Playground/demo seed: clone-time finance + production demo data (DEMO-1).
   # Docker is the playground runtime here, so default ON; override with the env var to disable.

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -83,7 +83,7 @@ application:
   jwt:
     secret: local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm
     expiration: 3600000 # 1 hour for local development
-    playground-expiration: 7776000000 # 90 days for playground demo sessions
+    playground-expiration: 1209600000 # 14 days for playground demo sessions
     refresh-expiration: 2592000000 # 30 days for local development
 
   # Auth cookies: Secure=false so cookies work over http://localhost

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -92,7 +92,7 @@ application:
   jwt:
     secret: ${JWT_SECRET}
     expiration: 900000 # 15 minutes
-    playground-expiration: 7776000000 # 90 days for playground demo sessions
+    playground-expiration: 1209600000 # 14 days for playground demo sessions
     refresh-expiration: 604800000 # 7 days
 
   mail:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -141,6 +141,12 @@ application:
     base-days: ${TRIAL_BASE_DAYS:90}
     dormancy-window-days: ${TRIAL_DORMANCY_WINDOW_DAYS:90}
     hard-cap-months: ${TRIAL_HARD_CAP_MONTHS:18}
+    read-only:
+      allow-paths:
+        - /api/v1/auth/**
+        - /api/v1/public/**
+        - /api/v1/subscriptions/*/activate
+        - /api/v1/subscriptions/**/activate
 
   # Auth cookies (HttpOnly). Set secure=false for local HTTP (e.g. http://localhost).
   auth:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -134,8 +134,13 @@ application:
   jwt:
     secret: ${JWT_SECRET}
     expiration: ${JWT_EXPIRATION:900000} # 15 minutes
-    playground-expiration: ${JWT_PLAYGROUND_EXPIRATION:7776000000} # 90 days
+    playground-expiration: ${JWT_PLAYGROUND_EXPIRATION:1209600000} # 14 days
     refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000} # 7 days
+
+  trial:
+    base-days: ${TRIAL_BASE_DAYS:90}
+    dormancy-window-days: ${TRIAL_DORMANCY_WINDOW_DAYS:90}
+    hard-cap-months: ${TRIAL_HARD_CAP_MONTHS:18}
 
   # Auth cookies (HttpOnly). Set secure=false for local HTTP (e.g. http://localhost).
   auth:

--- a/src/main/resources/db/migration/V20260627090000__trial_activation_lifecycle.sql
+++ b/src/main/resources/db/migration/V20260627090000__trial_activation_lifecycle.sql
@@ -1,0 +1,14 @@
+ALTER TABLE common_tenant.common_tenant
+    ADD COLUMN trial_started_at TIMESTAMPTZ,
+    ADD COLUMN last_activity_at TIMESTAMPTZ;
+
+ALTER TABLE common_tenant.common_tenant
+    DROP CONSTRAINT IF EXISTS chk_tenant_status;
+
+ALTER TABLE common_tenant.common_tenant
+    ADD CONSTRAINT chk_tenant_status
+    CHECK (status IN ('TRIAL', 'ACTIVE', 'EXPIRED', 'SUSPENDED', 'CANCELLED'));
+
+CREATE INDEX IF NOT EXISTS idx_tenant_trial_lifecycle
+    ON common_tenant.common_tenant(status, type, trial_started_at)
+    WHERE is_active = TRUE;

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -806,6 +806,8 @@ class ConstitutionArchTest {
       //   - TenantClonerService          : Onboarding: TEMPLATE→Yeni tenant klon
       //   - PlaygroundTTLReaperService   : Scheduled job: süresi dolan playground tenant'ları
       // temizle
+      //   - TrialLifecycleService        : Scheduled job: registered trial expiry/activity
+      // maintenance
       //   - TenantQueryAdapter           : Port/Adapter: tenant lookup (auth, event yolu)
       //   - CloneTemplateRolesStep       : Onboarding: TEMPLATE rollerini yeni tenant'a kopyala
       //   - SystemDataSourceConfig       : Altyapı: DataSource bean konfigürasyonu
@@ -821,6 +823,8 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("TenantClonerService")
               .and()
               .doNotHaveSimpleName("PlaygroundTTLReaperService")
+              .and()
+              .doNotHaveSimpleName("TrialLifecycleService")
               .and()
               .doNotHaveSimpleName("TenantQueryAdapter")
               .and()

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/JwtContextInterceptorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/JwtContextInterceptorTest.java
@@ -1,0 +1,92 @@
+package com.fabricmanagement.common.infrastructure.web;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
+import com.fabricmanagement.platform.auth.app.JwtService;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class JwtContextInterceptorTest {
+
+  private final JwtService jwtService = org.mockito.Mockito.mock(JwtService.class);
+  private final TenantQueryPort tenantQueryPort = org.mockito.Mockito.mock(TenantQueryPort.class);
+  private final TrialLifecyclePort trialLifecyclePort =
+      org.mockito.Mockito.mock(TrialLifecyclePort.class);
+  private final JwtContextInterceptor interceptor =
+      new JwtContextInterceptor(jwtService, tenantQueryPort, Optional.of(trialLifecyclePort));
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @DisplayName("touches trial activity for regular authenticated tenant requests")
+  void shouldTouchTrialActivityForRegularTenantToken() {
+    UUID tenantId = UUID.randomUUID();
+    arrangeToken(authClaims(tenantId, false, null, null));
+
+    interceptor.preHandle(request(), new MockHttpServletResponse(), new Object());
+
+    verify(trialLifecyclePort).touchTenantActivity(tenantId);
+  }
+
+  @Test
+  @DisplayName("skips trial activity touch for playground tokens")
+  void shouldSkipPlaygroundTokens() {
+    UUID tenantId = UUID.randomUUID();
+    arrangeToken(authClaims(tenantId, true, null, null));
+
+    interceptor.preHandle(request(), new MockHttpServletResponse(), new Object());
+
+    verify(trialLifecyclePort, never()).touchTenantActivity(tenantId);
+  }
+
+  @Test
+  @DisplayName("skips trial activity touch for partner tokens")
+  void shouldSkipPartnerTokens() {
+    UUID tenantId = UUID.randomUUID();
+    arrangeToken(authClaims(tenantId, false, "PARTNER", UUID.randomUUID()));
+
+    interceptor.preHandle(request(), new MockHttpServletResponse(), new Object());
+
+    verify(trialLifecyclePort, never()).touchTenantActivity(tenantId);
+  }
+
+  private void arrangeToken(JwtService.AuthTokenClaims claims) {
+    when(jwtService.validateToken("token")).thenReturn(true);
+    when(jwtService.extractAuthContext("token")).thenReturn(claims);
+    when(jwtService.getTenantUidFromToken("token")).thenReturn("ACME-001");
+  }
+
+  private static MockHttpServletRequest request() {
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/orders");
+    request.addHeader("Authorization", "Bearer token");
+    return request;
+  }
+
+  private static JwtService.AuthTokenClaims authClaims(
+      UUID tenantId, boolean playground, String userType, UUID partnerId) {
+    return new JwtService.AuthTokenClaims(
+        UUID.randomUUID(),
+        "ADMIN",
+        userType,
+        List.of(),
+        null,
+        tenantId,
+        playground,
+        playground ? "guest-123" : null,
+        partnerId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
@@ -1,0 +1,91 @@
+package com.fabricmanagement.common.infrastructure.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.common.infrastructure.web.exception.TenantReadOnlyException;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class TenantWriteGuardInterceptorTest {
+
+  private final TenantAccessPort tenantAccessPort =
+      org.mockito.Mockito.mock(TenantAccessPort.class);
+  private final TrialReadOnlyProperties properties = new TrialReadOnlyProperties();
+  private final TenantWriteGuardInterceptor interceptor =
+      new TenantWriteGuardInterceptor(Optional.of(tenantAccessPort), Optional.of(properties));
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @DisplayName("EXPIRED tenant write is rejected with TENANT_READ_ONLY")
+  void shouldRejectExpiredTenantWrite() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    when(tenantAccessPort.isWritable(tenantId)).thenReturn(false);
+
+    assertThatThrownBy(() -> preHandle("POST", "/api/v1/orders"))
+        .isInstanceOf(TenantReadOnlyException.class)
+        .hasMessage(TenantReadOnlyException.MESSAGE);
+  }
+
+  @Test
+  @DisplayName("EXPIRED tenant GET passes through")
+  void shouldAllowExpiredTenantRead() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    assertThatCode(() -> assertThat(preHandle("GET", "/api/v1/orders")).isTrue())
+        .doesNotThrowAnyException();
+    verify(tenantAccessPort, never()).isWritable(tenantId);
+  }
+
+  @Test
+  @DisplayName("EXPIRED tenant whitelisted POST passes through")
+  void shouldAllowWhitelistedExpiredTenantWrite() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    properties.setAllowPaths(List.of("/api/v1/subscriptions/*/activate", "/api/v1/auth/**"));
+
+    assertThat(preHandle("POST", "/api/v1/subscriptions/123/activate")).isTrue();
+    verify(tenantAccessPort, never()).isWritable(tenantId);
+  }
+
+  @Test
+  @DisplayName("TRIAL or ACTIVE tenant write passes through")
+  void shouldAllowWritableTenantWrite() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    when(tenantAccessPort.isWritable(tenantId)).thenReturn(true);
+
+    assertThat(preHandle("POST", "/api/v1/orders")).isTrue();
+    verify(tenantAccessPort).isWritable(tenantId);
+  }
+
+  @Test
+  @DisplayName("unauthenticated request passes through")
+  void shouldAllowUnauthenticatedRequest() {
+    assertThat(preHandle("POST", "/api/v1/orders")).isTrue();
+    verify(tenantAccessPort, never()).isWritable(org.mockito.ArgumentMatchers.any());
+  }
+
+  private boolean preHandle(String method, String path) {
+    MockHttpServletRequest request = new MockHttpServletRequest(method, path);
+    return interceptor.preHandle(request, new MockHttpServletResponse(), new Object());
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyExceptionHandlerTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyExceptionHandlerTest.java
@@ -1,0 +1,26 @@
+package com.fabricmanagement.common.infrastructure.web.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TenantReadOnlyExceptionHandlerTest {
+
+  @Test
+  @DisplayName("handler emits 403 TENANT_READ_ONLY")
+  void shouldEmitTenantReadOnlyProblemDetail() {
+    GlobalExceptionHandler handler = new GlobalExceptionHandler(null);
+    HttpServletRequest request = org.mockito.Mockito.mock(HttpServletRequest.class);
+    when(request.getRequestURI()).thenReturn("/api/v1/orders");
+
+    ApiProblemDetail response =
+        handler.handleTenantReadOnly(new TenantReadOnlyException(), request);
+
+    assertThat(response.getStatus()).isEqualTo(403);
+    assertThat(response.getCode()).isEqualTo("TENANT_READ_ONLY");
+    assertThat(response.getDetail()).isEqualTo(TenantReadOnlyException.MESSAGE);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
@@ -27,7 +27,7 @@ class JwtServiceTest {
 
   private static final String SECRET = "test-secret-key-must-be-at-least-256-bits-long-for-hs256";
   private static final long ACCESS_TOKEN_EXPIRATION = 900_000L;
-  private static final long PLAYGROUND_TOKEN_EXPIRATION = 7_776_000_000L;
+  private static final long PLAYGROUND_TOKEN_EXPIRATION = 1_209_600_000L;
 
   private final TenantQueryPort tenantQueryPort = org.mockito.Mockito.mock(TenantQueryPort.class);
   private final OrganizationRepository organizationRepository =
@@ -99,7 +99,7 @@ class JwtServiceTest {
         jwtService.secondsUntilExpiry(
             jwtService.generatePlaygroundAccessToken(user, "guest-123", "guest@example.com"));
 
-    assertThat(secondsUntilExpiry).isBetween(7_775_995L, 7_776_000L);
+    assertThat(secondsUntilExpiry).isBetween(1_209_595L, 1_209_600L);
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/platform/auth/app/PasswordSetupServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/PasswordSetupServiceTest.java
@@ -1,0 +1,158 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
+import com.fabricmanagement.platform.auth.domain.RegistrationToken;
+import com.fabricmanagement.platform.auth.domain.RegistrationTokenType;
+import com.fabricmanagement.platform.auth.dto.PasswordSetupRequest;
+import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
+import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
+import com.fabricmanagement.platform.auth.infra.repository.RegistrationTokenRepository;
+import com.fabricmanagement.platform.communication.app.ContactService;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.infra.repository.OrganizationAddressRepository;
+import com.fabricmanagement.platform.organization.infra.repository.OrganizationRepository;
+import com.fabricmanagement.platform.user.api.facade.UserFacade;
+import com.fabricmanagement.platform.user.app.UserContactAssignmentService;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.domain.port.EmployeeProjectionPort;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class PasswordSetupServiceTest {
+
+  @Mock private RegistrationTokenRepository tokenRepository;
+  @Mock private AuthUserRepository authUserRepository;
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private UserFacade userFacade;
+  @Mock private UserRepository userRepository;
+  @Mock private UserContactAssignmentService userContactAssignmentService;
+  @Mock private ContactService contactService;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private JwtService jwtService;
+  @Mock private DomainEventPublisher eventPublisher;
+  @Mock private EntityManager entityManager;
+  @Mock private OrganizationRepository organizationRepository;
+  @Mock private OrganizationAddressRepository organizationAddressRepository;
+  @Mock private TenantQueryPort tenantQueryPort;
+  @Mock private EmployeeProjectionPort employeeProjectionPort;
+  @Mock private TrialLifecyclePort trialLifecyclePort;
+
+  private PasswordSetupService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PasswordSetupService(
+            tokenRepository,
+            authUserRepository,
+            refreshTokenRepository,
+            userFacade,
+            userRepository,
+            userContactAssignmentService,
+            contactService,
+            passwordEncoder,
+            jwtService,
+            eventPublisher,
+            entityManager,
+            organizationRepository,
+            organizationAddressRepository,
+            tenantQueryPort,
+            employeeProjectionPort,
+            trialLifecyclePort);
+    ReflectionTestUtils.setField(service, "refreshTokenExpiration", 604_800_000L);
+    ReflectionTestUtils.setField(service, "accessTokenExpiration", 900_000L);
+  }
+
+  @Test
+  @DisplayName("self-service password setup activates the tenant trial")
+  void shouldActivateSelfServiceTrialOnPasswordSetup() {
+    PasswordSetupFixture fixture = arrangePasswordSetup(RegistrationTokenType.SELF_SERVICE);
+
+    service.setupPassword(fixture.request(), "127.0.0.1");
+
+    verify(trialLifecyclePort).startSelfServiceTrialIfNeeded(fixture.tenantId());
+  }
+
+  @Test
+  @DisplayName("sales-led password setup leaves trial activation unchanged")
+  void shouldNotActivateSalesLedTrialOnPasswordSetup() {
+    PasswordSetupFixture fixture = arrangePasswordSetup(RegistrationTokenType.SALES_LED);
+
+    service.setupPassword(fixture.request(), "127.0.0.1");
+
+    verify(trialLifecyclePort, never()).startSelfServiceTrialIfNeeded(any());
+  }
+
+  private PasswordSetupFixture arrangePasswordSetup(RegistrationTokenType tokenType) {
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    UUID organizationId = UUID.randomUUID();
+    String contactValue = "admin@example.com";
+    RegistrationToken token = RegistrationToken.create(contactValue, tokenType);
+    PasswordSetupRequest request =
+        PasswordSetupRequest.builder().token(token.getToken()).password("Str0ngPassword!").build();
+    UserDto userDto =
+        UserDto.builder()
+            .id(userId)
+            .tenantId(tenantId)
+            .organizationId(organizationId)
+            .hasCompletedOnboarding(true)
+            .build();
+    User user = buildVerifiedUser(tenantId, userId, organizationId, contactValue);
+
+    when(tokenRepository.findByToken(token.getToken())).thenReturn(Optional.of(token));
+    when(userFacade.findByContactValue(contactValue)).thenReturn(Optional.of(userDto));
+    when(authUserRepository.existsByUserId(userId)).thenReturn(false);
+    when(tenantQueryPort.findById(tenantId))
+        .thenReturn(Optional.of(new TenantReference(tenantId, "ACME-001", "Acme", "ACME")));
+    when(userRepository.findByTenantIdAndContactValue(tenantId, contactValue))
+        .thenReturn(Optional.of(user));
+    when(passwordEncoder.encode(request.getPassword())).thenReturn("hash");
+    when(jwtService.generateAccessToken(user)).thenReturn("access-token");
+    when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
+    when(employeeProjectionPort.findByUserId(tenantId, userId)).thenReturn(Optional.empty());
+
+    return new PasswordSetupFixture(request, tenantId);
+  }
+
+  private static User buildVerifiedUser(
+      UUID tenantId, UUID userId, UUID organizationId, String contactValue) {
+    Contact contact =
+        Contact.builder()
+            .contactType(ContactType.EMAIL)
+            .contactValue(contactValue)
+            .isVerified(true)
+            .build();
+    User user = User.create("Admin", "User", organizationId);
+    user.setId(userId);
+    user.setTenantId(tenantId);
+    user.setUid("ACME-001-USER-00001");
+    user.completeOnboarding();
+    user.getUserContacts().add(UserContact.builder().contact(contact).isDefault(true).build());
+    return user;
+  }
+
+  private record PasswordSetupFixture(PasswordSetupRequest request, UUID tenantId) {}
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/onboarding/CreateSubscriptionsStepTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/onboarding/CreateSubscriptionsStepTest.java
@@ -1,0 +1,46 @@
+package com.fabricmanagement.platform.auth.app.onboarding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.subscription.app.SubscriptionService;
+import com.fabricmanagement.platform.subscription.dto.CreateInitialSubscriptionsResult;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CreateSubscriptionsStepTest {
+
+  private final SubscriptionService subscriptionService =
+      org.mockito.Mockito.mock(SubscriptionService.class);
+  private final CreateSubscriptionsStep step = new CreateSubscriptionsStep(subscriptionService);
+
+  @Test
+  @DisplayName("uses the onboarding trial window for self-service subscriptions")
+  void shouldUseContextTrialDaysForSelfServiceSubscriptions() {
+    UUID tenantId = UUID.randomUUID();
+    Instant trialEndsAt = Instant.parse("2026-09-25T00:00:00Z");
+    OnboardingContext context = new OnboardingContext();
+    context.setTenantId(tenantId);
+    context.setSalesLed(false);
+    context.setTrialDays(90);
+    context.setSelectedOS(List.of("FabricOS"));
+    when(subscriptionService.createInitialSubscriptions(
+            eq(tenantId), eq(List.of("FabricOS")), eq(90)))
+        .thenReturn(
+            CreateInitialSubscriptionsResult.builder()
+                .osCodes(List.of("FabricOS"))
+                .trialEndsAt(trialEndsAt)
+                .build());
+
+    step.execute(context);
+
+    verify(subscriptionService).createInitialSubscriptions(tenantId, List.of("FabricOS"), 90);
+    assertThat(context.getTrialEndsAt()).isEqualTo(trialEndsAt);
+    assertThat(context.getSubscriptionOsCodes()).containsExactly("FabricOS");
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/onboarding/CreateTenantStepTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/onboarding/CreateTenantStepTest.java
@@ -1,0 +1,49 @@
+package com.fabricmanagement.platform.auth.app.onboarding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.tenant.api.facade.TenantFacade;
+import com.fabricmanagement.platform.tenant.dto.CreateTenantRequest;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class CreateTenantStepTest {
+
+  private final TenantFacade tenantFacade = org.mockito.Mockito.mock(TenantFacade.class);
+  private final CreateTenantStep step = new CreateTenantStep(tenantFacade);
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @DisplayName("self-service tenant creation defers trial activation until password setup")
+  void shouldDeferTrialActivationForSelfServiceTenant() {
+    UUID tenantId = UUID.randomUUID();
+    OnboardingContext context = new OnboardingContext();
+    context.setOrganizationName("Acme Textiles");
+    context.setOrganizationEmail("billing@example.com");
+    context.setCountry("TR");
+    context.setTrialDays(90);
+    context.setSalesLed(false);
+    when(tenantFacade.createTenant(org.mockito.ArgumentMatchers.any(CreateTenantRequest.class)))
+        .thenReturn(TenantDto.builder().id(tenantId).uid("ACME-001").build());
+
+    step.execute(context);
+
+    ArgumentCaptor<CreateTenantRequest> requestCaptor =
+        ArgumentCaptor.forClass(CreateTenantRequest.class);
+    verify(tenantFacade).createTenant(requestCaptor.capture());
+    assertThat(requestCaptor.getValue().getTrialDays()).isEqualTo(90);
+    assertThat(requestCaptor.getValue().isDeferTrialActivation()).isTrue();
+    assertThat(context.getTenantId()).isEqualTo(tenantId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/PlaygroundTTLReaperServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/PlaygroundTTLReaperServiceTest.java
@@ -8,11 +8,13 @@ import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
 import java.util.function.Function;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -54,6 +56,30 @@ class PlaygroundTTLReaperServiceTest {
       reaper.reapExpiredPlaygrounds();
 
       verify(mockJdbc).update(anyString(), any(java.sql.Timestamp.class));
+    }
+
+    @Test
+    @DisplayName("Should target only playground tenants")
+    @SuppressWarnings("unchecked")
+    void shouldNeverReapRegisteredTenants() {
+      JdbcTemplate mockJdbc = mock(JdbcTemplate.class);
+      when(mockJdbc.update(anyString(), any(java.sql.Timestamp.class))).thenReturn(3);
+
+      when(systemExecutor.executeInTransaction(any(Function.class)))
+          .thenAnswer(
+              invocation -> {
+                Function<JdbcTemplate, Integer> callback = invocation.getArgument(0);
+                return callback.apply(mockJdbc);
+              });
+
+      reaper.reapExpiredPlaygrounds();
+
+      ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+      verify(mockJdbc).update(sqlCaptor.capture(), any(java.sql.Timestamp.class));
+      Assertions.assertThat(sqlCaptor.getValue()).contains("WHERE type = 'PLAYGROUND'");
+      Assertions.assertThat(sqlCaptor.getValue()).doesNotContain("status = 'TRIAL'");
+      Assertions.assertThat(sqlCaptor.getValue()).doesNotContain("status = 'EXPIRED'");
+      Assertions.assertThat(sqlCaptor.getValue()).doesNotContain("status = 'ACTIVE'");
     }
 
     @Test

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -31,12 +32,13 @@ import org.springframework.test.util.ReflectionTestUtils;
 class TrialLifecycleServiceTest {
 
   @Mock private SystemTransactionExecutor systemExecutor;
+  @Mock private CacheManager cacheManager;
 
   private TrialLifecycleService service;
 
   @BeforeEach
   void setUp() {
-    service = new TrialLifecycleService(systemExecutor);
+    service = new TrialLifecycleService(systemExecutor, cacheManager);
     ReflectionTestUtils.setField(service, "baseDays", 90);
     ReflectionTestUtils.setField(service, "dormancyWindowDays", 90);
     ReflectionTestUtils.setField(service, "hardCapMonths", 18);

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
@@ -1,0 +1,154 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TrialLifecycleServiceTest {
+
+  @Mock private SystemTransactionExecutor systemExecutor;
+
+  private TrialLifecycleService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new TrialLifecycleService(systemExecutor);
+    ReflectionTestUtils.setField(service, "baseDays", 90);
+    ReflectionTestUtils.setField(service, "dormancyWindowDays", 90);
+    ReflectionTestUtils.setField(service, "hardCapMonths", 18);
+  }
+
+  @Test
+  @DisplayName("self-service activation starts trial only for unactivated registered trials")
+  void shouldStartSelfServiceTrialIfNeeded() {
+    UUID tenantId = UUID.randomUUID();
+    when(systemExecutor.executeUpdate(anyString(), any(), any(), any(), eq(tenantId)))
+        .thenReturn(1);
+
+    int affected = service.startSelfServiceTrialIfNeeded(tenantId);
+
+    assertThat(affected).isEqualTo(1);
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(systemExecutor).executeUpdate(sqlCaptor.capture(), any(), any(), any(), eq(tenantId));
+    assertThat(sqlCaptor.getValue()).contains("type = 'REGULAR'");
+    assertThat(sqlCaptor.getValue()).contains("status = 'TRIAL'");
+    assertThat(sqlCaptor.getValue()).contains("trial_started_at IS NULL");
+  }
+
+  @Test
+  @DisplayName("active trials slide to last activity plus dormancy window")
+  void shouldExtendEffectiveExpiryFromLastActivity() {
+    Instant now = Instant.parse("2026-06-27T12:00:00Z");
+    Instant started = now.minus(30, ChronoUnit.DAYS);
+    Instant lastActivity = now.minus(1, ChronoUnit.DAYS);
+
+    TrialLifecycleService.TrialDecision decision =
+        service.evaluate(
+            new TrialLifecycleService.TrialWindow(UUID.randomUUID(), started, lastActivity), now);
+
+    assertThat(decision.status()).isEqualTo(TenantStatus.TRIAL);
+    assertThat(decision.effectiveExpiry()).isEqualTo(lastActivity.plus(90, ChronoUnit.DAYS));
+  }
+
+  @Test
+  @DisplayName("dormant trials expire instead of being deleted")
+  void shouldExpireDormantTrial() {
+    Instant now = Instant.parse("2026-06-27T12:00:00Z");
+    Instant started = now.minus(120, ChronoUnit.DAYS);
+    Instant lastActivity = now.minus(91, ChronoUnit.DAYS);
+
+    TrialLifecycleService.TrialDecision decision =
+        service.evaluate(
+            new TrialLifecycleService.TrialWindow(UUID.randomUUID(), started, lastActivity), now);
+
+    assertThat(decision.status()).isEqualTo(TenantStatus.EXPIRED);
+    assertThat(decision.effectiveExpiry()).isEqualTo(lastActivity.plus(90, ChronoUnit.DAYS));
+  }
+
+  @Test
+  @DisplayName("hard cap expires trials even with recent activity")
+  void shouldExpireAtHardCap() {
+    Instant now = Instant.parse("2026-06-27T12:00:00Z");
+    Instant started = now.minus(19 * 31L, ChronoUnit.DAYS);
+    Instant lastActivity = now.minus(1, ChronoUnit.DAYS);
+
+    TrialLifecycleService.TrialDecision decision =
+        service.evaluate(
+            new TrialLifecycleService.TrialWindow(UUID.randomUUID(), started, lastActivity), now);
+
+    assertThat(decision.status()).isEqualTo(TenantStatus.EXPIRED);
+    assertThat(decision.effectiveExpiry())
+        .isEqualTo(started.atOffset(java.time.ZoneOffset.UTC).plusMonths(18).toInstant());
+  }
+
+  @Test
+  @DisplayName("activity touch is throttled to one write per tenant per UTC day")
+  void shouldThrottleActivityTouch() {
+    UUID tenantId = UUID.randomUUID();
+
+    service.touchTenantActivity(tenantId);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(systemExecutor)
+        .executeUpdate(
+            sqlCaptor.capture(), any(Timestamp.class), eq(tenantId), any(Timestamp.class));
+    assertThat(sqlCaptor.getValue()).contains("type = 'REGULAR'");
+    assertThat(sqlCaptor.getValue()).contains("status = 'TRIAL'");
+    assertThat(sqlCaptor.getValue()).contains("trial_started_at IS NOT NULL");
+    assertThat(sqlCaptor.getValue()).contains("last_activity_at IS NULL OR last_activity_at < ?");
+  }
+
+  @Test
+  @DisplayName("scheduled refresh updates only registered activated trial tenants")
+  @SuppressWarnings("unchecked")
+  void shouldRefreshRegisteredActivatedTrialWindows() {
+    UUID tenantId = UUID.randomUUID();
+    JdbcTemplate jdbc = mock(JdbcTemplate.class);
+    TrialLifecycleService.TrialWindow dormantTrial =
+        new TrialLifecycleService.TrialWindow(
+            tenantId,
+            Instant.now().minus(120, ChronoUnit.DAYS),
+            Instant.now().minus(91, ChronoUnit.DAYS));
+    when(jdbc.query(anyString(), any(RowMapper.class))).thenReturn(List.of(dormantTrial));
+    when(jdbc.update(anyString(), eq("EXPIRED"), any(Timestamp.class), eq(tenantId))).thenReturn(1);
+    when(systemExecutor.executeInTransaction(any(Function.class)))
+        .thenAnswer(
+            invocation -> {
+              Function<JdbcTemplate, Integer> callback = invocation.getArgument(0);
+              return callback.apply(jdbc);
+            });
+
+    service.refreshTrialWindows();
+
+    ArgumentCaptor<String> selectSqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbc).query(selectSqlCaptor.capture(), any(RowMapper.class));
+    assertThat(selectSqlCaptor.getValue()).contains("type = 'REGULAR'");
+    assertThat(selectSqlCaptor.getValue()).contains("status = 'TRIAL'");
+    assertThat(selectSqlCaptor.getValue()).contains("trial_started_at IS NOT NULL");
+    verify(jdbc).update(anyString(), eq("EXPIRED"), any(Timestamp.class), eq(tenantId));
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/adapter/TenantAccessAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/adapter/TenantAccessAdapterTest.java
@@ -1,0 +1,57 @@
+package com.fabricmanagement.platform.tenant.app.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.tenant.app.TenantSystemService;
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.annotation.Cacheable;
+
+class TenantAccessAdapterTest {
+
+  private final TenantSystemService tenantSystemService =
+      org.mockito.Mockito.mock(TenantSystemService.class);
+  private final TenantAccessAdapter adapter = new TenantAccessAdapter(tenantSystemService);
+
+  @Test
+  @DisplayName("isWritable follows TenantStatus.canWrite")
+  void shouldReturnWritableDecisionFromTenantStatus() {
+    assertWritable(TenantStatus.TRIAL, true);
+    assertWritable(TenantStatus.ACTIVE, true);
+    assertWritable(TenantStatus.EXPIRED, false);
+    assertWritable(TenantStatus.SUSPENDED, false);
+  }
+
+  @Test
+  @DisplayName("unknown tenant fails open")
+  void shouldFailOpenForUnknownTenant() {
+    UUID tenantId = UUID.randomUUID();
+    when(tenantSystemService.findById(tenantId)).thenReturn(Optional.empty());
+
+    assertThat(adapter.isWritable(tenantId)).isTrue();
+  }
+
+  @Test
+  @DisplayName("isWritable is cacheable")
+  void shouldBeCacheable() throws NoSuchMethodException {
+    Method method = TenantAccessAdapter.class.getMethod("isWritable", UUID.class);
+    Cacheable cacheable = method.getAnnotation(Cacheable.class);
+
+    assertThat(cacheable).isNotNull();
+    assertThat(cacheable.value()).containsExactly("tenant-writable");
+  }
+
+  private void assertWritable(TenantStatus status, boolean expected) {
+    UUID tenantId = UUID.randomUUID();
+    when(tenantSystemService.findById(tenantId))
+        .thenReturn(Optional.of(TenantDto.builder().id(tenantId).status(status).build()));
+
+    assertThat(adapter.isWritable(tenantId)).isEqualTo(expected);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/domain/TenantStatusTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/domain/TenantStatusTest.java
@@ -1,0 +1,29 @@
+package com.fabricmanagement.platform.tenant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TenantStatusTest {
+
+  @Test
+  @DisplayName("TRIAL, ACTIVE, and EXPIRED tenants can login")
+  void shouldAllowLoginForReadableStatuses() {
+    assertThat(TenantStatus.TRIAL.canLogin()).isTrue();
+    assertThat(TenantStatus.ACTIVE.canLogin()).isTrue();
+    assertThat(TenantStatus.EXPIRED.canLogin()).isTrue();
+    assertThat(TenantStatus.SUSPENDED.canLogin()).isFalse();
+    assertThat(TenantStatus.CANCELLED.canLogin()).isFalse();
+  }
+
+  @Test
+  @DisplayName("only TRIAL and ACTIVE tenants can write")
+  void shouldAllowWritesOnlyForTrialAndActive() {
+    assertThat(TenantStatus.TRIAL.canWrite()).isTrue();
+    assertThat(TenantStatus.ACTIVE.canWrite()).isTrue();
+    assertThat(TenantStatus.EXPIRED.canWrite()).isFalse();
+    assertThat(TenantStatus.SUSPENDED.canWrite()).isFalse();
+    assertThat(TenantStatus.CANCELLED.canWrite()).isFalse();
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/domain/TenantTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/domain/TenantTest.java
@@ -1,0 +1,36 @@
+package com.fabricmanagement.platform.tenant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TenantTest {
+
+  @Test
+  @DisplayName("new self-service tenant can remain unactivated before password setup")
+  void shouldAllowNullTrialActivationFieldsBeforeActivation() {
+    Tenant tenant = Tenant.create("Acme Textiles", "ACME-001");
+
+    assertThat(tenant.getTrialStartedAt()).isNull();
+    assertThat(tenant.getLastActivityAt()).isNull();
+    assertThat(tenant.getTrialEndsAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("startTrialNow starts the trial clock and stores effective expiry")
+  void shouldStartTrialNow() {
+    Tenant tenant = Tenant.create("Acme Textiles", "ACME-001");
+    Instant before = Instant.now();
+
+    tenant.startTrialNow(90);
+
+    assertThat(tenant.getStatus()).isEqualTo(TenantStatus.TRIAL);
+    assertThat(tenant.getTrialStartedAt()).isBetween(before, Instant.now());
+    assertThat(tenant.getLastActivityAt()).isEqualTo(tenant.getTrialStartedAt());
+    assertThat(Duration.between(tenant.getTrialStartedAt(), tenant.getTrialEndsAt()).toDays())
+        .isEqualTo(90);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/user/app/UserOnboardingServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/user/app/UserOnboardingServiceTest.java
@@ -1,0 +1,135 @@
+package com.fabricmanagement.platform.user.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.communication.app.AddressService;
+import com.fabricmanagement.platform.communication.app.ContactService;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.app.OrganizationAddressAssignmentService;
+import com.fabricmanagement.platform.organization.app.OrganizationContactAssignmentService;
+import com.fabricmanagement.platform.organization.app.OrganizationService;
+import com.fabricmanagement.platform.organization.dto.OrganizationDto;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.port.EmployeeProjectionPort;
+import com.fabricmanagement.platform.user.dto.CompleteOnboardingRequest;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserOnboardingService")
+class UserOnboardingServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID USER_ID = UUID.randomUUID();
+  private static final UUID ORG_ID = UUID.randomUUID();
+
+  @Mock private UserRepository userRepository;
+  @Mock private EmployeeProjectionPort employeeProjectionPort;
+  @Mock private DomainEventPublisher eventPublisher;
+  @Mock private OrganizationService organizationService;
+  @Mock private AddressService addressService;
+  @Mock private ContactService contactService;
+  @Mock private OrganizationAddressAssignmentService addressAssignmentService;
+  @Mock private OrganizationContactAssignmentService contactAssignmentService;
+  @Mock private UserProfileService userProfileService;
+
+  @InjectMocks private UserOnboardingService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @DisplayName("completeOnboarding stores mobilePhone as current user's personal mobile")
+  void completeOnboarding_storesMobilePhoneAsCurrentUserPersonalMobile() {
+    User user = user();
+    CompleteOnboardingRequest request =
+        CompleteOnboardingRequest.builder().mobilePhone(" +905551234567 ").build();
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(user));
+    when(organizationService.getRootOrganization())
+        .thenReturn(Optional.of(OrganizationDto.builder().id(ORG_ID).tenantId(TENANT_ID).build()));
+    when(userRepository.save(user)).thenReturn(user);
+    when(employeeProjectionPort.findByUserId(TENANT_ID, USER_ID)).thenReturn(Optional.empty());
+
+    service.completeOnboarding(USER_ID, request);
+
+    verify(userProfileService).updatePersonalContact(USER_ID, "+905551234567", ContactType.MOBILE);
+    verify(contactService, never()).createContact(any(), any(), any(), any(), any());
+    verify(contactAssignmentService, never()).assignContact(any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("completeOnboarding does not create a personal mobile when mobilePhone is absent")
+  void completeOnboarding_skipsPersonalMobileWhenMobilePhoneAbsent() {
+    User user = user();
+    CompleteOnboardingRequest request = CompleteOnboardingRequest.builder().build();
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(user));
+    when(organizationService.getRootOrganization())
+        .thenReturn(Optional.of(OrganizationDto.builder().id(ORG_ID).tenantId(TENANT_ID).build()));
+    when(userRepository.save(user)).thenReturn(user);
+    when(employeeProjectionPort.findByUserId(TENANT_ID, USER_ID)).thenReturn(Optional.empty());
+
+    service.completeOnboarding(USER_ID, request);
+
+    verify(userProfileService, never()).updatePersonalContact(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("completeOnboarding keeps company phone on organization contacts")
+  void completeOnboarding_keepsCompanyPhoneOnOrganizationContacts() {
+    User user = user();
+    CompleteOnboardingRequest request =
+        CompleteOnboardingRequest.builder()
+            .mobilePhone("+905551234567")
+            .companyPhone("+902121234567")
+            .build();
+    var companyContact =
+        com.fabricmanagement.platform.communication.domain.Contact.builder()
+            .contactValue("+902121234567")
+            .contactType(ContactType.MOBILE)
+            .build();
+    companyContact.setId(UUID.randomUUID());
+    companyContact.setTenantId(TENANT_ID);
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(user));
+    when(organizationService.getRootOrganization())
+        .thenReturn(Optional.of(OrganizationDto.builder().id(ORG_ID).tenantId(TENANT_ID).build()));
+    when(contactService.createContact(
+            eq("+902121234567"), eq(ContactType.MOBILE), eq("Organization"), eq(false), eq(null)))
+        .thenReturn(companyContact);
+    when(userRepository.save(user)).thenReturn(user);
+    when(employeeProjectionPort.findByUserId(TENANT_ID, USER_ID)).thenReturn(Optional.empty());
+
+    service.completeOnboarding(USER_ID, request);
+
+    verify(userProfileService).updatePersonalContact(USER_ID, "+905551234567", ContactType.MOBILE);
+    verify(contactAssignmentService).assignContact(ORG_ID, companyContact.getId(), false, null);
+  }
+
+  private static User user() {
+    User user = User.create("First", "Last", ORG_ID);
+    user.setId(USER_ID);
+    user.setTenantId(TENANT_ID);
+    return user;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/user/app/UserProfileServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/user/app/UserProfileServiceTest.java
@@ -4,11 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
 import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.domain.event.UserProfileUpdatedEvent;
 import com.fabricmanagement.platform.user.domain.port.EmployeeMutationPort;
@@ -201,6 +204,49 @@ class UserProfileServiceTest {
       verify(userContactAssignmentService)
           .assignContact(eq(USER_ID), eq(contact.getId()), eq(false));
       assertThat(result.getId()).isEqualTo(USER_ID);
+    }
+  }
+
+  @Nested
+  @DisplayName("updatePersonalContact")
+  class UpdatePersonalContact {
+
+    @Test
+    void createsAndAssignsPersonalMobileWhenMissing() {
+      Contact contact =
+          Contact.builder().contactValue("+905551234567").contactType(ContactType.MOBILE).build();
+      contact.setId(UUID.randomUUID());
+      contact.setTenantId(TENANT_ID);
+      when(contactService.findByValueAndType("+905551234567", ContactType.MOBILE))
+          .thenReturn(Optional.empty());
+      when(contactService.createContact(
+              "+905551234567", ContactType.MOBILE, "Personal mobile", true, null))
+          .thenReturn(contact);
+      when(userContactAssignmentService.existsUserContact(USER_ID, contact.getId()))
+          .thenReturn(false);
+
+      service.updatePersonalContact(USER_ID, "+905551234567", ContactType.MOBILE);
+
+      verify(contactService)
+          .createContact("+905551234567", ContactType.MOBILE, "Personal mobile", true, null);
+      verify(userContactAssignmentService).assignContact(USER_ID, contact.getId(), false);
+    }
+
+    @Test
+    void doesNotDuplicateExistingPersonalMobileAssignment() {
+      Contact contact =
+          Contact.builder().contactValue("+905551234567").contactType(ContactType.MOBILE).build();
+      contact.setId(UUID.randomUUID());
+      contact.setTenantId(TENANT_ID);
+      when(contactService.findByValueAndType("+905551234567", ContactType.MOBILE))
+          .thenReturn(Optional.of(contact));
+      when(userContactAssignmentService.existsUserContact(USER_ID, contact.getId()))
+          .thenReturn(true);
+
+      service.updatePersonalContact(USER_ID, "+905551234567", ContactType.MOBILE);
+
+      verify(contactService, never()).createContact(any(), any(), any(), any(), any());
+      verify(userContactAssignmentService, never()).assignContact(any(), any(), any());
     }
   }
 }


### PR DESCRIPTION
Add nullable mobilePhone to CompleteOnboardingRequest (max 20, phone pattern). UserOnboardingService.completeOnboarding persists a non-blank mobilePhone as the current user's personal MOBILE contact via the existing UserProfileService.updatePersonalContact path — the same contact that Settings > profile edits, so there is no duplicate field. updatePersonalContact is made public so onboarding and profile share one path. Mobile is record data only; no SMS/OTP wiring (email remains the verification channel).

Tests: onboarding mobile persistence, absence, company-contact separation, idempotent re-assignment. openapi snapshot updated.