### PR TITLE
feat(trial): go-real transition — purge demo data, flip to real mode,…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -10,26 +10,12 @@ servers:
 - description: Current host
   url: /
 tags:
-- description: FX Exposure summary operations
-  name: Finance - FX Exposure
 - description: Mobile Offline Synchronization API
   name: Offline Sync
-- description: Stock Reservation and Lot Engine API
-  name: IWM Stock Reservation
-- description: Dashboard widget metrikleri
-  name: FlowBoard — Dashboard
-- description: Work Order operations
-  name: Work Order
 - description: Payment operations
   name: Payment
 - description: Manage certifications for trading partners
   name: Partner Certifications
-- description: Notification management and preferences
-  name: Notifications
-- description: Financial period close and FX revaluation
-  name: FinancialPeriod
-- description: Organization Contact operations
-  name: Organization Contact
 - description: Cross-context analytics APIs
   name: Analytics
 - description: "B2B partner management - suppliers, customers, fason partners"
@@ -44,38 +30,20 @@ tags:
   name: Inventory Balance
 - description: Cash flow forecasting operations
   name: Finance - Cash Flow
-- description: Approval Request operations
-  name: Approval Request
-- description: Physical stock unit lifecycle management
-  name: StockUnit
-- description: Procurement Purchase Order API
-  name: Purchase Order
-- description: Partner portal user management
-  name: Partner Users
-- description: Payroll Self Service operations
-  name: Payroll Self Service
 - description: IWM Warehouse Location Management API
   name: IWM Location
 - description: Recurring task templates
   name: FlowBoard — Recurring Tasks
-- description: Employee Profile operations
-  name: Employee Profile
-- description: Goods Receipt operations
-  name: Goods Receipt
 - description: Tenant Settings operations
   name: Tenant Settings
 - description: Organization operations
   name: Organization
-- description: Automation rules management
-  name: FlowBoard — Otomasyon
 - description: Inventory Transaction operations
   name: Inventory Transaction
 - description: Fiber operations
   name: Fiber
 - description: Policy operations
   name: Policy
-- description: Board management and kanban view
-  name: FlowBoard — Board
 - description: Quote management with pricing engine integration
   name: Quotes
 - description: Fiber Request Platform operations
@@ -88,6 +56,84 @@ tags:
   name: Address Validation
 - description: Batch Lineage operations
   name: Batch Lineage
+- description: Address operations
+  name: Address
+- description: Permission Management operations
+  name: Permission Management
+- description: Invoice operations
+  name: Invoice
+- description: Fiber Request operations
+  name: Fiber Request
+- description: Contact operations
+  name: Contact
+- description: Platform Notification operations
+  name: Platform Notification
+- description: Task management and status updates
+  name: FlowBoard — Task
+- description: Audit operations
+  name: Audit
+- description: WhatsApp Business API webhook endpoints
+  name: WhatsApp Webhooks
+- description: User performance leaderboard
+  name: FlowBoard — Performance
+- description: Tenant go-real transition operations
+  name: Tenant Go Real
+- description: Subcontract Order operations
+  name: Subcontract Order
+- description: Fiber Test Result operations
+  name: Fiber Test Result
+- description: User Contact operations
+  name: User Contact
+- description: User Promotion operations
+  name: User Promotion
+- description: Tenant Seed operations
+  name: Tenant Seed
+- description: "Self-service tenant registration. No authentication required. Creates\
+    \ tenant, company, admin user, FabricOS trial, and sends setup link by email.\
+    \ Email link click = email verified."
+  name: Public Signup
+- description: Manage certifications for organizations
+  name: Organization Certifications
+- description: Department operations
+  name: Department
+- description: Role operations
+  name: Role
+- description: User operations
+  name: User
+- description: Supplier Quote Management API
+  name: Supplier Quote
+- description: FX Exposure summary operations
+  name: Finance - FX Exposure
+- description: Stock Reservation and Lot Engine API
+  name: IWM Stock Reservation
+- description: Dashboard widget metrikleri
+  name: FlowBoard — Dashboard
+- description: Work Order operations
+  name: Work Order
+- description: Notification management and preferences
+  name: Notifications
+- description: Financial period close and FX revaluation
+  name: FinancialPeriod
+- description: Organization Contact operations
+  name: Organization Contact
+- description: Approval Request operations
+  name: Approval Request
+- description: Physical stock unit lifecycle management
+  name: StockUnit
+- description: Procurement Purchase Order API
+  name: Purchase Order
+- description: Partner portal user management
+  name: Partner Users
+- description: Payroll Self Service operations
+  name: Payroll Self Service
+- description: Employee Profile operations
+  name: Employee Profile
+- description: Goods Receipt operations
+  name: Goods Receipt
+- description: Automation rules management
+  name: FlowBoard — Otomasyon
+- description: Board management and kanban view
+  name: FlowBoard — Board
 - description: Fiber Quality Standard operations
   name: Fiber Quality Standard
 - description: Company Type operations
@@ -98,8 +144,6 @@ tags:
     \ user, subscriptions, and sends welcome email with setup link. Requires platform\
     \ admin in production."
   name: Tenant Onboarding (Admin)
-- description: Address operations
-  name: Address
 - description: Task Template operations
   name: Task Template
 - description: Tenant management operations (PLATFORM_ADMIN only)
@@ -114,10 +158,6 @@ tags:
   name: Health
 - description: Subscription operations
   name: Subscription
-- description: Permission Management operations
-  name: Permission Management
-- description: Invoice operations
-  name: Invoice
 - description: Fabric A I operations
   name: Fabric A I
 - description: Recipe operations
@@ -126,32 +166,18 @@ tags:
   name: Registration
 - description: Multilingual and localization management
   name: i18n
-- description: Fiber Request operations
-  name: Fiber Request
-- description: Contact operations
-  name: Contact
 - description: Product Batch Inventory & Lifecycle Management API
   name: Batch
 - description: Hr Policy Pack operations
   name: Hr Policy Pack
 - description: Whisper operations
   name: Whisper
-- description: Platform Notification operations
-  name: Platform Notification
-- description: Task management and status updates
-  name: FlowBoard — Task
-- description: Audit operations
-  name: Audit
 - description: Endpoints for PLG Simulation Playground
   name: Playground Auth
 - description: Sample request and delivery management
   name: Sample Management
-- description: WhatsApp Business API webhook endpoints
-  name: WhatsApp Webhooks
 - description: Production Output operations
   name: Production Output
-- description: User performance leaderboard
-  name: FlowBoard — Performance
 - description: Kullanici dashboard yapilandirmasi ve widget yonetimi
   name: FlowBoard — Dashboard
 - description: Tenant-specific quality grading system management
@@ -162,50 +188,26 @@ tags:
   name: User Work Location
 - description: User Nav Preferences operations
   name: User Nav Preferences
-- description: Subcontract Order operations
-  name: Subcontract Order
 - description: Notification operations
   name: Notification
-- description: Fiber Test Result operations
-  name: Fiber Test Result
-- description: User Contact operations
-  name: User Contact
 - description: Sales order management with TradingPartner integration
   name: Sales Orders
 - description: Sales Product operations
   name: Sales Product
-- description: User Promotion operations
-  name: User Promotion
 - description: User Onboarding operations
   name: User Onboarding
 - description: Platform Admin operations
   name: Platform Admin
-- description: Tenant Seed operations
-  name: Tenant Seed
-- description: "Self-service tenant registration. No authentication required. Creates\
-    \ tenant, company, admin user, FabricOS trial, and sends setup link by email.\
-    \ Email link click = email verified."
-  name: Public Signup
-- description: Manage certifications for organizations
-  name: Organization Certifications
-- description: Department operations
-  name: Department
 - description: User Address operations
   name: User Address
 - description: User workload analysis
   name: FlowBoard — Workload
 - description: Read-only accounts receivable intelligence
   name: Receivables Insights
-- description: Role operations
-  name: Role
-- description: User operations
-  name: User
 - description: Exchange Rate operations
   name: Exchange Rate
 - description: Password operations
   name: Password
-- description: Supplier Quote Management API
-  name: Supplier Quote
 paths:
   /api/v1/admin/onboarding/tenant:
     post:
@@ -39802,6 +39804,74 @@ paths:
       summary: Push offline data to backend
       tags:
       - Offline Sync
+  /api/v1/tenant/go-real:
+    post:
+      operationId: goReal
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CompleteOnboardingRequest"
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseGoRealResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      tags:
+      - Tenant Go Real
   /api/v1/webhooks/whatsapp:
     get:
       description: Meta webhook verification endpoint (GET)
@@ -41790,6 +41860,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/FinancialPeriodDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseGoRealResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/GoRealResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -49468,6 +49556,25 @@ components:
             type: string
             description: Additional processing or requirement notes
       description: Generic RFQ specs for undefined or basic modules
+    GoRealResponse:
+      type: object
+      properties:
+        deletedRows:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+        demoMode:
+          type: boolean
+        tenantId:
+          type: string
+          format: uuid
+        trialEndsAt:
+          type: string
+          format: date-time
+        trialStartedAt:
+          type: string
+          format: date-time
     GoodsReceiptItemRequest:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
@@ -24,6 +24,7 @@ public class TenantWriteGuardInterceptor implements HandlerInterceptor {
       List.of(
           "/api/v1/auth/**",
           "/api/v1/public/**",
+          "/api/v1/tenant/go-real",
           "/api/v1/subscriptions/*/activate",
           "/api/v1/subscriptions/**/activate");
 

--- a/src/main/java/com/fabricmanagement/platform/tenant/api/controller/TenantGoRealController.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/api/controller/TenantGoRealController.java
@@ -1,0 +1,50 @@
+package com.fabricmanagement.platform.tenant.api.controller;
+
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.tenant.app.TenantGoRealService;
+import com.fabricmanagement.platform.tenant.dto.GoRealResponse;
+import com.fabricmanagement.platform.user.dto.CompleteOnboardingRequest;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenant")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Tenant Go Real", description = "Tenant go-real transition operations")
+public class TenantGoRealController {
+
+  private final TenantGoRealService tenantGoRealService;
+
+  @PostMapping("/go-real")
+  public ResponseEntity<ApiResponse<GoRealResponse>> goReal(
+      @RequestBody(required = false) @Valid CompleteOnboardingRequest request) {
+    AuthenticatedUserContext ctx = currentUser();
+    log.info("Go-real requested: tenantId={}, userId={}", ctx.tenantId(), ctx.userId());
+
+    GoRealResponse response = tenantGoRealService.goReal(ctx, request);
+    return ResponseEntity.ok(ApiResponse.success(response, "Tenant switched to real mode"));
+  }
+
+  private AuthenticatedUserContext currentUser() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null && auth.getDetails() instanceof AuthenticatedUserContext ctx) {
+      return ctx;
+    }
+    if (auth != null && auth.getPrincipal() instanceof AuthenticatedUserContext ctx) {
+      return ctx;
+    }
+    throw new PlatformDomainException("User not authenticated", "USER_NOT_AUTHENTICATED", 401);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantGoRealService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantGoRealService.java
@@ -1,0 +1,70 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.tenant.dto.GoRealResponse;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import com.fabricmanagement.platform.user.app.UserOnboardingService;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.dto.CompleteOnboardingRequest;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TenantGoRealService {
+
+  private final TenantSystemService tenantSystemService;
+  private final UserRepository userRepository;
+  private final UserOnboardingService userOnboardingService;
+  private final TenantTransactionalPurgeService purgeService;
+
+  @Transactional
+  public GoRealResponse goReal(AuthenticatedUserContext ctx, CompleteOnboardingRequest request) {
+    if (ctx == null || ctx.tenantId() == null || ctx.userId() == null) {
+      throw new PlatformDomainException("User not authenticated", "USER_NOT_AUTHENTICATED", 401);
+    }
+
+    UUID tenantId = ctx.tenantId();
+    UUID userId = ctx.userId();
+    TenantDto tenant =
+        tenantSystemService
+            .findById(tenantId)
+            .orElseThrow(
+                () -> new PlatformDomainException("Tenant not found", "TENANT_NOT_FOUND", 404));
+    if (!tenant.isDemoMode()) {
+      throw new PlatformDomainException("Tenant is already real", "TENANT_ALREADY_REAL", 409);
+    }
+
+    User caller =
+        userRepository
+            .findByTenantIdAndId(tenantId, userId)
+            .orElseThrow(
+                () -> new PlatformDomainException("User not found", "USER_NOT_FOUND", 404));
+    ensureOwnerCanGoReal(caller);
+
+    TenantContext.executeInTenantContext(
+        tenantId, () -> userOnboardingService.completeOnboarding(userId, request));
+    TenantTransactionalPurgeService.PurgeResult result = purgeService.goReal(tenantId);
+    return new GoRealResponse(
+        tenantId, false, result.trialStartedAt(), result.trialEndsAt(), result.deletedRows());
+  }
+
+  private void ensureOwnerCanGoReal(User caller) {
+    if (caller.isDemoSeed()) {
+      throw new PlatformDomainException(
+          "Seeded demo users cannot switch the tenant to real mode", "GO_REAL_REQUIRES_OWNER", 403);
+    }
+    String roleCode = caller.getRole() != null ? caller.getRole().getRoleCode() : null;
+    if (!"ADMIN".equalsIgnoreCase(roleCode) && !"PLATFORM_ADMIN".equalsIgnoreCase(roleCode)) {
+      throw new PlatformDomainException(
+          "Only a tenant owner or admin can switch the tenant to real mode",
+          "GO_REAL_REQUIRES_OWNER",
+          403);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -1,0 +1,563 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantTransactionalPurgeService {
+
+  private static final String TENANT_DEMOMODE_CACHE = "tenant-demomode";
+
+  private static final List<String> TRANSACTIONAL_TABLES =
+      List.of(
+          "flowboard.task_attachment",
+          "flowboard.task_time_entry",
+          "flowboard.task_dependency",
+          "flowboard.task_activity_log",
+          "flowboard.task_comment",
+          "flowboard.task_checklist",
+          "flowboard.task_label_assignment",
+          "flowboard.task_assignee",
+          "flowboard.task_reminder",
+          "flowboard.task_relation",
+          "flowboard.escalation_log",
+          "flowboard.task",
+          "flowboard.dashboard_widget",
+          "flowboard.dashboard_config",
+          "flowboard.board_view",
+          "flowboard.board_group",
+          "flowboard.automation_rule",
+          "flowboard.recurring_task_template",
+          "flowboard.task_template",
+          "flowboard.task_label",
+          "flowboard.user_performance_snapshot",
+          "flowboard.board",
+          "notification.notification_log",
+          "notification.notification_queue",
+          "common_communication.communication_email_outbox",
+          "common_communication.common_verification_log",
+          "common_communication.common_notification",
+          "common_approval.approval_request",
+          "common_approval.user_promotion_request",
+          "common_approval.approval_policy",
+          "finance.fx_revaluation",
+          "finance.fx_realization",
+          "finance.finance_credit_note_application",
+          "finance.finance_payment_allocation",
+          "finance.finance_payment",
+          "finance.finance_invoice_tax_line",
+          "finance.finance_invoice_line",
+          "finance.finance_invoice",
+          "finance.financial_period",
+          "finance.document_number_counter",
+          "costing.cost_calculation_line",
+          "costing.cost_calculation",
+          "costing.cost_history",
+          "costing.volume_price_break",
+          "costing.price_list_item",
+          "costing.price_list",
+          "costing.cost_template",
+          "costing.cost_item",
+          "costing.exchange_rate_snapshot",
+          "costing.exchange_rate_cache",
+          "logistics.logistics_shipment_line_batch",
+          "logistics.logistics_shipment_line",
+          "logistics.logistics_shipment",
+          "iwm.rma_line",
+          "iwm.rma",
+          "iwm.stock_transfer",
+          "iwm.stock_count_assignee",
+          "iwm.stock_count_line",
+          "iwm.stock_count",
+          "iwm.stock_count_tolerance",
+          "iwm.stock_reservation",
+          "iwm.stock_adjustment_request",
+          "iwm.min_stock_rule",
+          "iwm.lot_end_rule",
+          "iwm.return_rate_rule",
+          "iwm.warehouse_location",
+          "production.production_output_item",
+          "production.production_output_record",
+          "production.work_order_output",
+          "production.work_order_consumption",
+          "production.stock_unit_audit_log",
+          "production.stock_unit",
+          "production.goods_receipt_item",
+          "production.goods_receipt",
+          "production.prod_work_order_assignee",
+          "production.prod_work_order",
+          "production.prod_recipe_component",
+          "production.prod_recipe",
+          "production.production_quality_fiber_test_result",
+          "production.production_execution_batch_attribute",
+          "production.production_execution_batch_certification",
+          "production.production_execution_batch_override_log",
+          "production.production_execution_batch_reservation",
+          "production.production_execution_inventory_transaction",
+          "production.production_execution_inventory_balance",
+          "production.production_execution_batch_lineage",
+          "production.production_execution_batch",
+          "production.production_fiber_request",
+          "production.prod_yarn_category",
+          "production.prod_yarn_attribute",
+          "production.prod_yarn_certification",
+          "procurement.supplier_quote_token",
+          "procurement.supplier_quote_line",
+          "procurement.supplier_quote",
+          "procurement.supplier_rfq_recipient",
+          "procurement.supplier_rfq_line",
+          "procurement.supplier_rfq",
+          "procurement.subcontract_order",
+          "procurement.purchase_order_line",
+          "procurement.purchase_order",
+          "sales_ord.sales_order_line_processed_shipments",
+          "sales_ord.sales_order_line",
+          "sales_ord.sales_order",
+          "sales.sample_delivery",
+          "sales.sample_request",
+          "sales.quote_approval_token",
+          "sales.quote_line",
+          "sales.quote",
+          "sales.sales_product",
+          "sales.discount_policy",
+          "human.human_pay_run_audit_log",
+          "human.human_pay_run_payout",
+          "human.human_pay_run_entry",
+          "human.human_pay_run",
+          "human.human_pay_period",
+          "human.human_leave_accrual_log",
+          "human.human_leave_balance",
+          "human.human_employee_number_sequence",
+          "common_user.profile_update_request",
+          "common_infrastructure.document_sequence");
+
+  private final SystemTransactionExecutor systemExecutor;
+  private final CacheManager cacheManager;
+  private final Clock clock;
+
+  @Value("${application.trial.base-days:90}")
+  private int baseDays;
+
+  public PurgeResult goReal(UUID tenantId) {
+    if (tenantId == null) {
+      throw new PlatformDomainException("Tenant not found", "TENANT_NOT_FOUND", 404);
+    }
+    Instant now = Instant.now(clock);
+    Instant trialEndsAt = now.plus(baseDays, ChronoUnit.DAYS);
+
+    Map<String, Integer> deletedRows =
+        systemExecutor.executeInTransaction(
+            jdbc -> {
+              ensureTenantIsDemoMode(jdbc, tenantId);
+              Map<String, Integer> rows = new LinkedHashMap<>();
+              deleteTransactionalRows(jdbc, tenantId, rows);
+              deleteSeedUsers(jdbc, tenantId, rows);
+              deleteTradingPartnerRows(jdbc, tenantId, rows);
+              deleteProductReferenceRows(jdbc, tenantId, rows);
+              flipDemoModeAndStartClock(jdbc, tenantId, now, trialEndsAt);
+              return rows;
+            });
+
+    evictDemoModeCache(tenantId);
+    log.info(
+        "Tenant go-real purge completed: tenantId={}, trialEndsAt={}, deletedRows={}",
+        tenantId,
+        trialEndsAt,
+        deletedRows);
+    return new PurgeResult(tenantId, deletedRows, now, trialEndsAt);
+  }
+
+  private void ensureTenantIsDemoMode(JdbcTemplate jdbc, UUID tenantId) {
+    Boolean demoMode;
+    try {
+      demoMode =
+          jdbc.queryForObject(
+              """
+              SELECT demo_mode
+              FROM common_tenant.common_tenant
+              WHERE id = ?
+              FOR UPDATE
+              """,
+              Boolean.class,
+              tenantId);
+    } catch (EmptyResultDataAccessException ex) {
+      throw new PlatformDomainException("Tenant not found", "TENANT_NOT_FOUND", 404);
+    }
+    if (!Boolean.TRUE.equals(demoMode)) {
+      throw new PlatformDomainException("Tenant is already real", "TENANT_ALREADY_REAL", 409);
+    }
+  }
+
+  private void deleteTransactionalRows(
+      JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    for (String table : TRANSACTIONAL_TABLES) {
+      delete(jdbc, rows, table, "DELETE FROM " + table + " WHERE tenant_id = ?", tenantId);
+    }
+  }
+
+  private void deleteTradingPartnerRows(
+      JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    delete(
+        jdbc,
+        rows,
+        "common_communication.common_contact(external-partner-orgs)",
+        """
+        WITH partner_orgs AS (
+          SELECT id
+          FROM common_company.common_organization
+          WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'
+        ),
+        partner_contacts AS (
+          SELECT oc.contact_id
+          FROM common_company.common_organization_contact oc
+          JOIN partner_orgs po ON po.id = oc.organization_id
+        )
+        DELETE FROM common_communication.common_contact c
+        USING partner_contacts pc
+        WHERE c.id = pc.contact_id
+          AND c.tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_user.common_user_contact uc
+            WHERE uc.contact_id = c.id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_company.common_organization_contact oc2
+            JOIN common_company.common_organization o2 ON o2.id = oc2.organization_id
+            WHERE oc2.contact_id = c.id
+              AND o2.tenant_id = ?
+              AND o2.organization_type <> 'EXTERNAL_PARTNER'
+          )
+        """,
+        tenantId,
+        tenantId,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_communication.common_address(external-partner-orgs)",
+        """
+        WITH partner_orgs AS (
+          SELECT id
+          FROM common_company.common_organization
+          WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'
+        ),
+        partner_addresses AS (
+          SELECT oa.address_id
+          FROM common_company.common_organization_address oa
+          JOIN partner_orgs po ON po.id = oa.organization_id
+        )
+        DELETE FROM common_communication.common_address a
+        USING partner_addresses pa
+        WHERE a.id = pa.address_id
+          AND a.tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_user.common_user_address ua
+            WHERE ua.address_id = a.id
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_company.common_organization_address oa2
+            JOIN common_company.common_organization o2 ON o2.id = oa2.organization_id
+            WHERE oa2.address_id = a.id
+              AND o2.tenant_id = ?
+              AND o2.organization_type <> 'EXTERNAL_PARTNER'
+          )
+        """,
+        tenantId,
+        tenantId,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.common_organization_contact(external-partner-orgs)",
+        """
+        DELETE FROM common_company.common_organization_contact oc
+        USING common_company.common_organization o
+        WHERE oc.organization_id = o.id
+          AND o.tenant_id = ?
+          AND o.organization_type = 'EXTERNAL_PARTNER'
+        """,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.common_organization_address(external-partner-orgs)",
+        """
+        DELETE FROM common_company.common_organization_address oa
+        USING common_company.common_organization o
+        WHERE oa.organization_id = o.id
+          AND o.tenant_id = ?
+          AND o.organization_type = 'EXTERNAL_PARTNER'
+        """,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.common_organization(external-partners)",
+        """
+        DELETE FROM common_company.common_organization
+        WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'
+        """,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.partner_trading_partner_certification",
+        "DELETE FROM common_company.partner_trading_partner_certification WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.organization_certification",
+        "DELETE FROM common_company.organization_certification WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_company.common_trading_partner+unreferenced_registry",
+        """
+        WITH deleted_partners AS (
+          DELETE FROM common_company.common_trading_partner
+          WHERE tenant_id = ?
+          RETURNING registry_id
+        )
+        DELETE FROM common_company.trading_partner_registry r
+        WHERE r.id IN (SELECT registry_id FROM deleted_partners)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_company.common_trading_partner remaining
+            WHERE remaining.registry_id = r.id
+              AND remaining.tenant_id <> ?
+          )
+        """,
+        tenantId,
+        tenantId);
+  }
+
+  private void deleteProductReferenceRows(
+      JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    delete(
+        jdbc,
+        rows,
+        "production.prod_product_attribute",
+        "DELETE FROM production.prod_product_attribute WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.quality_grade",
+        "DELETE FROM production.quality_grade WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_fiber_certification",
+        "DELETE FROM production.prod_fiber_certification WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_fiber_quality_standard",
+        "DELETE FROM production.prod_fiber_quality_standard WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_fiber",
+        "DELETE FROM production.prod_fiber WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_product",
+        "DELETE FROM production.prod_product WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_fiber_iso_code",
+        "DELETE FROM production.prod_fiber_iso_code WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.prod_fiber_category",
+        "DELETE FROM production.prod_fiber_category WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.inheritance_rule_schema",
+        "DELETE FROM production.inheritance_rule_schema WHERE tenant_id = ?",
+        tenantId);
+  }
+
+  private void deleteSeedUsers(JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    delete(
+        jdbc,
+        rows,
+        "common_communication.common_contact(seed-demo-users)",
+        """
+        WITH seed_contacts AS (
+          SELECT uc.contact_id
+          FROM common_user.common_user_contact uc
+          JOIN common_user.common_user u ON u.id = uc.user_id
+          WHERE u.tenant_id = ? AND u.demo_seed = true
+        )
+        DELETE FROM common_communication.common_contact c
+        USING seed_contacts sc
+        WHERE c.id = sc.contact_id
+          AND c.tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_user.common_user_contact uc2
+            JOIN common_user.common_user u2 ON u2.id = uc2.user_id
+            WHERE uc2.contact_id = c.id
+              AND u2.tenant_id = ?
+              AND u2.demo_seed = false
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_company.common_organization_contact oc
+            WHERE oc.contact_id = c.id
+          )
+        """,
+        tenantId,
+        tenantId,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "common_communication.common_address(seed-demo-users)",
+        """
+        WITH seed_addresses AS (
+          SELECT ua.address_id
+          FROM common_user.common_user_address ua
+          JOIN common_user.common_user u ON u.id = ua.user_id
+          WHERE u.tenant_id = ? AND u.demo_seed = true
+        )
+        DELETE FROM common_communication.common_address a
+        USING seed_addresses sa
+        WHERE a.id = sa.address_id
+          AND a.tenant_id = ?
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_user.common_user_address ua2
+            JOIN common_user.common_user u2 ON u2.id = ua2.user_id
+            WHERE ua2.address_id = a.id
+              AND u2.tenant_id = ?
+              AND u2.demo_seed = false
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM common_company.common_organization_address oa
+            WHERE oa.address_id = a.id
+          )
+        """,
+        tenantId,
+        tenantId,
+        tenantId);
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_auth.common_refresh_token", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_auth.common_trusted_device", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_auth.common_auth_user", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_user.user_nav_preferences", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "i18n.user_locale_config", "user_id");
+    deleteSeedUserOwnedRows(
+        jdbc, tenantId, rows, "notification.user_notification_preference", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "human.human_employee", "user_id");
+    deleteSeedUserOwnedRows(
+        jdbc, tenantId, rows, "common_user.common_user_work_location", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_user.common_user_address", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_user.common_user_contact", "user_id");
+    deleteSeedUserOwnedRows(jdbc, tenantId, rows, "common_user.common_user_department", "user_id");
+    delete(
+        jdbc,
+        rows,
+        "common_user.common_user(seed-demo-users)",
+        "DELETE FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true",
+        tenantId);
+  }
+
+  private void deleteSeedUserOwnedRows(
+      JdbcTemplate jdbc,
+      UUID tenantId,
+      Map<String, Integer> rows,
+      String table,
+      String userColumn) {
+    delete(
+        jdbc,
+        rows,
+        table + "(seed-demo-users)",
+        "DELETE FROM "
+            + table
+            + " WHERE tenant_id = ? AND "
+            + userColumn
+            + " IN (SELECT id FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true)",
+        tenantId,
+        tenantId);
+  }
+
+  private void flipDemoModeAndStartClock(
+      JdbcTemplate jdbc, UUID tenantId, Instant now, Instant trialEndsAt) {
+    int affected =
+        jdbc.update(
+            """
+            UPDATE common_tenant.common_tenant
+            SET demo_mode = false,
+                trial_started_at = ?,
+                last_activity_at = ?,
+                trial_ends_at = ?,
+                updated_at = now(),
+                version = version + 1
+            WHERE id = ?
+              AND demo_mode = true
+            """,
+            Timestamp.from(now),
+            Timestamp.from(now),
+            Timestamp.from(trialEndsAt),
+            tenantId);
+    if (affected != 1) {
+      throw new PlatformDomainException("Tenant is already real", "TENANT_ALREADY_REAL", 409);
+    }
+  }
+
+  private void delete(
+      JdbcTemplate jdbc, Map<String, Integer> rows, String label, String sql, Object... args) {
+    int deleted = jdbc.update(sql, args);
+    rows.put(label, deleted);
+    log.debug("Tenant go-real purge table deleted: table={}, rows={}", label, deleted);
+  }
+
+  private void evictDemoModeCache(UUID tenantId) {
+    var cache = cacheManager.getCache(TENANT_DEMOMODE_CACHE);
+    if (cache != null) {
+      cache.evict(tenantId.toString());
+    }
+  }
+
+  public record PurgeResult(
+      UUID tenantId,
+      Map<String, Integer> deletedRows,
+      Instant trialStartedAt,
+      Instant trialEndsAt) {}
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleService.java
@@ -61,6 +61,7 @@ public class TrialLifecycleService implements TrialLifecyclePort {
           AND type = 'REGULAR'
           AND status = 'TRIAL'
           AND trial_started_at IS NULL
+          AND demo_mode = false
           AND is_active = true
         """,
         Timestamp.from(now),

--- a/src/main/java/com/fabricmanagement/platform/tenant/dto/GoRealResponse.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/dto/GoRealResponse.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.platform.tenant.dto;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+public record GoRealResponse(
+    UUID tenantId,
+    boolean demoMode,
+    Instant trialStartedAt,
+    Instant trialEndsAt,
+    Map<String, Integer> deletedRows) {}

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -808,6 +808,7 @@ class ConstitutionArchTest {
       // temizle
       //   - TrialLifecycleService        : Scheduled job: registered trial expiry/activity
       // maintenance
+      //   - TenantTransactionalPurgeService : Go-real purge, atomic tenant-scoped seed/data wipe
       //   - TenantQueryAdapter           : Port/Adapter: tenant lookup (auth, event yolu)
       //   - CloneTemplateRolesStep       : Onboarding: TEMPLATE rollerini yeni tenant'a kopyala
       //   - SystemDataSourceConfig       : Altyapı: DataSource bean konfigürasyonu
@@ -825,6 +826,8 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("PlaygroundTTLReaperService")
               .and()
               .doNotHaveSimpleName("TrialLifecycleService")
+              .and()
+              .doNotHaveSimpleName("TenantTransactionalPurgeService")
               .and()
               .doNotHaveSimpleName("TenantQueryAdapter")
               .and()

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
@@ -67,6 +67,16 @@ class TenantWriteGuardInterceptorTest {
   }
 
   @Test
+  @DisplayName("EXPIRED tenant go-real POST passes through read-only guard")
+  void shouldAllowGoRealForExpiredTenantWriteGuard() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    assertThat(preHandle("POST", "/api/v1/tenant/go-real")).isTrue();
+    verify(tenantAccessPort, never()).isWritable(tenantId);
+  }
+
+  @Test
   @DisplayName("TRIAL or ACTIVE tenant write passes through")
   void shouldAllowWritableTenantWrite() {
     UUID tenantId = UUID.randomUUID();

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantGoRealServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantGoRealServiceTest.java
@@ -1,0 +1,137 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.tenant.dto.GoRealResponse;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import com.fabricmanagement.platform.user.app.UserOnboardingService;
+import com.fabricmanagement.platform.user.domain.Role;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.dto.CompleteOnboardingRequest;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantGoRealServiceTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+  @Mock private TenantSystemService tenantSystemService;
+  @Mock private UserRepository userRepository;
+  @Mock private UserOnboardingService userOnboardingService;
+  @Mock private TenantTransactionalPurgeService purgeService;
+
+  private TenantGoRealService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new TenantGoRealService(
+            tenantSystemService, userRepository, userOnboardingService, purgeService);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void shouldConfirmDetailsThenPurgeForDemoModeOwner() {
+    CompleteOnboardingRequest request =
+        CompleteOnboardingRequest.builder().organizationName("Acme Real Ltd").build();
+    Instant startedAt = Instant.parse("2026-06-27T12:00:00Z");
+    Instant endsAt = Instant.parse("2026-09-25T12:00:00Z");
+    when(tenantSystemService.findById(TENANT_ID))
+        .thenReturn(Optional.of(TenantDto.builder().id(TENANT_ID).demoMode(true).build()));
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(owner()));
+    when(purgeService.goReal(TENANT_ID))
+        .thenReturn(
+            new TenantTransactionalPurgeService.PurgeResult(
+                TENANT_ID, Map.of("sales.quote", 3), startedAt, endsAt));
+
+    GoRealResponse response = service.goReal(context("ADMIN"), request);
+
+    assertThat(response.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(response.demoMode()).isFalse();
+    assertThat(response.trialStartedAt()).isEqualTo(startedAt);
+    assertThat(response.trialEndsAt()).isEqualTo(endsAt);
+    assertThat(response.deletedRows()).containsEntry("sales.quote", 3);
+    verify(userOnboardingService).completeOnboarding(USER_ID, request);
+    verify(purgeService).goReal(TENANT_ID);
+  }
+
+  @Test
+  void shouldRefuseAlreadyRealTenantWithoutPurging() {
+    when(tenantSystemService.findById(TENANT_ID))
+        .thenReturn(Optional.of(TenantDto.builder().id(TENANT_ID).demoMode(false).build()));
+
+    assertThatThrownBy(() -> service.goReal(context("ADMIN"), null))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("TENANT_ALREADY_REAL", 409);
+
+    verifyNoInteractions(userRepository, userOnboardingService, purgeService);
+  }
+
+  @Test
+  void shouldRefuseDemoSeedCallerWithoutPurging() {
+    User seeded = owner();
+    seeded.setDemoSeed(true);
+    when(tenantSystemService.findById(TENANT_ID))
+        .thenReturn(Optional.of(TenantDto.builder().id(TENANT_ID).demoMode(true).build()));
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(seeded));
+
+    assertThatThrownBy(() -> service.goReal(context("ADMIN"), null))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("GO_REAL_REQUIRES_OWNER", 403);
+
+    verifyNoInteractions(userOnboardingService, purgeService);
+  }
+
+  @Test
+  void shouldRefuseNonAdminCallerWithoutPurging() {
+    User worker = owner();
+    worker.setRole(Role.create("Worker", "WORKER", "Worker"));
+    when(tenantSystemService.findById(TENANT_ID))
+        .thenReturn(Optional.of(TenantDto.builder().id(TENANT_ID).demoMode(true).build()));
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(worker));
+
+    assertThatThrownBy(() -> service.goReal(context("WORKER"), null))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("GO_REAL_REQUIRES_OWNER", 403);
+
+    verifyNoInteractions(userOnboardingService, purgeService);
+  }
+
+  private AuthenticatedUserContext context(String roleCode) {
+    return new AuthenticatedUserContext(USER_ID, roleCode, List.of(), null, TENANT_ID);
+  }
+
+  private User owner() {
+    User user = User.create("Owner", "User", UUID.randomUUID());
+    user.setId(USER_ID);
+    user.setTenantId(TENANT_ID);
+    user.setRole(Role.create("Admin", "ADMIN", "Admin"));
+    return user;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -1,0 +1,283 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import java.sql.Timestamp;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class TenantTransactionalPurgeServiceTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final Instant NOW = Instant.parse("2026-06-27T12:00:00Z");
+
+  @Mock private SystemTransactionExecutor systemExecutor;
+  @Mock private CacheManager cacheManager;
+  @Mock private Cache cache;
+  @Mock private JdbcTemplate jdbc;
+
+  private TenantTransactionalPurgeService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new TenantTransactionalPurgeService(
+            systemExecutor, cacheManager, Clock.fixed(NOW, ZoneOffset.UTC));
+    ReflectionTestUtils.setField(service, "baseDays", 90);
+  }
+
+  @Test
+  void shouldPurgeTransactionalTablesSeedUsersFlipDemoModeAndEvictCache() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+    doReturn(1)
+        .when(jdbc)
+        .update(
+            contains("UPDATE common_tenant.common_tenant"),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            eq(TENANT_ID));
+    when(cacheManager.getCache("tenant-demomode")).thenReturn(cache);
+
+    TenantTransactionalPurgeService.PurgeResult result = service.goReal(TENANT_ID);
+
+    assertThat(result.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(result.trialStartedAt()).isEqualTo(NOW);
+    assertThat(result.trialEndsAt()).isEqualTo(Instant.parse("2026-09-25T12:00:00Z"));
+    assertThat(result.deletedRows())
+        .containsKeys(
+            "sales.quote",
+            "procurement.purchase_order",
+            "production.prod_product",
+            "iwm.warehouse_location",
+            "finance.finance_invoice",
+            "flowboard.task",
+            "common_approval.approval_request",
+            "notification.notification_queue",
+            "common_company.common_organization(external-partners)",
+            "common_company.common_trading_partner+unreferenced_registry",
+            "human.human_employee_number_sequence",
+            "common_user.common_user(seed-demo-users)");
+    verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM procurement.purchase_order WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(contains("DELETE FROM production.prod_product WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains(
+                "DELETE FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains(
+                "DELETE FROM common_company.common_organization\n"
+                    + "WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM common_company.trading_partner_registry r"),
+            eq(TENANT_ID),
+            eq(TENANT_ID));
+    verify(cache).evict(TENANT_ID.toString());
+  }
+
+  @Test
+  void shouldRefuseNonDemoTenantBeforeDeletingAnything() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(false);
+
+    assertThatThrownBy(() -> service.goReal(TENANT_ID))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("TENANT_ALREADY_REAL", 409);
+
+    verify(jdbc, never())
+        .update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(cacheManager, never()).getCache("tenant-demomode");
+  }
+
+  @Test
+  void shouldPropagateFailureSoTransactionExecutorCanRollbackAndSkipCacheEviction() {
+    RuntimeException failure = new RuntimeException("forced purge failure");
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+    doThrow(failure)
+        .when(jdbc)
+        .update(contains("DELETE FROM finance.finance_payment WHERE tenant_id = ?"), eq(TENANT_ID));
+
+    assertThatThrownBy(() -> service.goReal(TENANT_ID)).isSameAs(failure);
+    verify(cacheManager, never()).getCache("tenant-demomode");
+  }
+
+  @Test
+  void shouldNotDeleteIdentityConfigurationTablesWholesale() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+    doReturn(1)
+        .when(jdbc)
+        .update(
+            contains("UPDATE common_tenant.common_tenant"),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            eq(TENANT_ID));
+
+    service.goReal(TENANT_ID);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbc, org.mockito.Mockito.atLeastOnce()).update(sqlCaptor.capture(), eq(TENANT_ID));
+    List<String> sql = sqlCaptor.getAllValues();
+    assertThat(sql)
+        .noneMatch(statement -> statement.contains("DELETE FROM common_tenant.common_tenant"))
+        .noneMatch(
+            statement ->
+                statement.contains("DELETE FROM common_company.common_organization")
+                    && !statement.contains("organization_type = 'EXTERNAL_PARTNER'"))
+        .noneMatch(
+            statement -> statement.contains("DELETE FROM common_company.common_subscription"))
+        .noneMatch(statement -> statement.contains("DELETE FROM common_user.common_role"))
+        .noneMatch(statement -> statement.contains("DELETE FROM common_user.permission_template"))
+        .noneMatch(statement -> statement.contains("DELETE FROM common_company.common_department"))
+        .noneMatch(statement -> statement.contains("DELETE FROM human.human_holiday_calendar"))
+        .noneMatch(
+            statement -> statement.contains("DELETE FROM human.human_hr_country_pack_mapping"))
+        .noneMatch(statement -> statement.contains("DELETE FROM human.human_hr_policy_pack"))
+        .noneMatch(statement -> statement.contains("DELETE FROM human.human_leave_type"));
+  }
+
+  @Test
+  void shouldDeleteProductionReferenceTablesInFkSafeOrder() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+    doReturn(1)
+        .when(jdbc)
+        .update(
+            contains("UPDATE common_tenant.common_tenant"),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            eq(TENANT_ID));
+
+    service.goReal(TENANT_ID);
+
+    ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbc, org.mockito.Mockito.atLeastOnce()).update(sqlCaptor.capture(), eq(TENANT_ID));
+    List<String> sql = sqlCaptor.getAllValues();
+    assertThat(indexOf(sql, "DELETE FROM production.prod_product_attribute WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.quality_grade WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_product WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.prod_fiber_certification WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"));
+    assertThat(
+            indexOf(sql, "DELETE FROM production.prod_fiber_quality_standard WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_product WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber_iso_code WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber_category WHERE tenant_id = ?"));
+  }
+
+  @Test
+  void shouldDeleteExternalPartnerOrganizationsAndOnlyUnreferencedRegistryRows() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+    doReturn(1)
+        .when(jdbc)
+        .update(
+            contains("UPDATE common_tenant.common_tenant"),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            eq(TENANT_ID));
+
+    service.goReal(TENANT_ID);
+
+    verify(jdbc)
+        .update(
+            contains(
+                "DELETE FROM common_company.common_organization\n"
+                    + "WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'"),
+            eq(TENANT_ID));
+
+    ArgumentCaptor<String> twoTenantSqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbc, org.mockito.Mockito.atLeastOnce())
+        .update(twoTenantSqlCaptor.capture(), eq(TENANT_ID), eq(TENANT_ID));
+
+    String registryCleanup =
+        findStatement(
+            twoTenantSqlCaptor.getAllValues(),
+            "DELETE FROM common_company.trading_partner_registry r");
+    assertThat(registryCleanup)
+        .contains("DELETE FROM common_company.common_trading_partner")
+        .contains("WHERE tenant_id = ?")
+        .contains("RETURNING registry_id")
+        .contains("AND NOT EXISTS")
+        .contains("remaining.registry_id = r.id")
+        .contains("remaining.tenant_id <> ?");
+  }
+
+  private int indexOf(List<String> statements, String needle) {
+    for (int i = 0; i < statements.size(); i++) {
+      if (statements.get(i).contains(needle)) {
+        return i;
+      }
+    }
+    throw new AssertionError("SQL statement not found: " + needle);
+  }
+
+  private String findStatement(List<String> statements, String needle) {
+    for (String statement : statements) {
+      if (statement.contains(needle)) {
+        return statement;
+      }
+    }
+    throw new AssertionError("SQL statement not found: " + needle);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void stubSystemTransaction() {
+    when(systemExecutor.executeInTransaction(any(Function.class)))
+        .thenAnswer(
+            invocation -> {
+              Function<JdbcTemplate, Map<String, Integer>> work = invocation.getArgument(0);
+              return work.apply(jdbc);
+            });
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TrialLifecycleServiceTest.java
@@ -59,6 +59,7 @@ class TrialLifecycleServiceTest {
     assertThat(sqlCaptor.getValue()).contains("type = 'REGULAR'");
     assertThat(sqlCaptor.getValue()).contains("status = 'TRIAL'");
     assertThat(sqlCaptor.getValue()).contains("trial_started_at IS NULL");
+    assertThat(sqlCaptor.getValue()).contains("demo_mode = false");
   }
 
   @Test


### PR DESCRIPTION
… start clock

Adds the "start using for real" step: a demoMode (playground) tenant becomes a clean real-trial workspace — same tenant, seed wiped, 90-day clock started.

- POST /api/v1/tenant/go-real (TenantGoRealController/Service): owner/admin only, rejects seeded (demo_seed) callers, 409 if the tenant is already real; whitelisted in the read-only guard.
- Confirm/update details (CompleteOnboardingRequest enrich) before the purge.
- TenantTransactionalPurgeService: one atomic BYPASSRLS transaction that
  - deletes demo_seed users (+ their auth/contact/address/department/pref rows),
  - wipes ALL transactional data across modules (sales, procurement, production, inventory, finance, costing, quality, approvals, notifications, flowboard), FK-safe order reasoned from the real DDL,
  - deletes EXTERNAL_PARTNER (demo) orgs + their contacts/addresses, preserving contacts/addresses shared with the tenant's internal org,
  - deletes tenant trading partners and only the now-unreferenced registry rows,
  - resets the tenant's employee-number sequence,
  - PRESERVES identity/config (tenant, internal org, surviving users, roles, permission templates, departments, subscriptions, HR policy/leave config), refusing to run unless demoMode=true; partial failure rolls back.
- Flips demoMode=false (evicts tenant-demomode) and starts the trial clock here; password-setup activation now skips demoMode tenants (AND demo_mode=false), so the 90-day clock starts only at go-real for playground tenants.
- openapi: go-real endpoint + GoRealResponse.

FE confirm/update screen is a follow-up. Most safety-critical purge paths reviewed against the real schema (partner-org seed leak + production FK order fixed in review).