### PR TITLE
feat(user): include tenant trial/demo context in the /me response

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12264,7 +12264,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/ApiResponseUserDto"
+                $ref: "#/components/schemas/ApiResponseCurrentUserResponse"
           description: OK
         "400":
           content:
@@ -41657,6 +41657,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponseCurrentUserResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CurrentUserResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseDashboardConfigDto:
       type: object
       properties:
@@ -48309,6 +48327,120 @@ components:
         targetInvoiceId:
           type: string
           format: uuid
+    CurrentTenantContextDto:
+      type: object
+      properties:
+        demoMode:
+          type: boolean
+        status:
+          type: string
+          enum:
+          - TRIAL
+          - ACTIVE
+          - EXPIRED
+          - SUSPENDED
+          - CANCELLED
+        trialEndsAt:
+          type: string
+          format: date-time
+    CurrentUserResponse:
+      type: object
+      properties:
+        birthDate:
+          type: string
+          format: date
+        createdAt:
+          type: string
+          format: date-time
+        departmentCodes:
+          type: array
+          items:
+            type: string
+        departmentId:
+          type: string
+          format: uuid
+        departmentName:
+          type: string
+        displayName:
+          type: string
+        emergencyContact:
+          $ref: "#/components/schemas/EmergencyContactDto"
+        employeeNumber:
+          type: string
+        firstName:
+          type: string
+        gender:
+          type: string
+        hasCompletedOnboarding:
+          type: boolean
+        hireDate:
+          type: string
+          format: date
+        id:
+          type: string
+          format: uuid
+        isActive:
+          type: boolean
+        isEmployee:
+          type: boolean
+        lastActiveAt:
+          type: string
+          format: date-time
+        lastName:
+          type: string
+        nationality:
+          type: string
+        onboardingCompletedAt:
+          type: string
+          format: date-time
+        organizationId:
+          type: string
+          format: uuid
+        permissions:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
+              enum:
+              - OWN
+              - DEPARTMENT
+              - ORGANIZATION
+              - GLOBAL
+        preferredLocale:
+          type: string
+        preferredTimezone:
+          type: string
+        primaryDepartmentCode:
+          type: string
+        role:
+          type: string
+        roleCode:
+          type: string
+        roleId:
+          type: string
+          format: uuid
+        superAdmin:
+          type: boolean
+        tenant:
+          $ref: "#/components/schemas/CurrentTenantContextDto"
+        tenantId:
+          type: string
+          format: uuid
+        title:
+          type: string
+        uid:
+          type: string
+        updatedAt:
+          type: string
+          format: date-time
+        userType:
+          type: string
+        wipLimit:
+          type: integer
+          format: int32
+        workLocationLabel:
+          type: string
     CustomerApprovalRequest:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/platform/user/api/controller/UserController.java
+++ b/src/main/java/com/fabricmanagement/platform/user/api/controller/UserController.java
@@ -11,12 +11,14 @@ import com.fabricmanagement.platform.common.exception.PlatformDomainException;
 import com.fabricmanagement.platform.communication.app.ContactSuggestionService;
 import com.fabricmanagement.platform.communication.dto.ContactSuggestionsDto;
 import com.fabricmanagement.platform.subscription.app.UserCreationOptionsService;
+import com.fabricmanagement.platform.tenant.app.TenantService;
 import com.fabricmanagement.platform.user.app.UserLocaleService;
 import com.fabricmanagement.platform.user.app.UserService;
 import com.fabricmanagement.platform.user.domain.DataScope;
 import com.fabricmanagement.platform.user.domain.port.EmployeeCreationPort;
 import com.fabricmanagement.platform.user.dto.CreateExternalUserRequest;
 import com.fabricmanagement.platform.user.dto.CreateInternalUserRequest;
+import com.fabricmanagement.platform.user.dto.CurrentUserResponse;
 import com.fabricmanagement.platform.user.dto.UpdateLocalePreferencesRequest;
 import com.fabricmanagement.platform.user.dto.UpdateUserRequest;
 import com.fabricmanagement.platform.user.dto.UserDto;
@@ -47,6 +49,7 @@ public class UserController {
   private final UserDepartmentRepository userDepartmentRepository;
   private final UserLocaleService userLocaleService;
   private final PermissionEvaluator permissionEvaluator;
+  private final TenantService tenantService;
 
   private PermissionResult getPermissions(UUID requesterId) {
     UUID tenantId = TenantContext.requireTenantId();
@@ -260,7 +263,7 @@ public class UserController {
    * <p>Uses TenantContext.getCurrentUserId() to get the authenticated user.
    */
   @GetMapping("/me")
-  public ResponseEntity<ApiResponse<UserDto>> getCurrentUser() {
+  public ResponseEntity<ApiResponse<CurrentUserResponse>> getCurrentUser() {
     UUID userId = TenantContext.getCurrentUserId();
     UUID tenantId = TenantContext.requireTenantId();
 
@@ -282,7 +285,8 @@ public class UserController {
     user.setPermissions(permResult.permissions());
     user.setSuperAdmin(permResult.isSuperAdmin());
 
-    return ResponseEntity.ok(ApiResponse.success(user));
+    return ResponseEntity.ok(
+        ApiResponse.success(CurrentUserResponse.from(user, tenantService.getMyTenant())));
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/platform/user/dto/CurrentTenantContextDto.java
+++ b/src/main/java/com/fabricmanagement/platform/user/dto/CurrentTenantContextDto.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.platform.user.dto;
+
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CurrentTenantContextDto {
+
+  private boolean demoMode;
+  private TenantStatus status;
+  private Instant trialEndsAt;
+
+  public static CurrentTenantContextDto from(TenantDto tenant) {
+    return CurrentTenantContextDto.builder()
+        .demoMode(tenant.isDemoMode())
+        .status(tenant.getStatus())
+        .trialEndsAt(tenant.getTrialEndsAt())
+        .build();
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/user/dto/CurrentUserResponse.java
+++ b/src/main/java/com/fabricmanagement/platform/user/dto/CurrentUserResponse.java
@@ -1,0 +1,24 @@
+package com.fabricmanagement.platform.user.dto;
+
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import org.springframework.beans.BeanUtils;
+
+public class CurrentUserResponse extends UserDto {
+
+  private CurrentTenantContextDto tenant;
+
+  public CurrentTenantContextDto getTenant() {
+    return tenant;
+  }
+
+  public void setTenant(CurrentTenantContextDto tenant) {
+    this.tenant = tenant;
+  }
+
+  public static CurrentUserResponse from(UserDto user, TenantDto tenant) {
+    CurrentUserResponse response = new CurrentUserResponse();
+    BeanUtils.copyProperties(user, response);
+    response.setTenant(CurrentTenantContextDto.from(tenant));
+    return response;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/user/api/controller/UserControllerTest.java
+++ b/src/test/java/com/fabricmanagement/platform/user/api/controller/UserControllerTest.java
@@ -1,0 +1,131 @@
+package com.fabricmanagement.platform.user.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.PermissionEvaluator;
+import com.fabricmanagement.common.infrastructure.security.dto.PermissionResult;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.platform.communication.app.ContactSuggestionService;
+import com.fabricmanagement.platform.subscription.app.UserCreationOptionsService;
+import com.fabricmanagement.platform.tenant.app.TenantService;
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fabricmanagement.platform.tenant.dto.TenantDto;
+import com.fabricmanagement.platform.user.app.UserLocaleService;
+import com.fabricmanagement.platform.user.app.UserService;
+import com.fabricmanagement.platform.user.domain.DataScope;
+import com.fabricmanagement.platform.user.domain.port.EmployeeCreationPort;
+import com.fabricmanagement.platform.user.dto.CurrentUserResponse;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.platform.user.infra.repository.UserDepartmentRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+  private static final Instant TRIAL_ENDS_AT = Instant.parse("2026-09-26T12:00:00Z");
+
+  @Mock private UserService userService;
+  @Mock private ContactSuggestionService contactSuggestionService;
+  @Mock private EmployeeCreationPort employeeCreationPort;
+  @Mock private UserCreationOptionsService userCreationOptionsService;
+  @Mock private UserDepartmentRepository userDepartmentRepository;
+  @Mock private UserLocaleService userLocaleService;
+  @Mock private PermissionEvaluator permissionEvaluator;
+  @Mock private TenantService tenantService;
+
+  private UserController controller;
+
+  @BeforeEach
+  void setUp() {
+    controller =
+        new UserController(
+            userService,
+            contactSuggestionService,
+            employeeCreationPort,
+            userCreationOptionsService,
+            userDepartmentRepository,
+            userLocaleService,
+            permissionEvaluator,
+            tenantService);
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(USER_ID);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void getCurrentUserIncludesDemoTrialTenantContext() {
+    stubCurrentUser();
+    when(tenantService.getMyTenant())
+        .thenReturn(
+            TenantDto.builder()
+                .id(TENANT_ID)
+                .demoMode(true)
+                .status(TenantStatus.TRIAL)
+                .trialEndsAt(TRIAL_ENDS_AT)
+                .build());
+
+    ResponseEntity<ApiResponse<CurrentUserResponse>> response = controller.getCurrentUser();
+
+    CurrentUserResponse body = response.getBody().getData();
+    assertThat(body.getId()).isEqualTo(USER_ID);
+    assertThat(body.getTenant().isDemoMode()).isTrue();
+    assertThat(body.getTenant().getStatus()).isEqualTo(TenantStatus.TRIAL);
+    assertThat(body.getTenant().getTrialEndsAt()).isEqualTo(TRIAL_ENDS_AT);
+  }
+
+  @Test
+  void getCurrentUserIncludesActiveRealTenantContext() {
+    stubCurrentUser();
+    when(tenantService.getMyTenant())
+        .thenReturn(
+            TenantDto.builder()
+                .id(TENANT_ID)
+                .demoMode(false)
+                .status(TenantStatus.ACTIVE)
+                .trialEndsAt(null)
+                .build());
+
+    ResponseEntity<ApiResponse<CurrentUserResponse>> response = controller.getCurrentUser();
+
+    CurrentUserResponse body = response.getBody().getData();
+    assertThat(body.getTenant().isDemoMode()).isFalse();
+    assertThat(body.getTenant().getStatus()).isEqualTo(TenantStatus.ACTIVE);
+    assertThat(body.getTenant().getTrialEndsAt()).isNull();
+  }
+
+  private void stubCurrentUser() {
+    UserDto user =
+        UserDto.builder()
+            .id(USER_ID)
+            .tenantId(TENANT_ID)
+            .firstName("Ada")
+            .lastName("Lovelace")
+            .roleCode("ADMIN")
+            .departmentCodes(List.of("ADMIN"))
+            .build();
+    PermissionResult permissions =
+        new PermissionResult(Map.of("members", Map.of("read", DataScope.GLOBAL)), false);
+    when(userService.findByIdWithPermissionData(TENANT_ID, USER_ID)).thenReturn(Optional.of(user));
+    when(permissionEvaluator.evaluate(TENANT_ID, "ADMIN", List.of("ADMIN"), USER_ID))
+        .thenReturn(permissions);
+  }
+}


### PR DESCRIPTION
The frontend needs to know the tenant's mode to render trial/playground UI, but GET /api/v1/common/users/me returned only user fields. Add a /me-specific CurrentUserResponse that keeps the existing UserDto fields and nests a small tenant context (demoMode, status, trialEndsAt). Other UserDto endpoints are unchanged.

- CurrentTenantContextDto { demoMode, status, trialEndsAt } from TenantDto.
- CurrentUserResponse (user fields + tenant) returned only by /me.
- openapi updated; UserControllerTest covers demo-TRIAL and real-ACTIVE.

Foundation for the trial FE series; no behaviour change for other callers.