### PR TITLE
feat(trial): gate view-as impersonation on demoMode capability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,28 @@ jobs:
       - name: Run tests
         run: mvn clean verify
 
+      - name: Print test failures
+        if: always()
+        run: |
+          echo "=== Surefire/Failsafe failure summary ==="
+          grep -R -n -E "<failure|<error" target/surefire-reports target/failsafe-reports 2>/dev/null || true
+
+          echo "=== Failing text reports ==="
+          for reports_dir in target/surefire-reports target/failsafe-reports; do
+            if [ ! -d "${reports_dir}" ]; then
+              echo "No ${reports_dir} directory."
+              continue
+            fi
+
+            for report in "${reports_dir}"/*.txt; do
+              [ -e "${report}" ] || continue
+              if grep -q -E "<<< FAILURE!|<<< ERROR!" "${report}"; then
+                echo "---- ${report} ----"
+                sed -n '1,300p' "${report}" || true
+              fi
+            done
+          done
+
       - name: Generate test report
         if: always()
         run: |

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -23953,8 +23953,8 @@ paths:
       - Platform Notification
   /api/v1/playground/impersonate/{userId}:
     post:
-      description: Validates the target user belongs to the current playground tenant
-        and generates a new JWT token for that persona.
+      description: "Validates the current tenant is in demo mode, verifies the target\
+        \ user belongs to that tenant, and generates a new JWT token for that persona."
       operationId: impersonate
       parameters:
       - description: Target user ID to impersonate
@@ -23989,7 +23989,7 @@ paths:
           description: Unauthorized
         "403":
           content: {}
-          description: Not a valid playground session or user outside playground
+          description: Demo mode is required or user is outside the current tenant
         "404":
           content:
             application/problem+json:
@@ -24128,7 +24128,7 @@ paths:
           description: Unauthorized
         "403":
           content: {}
-          description: Not a valid playground session
+          description: Demo mode is required
         "404":
           content:
             application/problem+json:

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptor.java
@@ -24,6 +24,7 @@ public class TenantWriteGuardInterceptor implements HandlerInterceptor {
       List.of(
           "/api/v1/auth/**",
           "/api/v1/public/**",
+          "/api/v1/playground/impersonate/**",
           "/api/v1/tenant/go-real",
           "/api/v1/subscriptions/*/activate",
           "/api/v1/subscriptions/**/activate");

--- a/src/main/java/com/fabricmanagement/platform/auth/api/controller/PlaygroundAuthController.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/api/controller/PlaygroundAuthController.java
@@ -15,6 +15,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.time.Instant;
@@ -110,12 +111,12 @@ public class PlaygroundAuthController {
   @Operation(
       summary = "Switch persona in the current playground session",
       description =
-          "Validates the target user belongs to the current playground tenant and generates a new JWT token for that persona.")
+          "Validates the current tenant is in demo mode, verifies the target user belongs to that tenant, and generates a new JWT token for that persona.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "Persona switched successfully"),
     @ApiResponse(
         responseCode = "403",
-        description = "Not a valid playground session or user outside playground",
+        description = "Demo mode is required or user is outside the current tenant",
         content = @Content)
   })
   @PreAuthorize("isAuthenticated()")
@@ -125,10 +126,11 @@ public class PlaygroundAuthController {
               example = "550e8400-e29b-41d4-a716-446655440000")
           @PathVariable
           UUID userId,
+      HttpServletRequest request,
       HttpServletResponse response) {
     AuthenticatedUserContext ctx = getAuthenticatedContextOrNull();
-    if (ctx == null || !ctx.isPlayground()) {
-      throw new AccessDeniedException("Not a valid playground session");
+    if (ctx == null) {
+      throw new AccessDeniedException("Authenticated user context is required");
     }
 
     log.info(
@@ -137,11 +139,13 @@ public class PlaygroundAuthController {
         userId,
         ctx.tenantId());
 
+    String refreshToken = resolveRefreshTokenCookie(request);
+    boolean realSession = !ctx.isPlayground();
     PlaygroundImpersonateResponse impersonateResponse =
-        playgroundService.impersonate(ctx.tenantId(), userId, ctx.guestId());
+        playgroundService.impersonate(ctx.tenantId(), userId, ctx.guestId(), realSession);
 
     // Set JWT as HttpOnly cookie — frontend uses cookie-based auth exclusively
-    authCookieSupport.addAuthCookies(response, impersonateResponse.token(), null);
+    authCookieSupport.addAuthCookies(response, impersonateResponse.token(), refreshToken);
 
     return ResponseEntity.ok(impersonateResponse);
   }
@@ -153,16 +157,13 @@ public class PlaygroundAuthController {
           "Returns a list of all active users in the cloned playground tenant that can be impersonated.")
   @ApiResponses({
     @ApiResponse(responseCode = "200", description = "List of personas retrieved successfully"),
-    @ApiResponse(
-        responseCode = "403",
-        description = "Not a valid playground session",
-        content = @Content)
+    @ApiResponse(responseCode = "403", description = "Demo mode is required", content = @Content)
   })
   @PreAuthorize("isAuthenticated()")
   public ResponseEntity<List<PlaygroundPersonaDto>> listPersonas() {
     AuthenticatedUserContext ctx = getAuthenticatedContextOrNull();
-    if (ctx == null || !ctx.isPlayground()) {
-      throw new AccessDeniedException("Not a valid playground session");
+    if (ctx == null) {
+      throw new AccessDeniedException("Authenticated user context is required");
     }
 
     List<PlaygroundPersonaDto> personas = playgroundService.listPersonas(ctx.tenantId());
@@ -173,6 +174,18 @@ public class PlaygroundAuthController {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     if (auth != null && auth.getPrincipal() instanceof AuthenticatedUserContext ctx) {
       return ctx;
+    }
+    return null;
+  }
+
+  private String resolveRefreshTokenCookie(HttpServletRequest request) {
+    if (request.getCookies() == null) {
+      return null;
+    }
+    for (Cookie cookie : request.getCookies()) {
+      if (AuthCookieSupport.REFRESH_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+        return cookie.getValue();
+      }
     }
     return null;
   }

--- a/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
@@ -84,14 +84,7 @@ public class JwtService {
     String contactValue = getVerifiedContactOrThrow(user);
     log.debug("Generating access token for user: {}", contactValue);
 
-    Map<String, Object> claims = buildCommonClaims(user);
-
-    // Load organization for organization_type (category equivalent)
-    Optional<Organization> orgOpt =
-        organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId());
-    orgOpt.ifPresent(o -> claims.put("organization_type", o.getOrganizationType().name()));
-
-    return buildToken(contactValue, claims, accessTokenExpiration);
+    return buildToken(contactValue, buildAccessTokenClaims(user), accessTokenExpiration);
   }
 
   /**
@@ -127,6 +120,29 @@ public class JwtService {
     return buildToken(contactValue, claims, playgroundTokenExpiration);
   }
 
+  /**
+   * Generates a normal-session access token for demo impersonation.
+   *
+   * <p>This keeps the real-login session model: regular access-token lifetime and no {@code
+   * is_playground} claim. Demo authorization is decided from the tenant's demoMode flag, while this
+   * token keeps an explicit impersonation marker for downstream diagnostics and compatibility.
+   */
+  public String generateDemoImpersonationAccessToken(
+      User user, String guestId, String contactValue) {
+    log.debug(
+        "Generating demo impersonation access token for user: {}, guestId: {}",
+        contactValue,
+        guestId);
+
+    Map<String, Object> claims = buildAccessTokenClaims(user);
+    claims.put("demo_impersonation", true);
+    if (guestId != null && !guestId.isBlank()) {
+      claims.put("guest_id", guestId);
+    }
+
+    return buildToken(contactValue, claims, accessTokenExpiration);
+  }
+
   private String getVerifiedContactOrThrow(User user) {
     return user.getAnyVerifiedContact()
         .map(contact -> contact.getContactValue())
@@ -134,6 +150,16 @@ public class JwtService {
             () ->
                 new PlatformDomainException(
                     "User has no verified contact", "AUTH_NO_VERIFIED_CONTACT", 400));
+  }
+
+  private Map<String, Object> buildAccessTokenClaims(User user) {
+    Map<String, Object> claims = buildCommonClaims(user);
+
+    // Load organization for organization_type (category equivalent)
+    Optional<Organization> orgOpt =
+        organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId());
+    orgOpt.ifPresent(o -> claims.put("organization_type", o.getOrganizationType().name()));
+    return claims;
   }
 
   private Map<String, Object> buildCommonClaims(User user) {

--- a/src/main/java/com/fabricmanagement/platform/auth/app/PlaygroundService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/PlaygroundService.java
@@ -1,9 +1,11 @@
 package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
 import com.fabricmanagement.platform.auth.dto.PlaygroundImpersonateResponse;
 import com.fabricmanagement.platform.auth.dto.PlaygroundInitResponse;
 import com.fabricmanagement.platform.auth.dto.PlaygroundPersonaDto;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
 import com.fabricmanagement.platform.organization.domain.Organization;
 import com.fabricmanagement.platform.organization.domain.OrganizationType;
 import com.fabricmanagement.platform.organization.infra.repository.OrganizationRepository;
@@ -32,6 +34,7 @@ public class PlaygroundService {
   private final UserRepository userRepository;
   private final OrganizationRepository organizationRepository;
   private final TransactionTemplate transactionTemplate;
+  private final TenantAccessPort tenantAccessPort;
 
   private static final Map<String, String> PLAYGROUND_JOB_TITLES =
       Map.ofEntries(
@@ -193,6 +196,14 @@ public class PlaygroundService {
 
   @Transactional
   public PlaygroundImpersonateResponse impersonate(UUID tenantId, UUID userId, String guestId) {
+    return impersonate(tenantId, userId, guestId, false);
+  }
+
+  @Transactional
+  public PlaygroundImpersonateResponse impersonate(
+      UUID tenantId, UUID userId, String guestId, boolean preserveRealSession) {
+    requireDemoMode(tenantId);
+
     return TenantContext.executeInTenantContext(
         tenantId,
         () -> {
@@ -203,7 +214,10 @@ public class PlaygroundService {
 
           String contactValue = resolvePlaygroundContact(targetUser);
           String newToken =
-              jwtService.generatePlaygroundAccessToken(targetUser, guestId, contactValue);
+              preserveRealSession
+                  ? jwtService.generateDemoImpersonationAccessToken(
+                      targetUser, guestId, contactValue)
+                  : jwtService.generatePlaygroundAccessToken(targetUser, guestId, contactValue);
 
           String roleName =
               targetUser.getRole() != null ? targetUser.getRole().getRoleName() : "No Role";
@@ -215,6 +229,8 @@ public class PlaygroundService {
 
   @Transactional(readOnly = true)
   public List<PlaygroundPersonaDto> listPersonas(UUID tenantId) {
+    requireDemoMode(tenantId);
+
     return TenantContext.executeInTenantContext(
         tenantId,
         () -> {
@@ -253,6 +269,21 @@ public class PlaygroundService {
                   })
               .toList();
         });
+  }
+
+  private void requireDemoMode(UUID tenantId) {
+    boolean demoMode;
+    try {
+      demoMode = tenantAccessPort.isDemoMode(tenantId);
+    } catch (RuntimeException ex) {
+      log.warn(
+          "Could not resolve demo mode for tenant {}; refusing playground capability", tenantId);
+      demoMode = false;
+    }
+    if (!demoMode) {
+      throw new PlatformDomainException(
+          "Demo mode is required to use playground impersonation", "DEMO_MODE_REQUIRED", 403);
+    }
   }
 
   private String resolvePlaygroundContact(User user) {

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
@@ -278,8 +278,8 @@ public class TenantClonerService {
               String name = "Playground " + playgroundSuffix;
 
               jdbc.update(
-                  "INSERT INTO common_tenant.common_tenant (id, uid, slug, name, type, status, settings, is_active, created_at, updated_at, version) "
-                      + "VALUES (?, ?, ?, ?, ?, ?, '{}'::jsonb, true, now(), now(), 0)",
+                  "INSERT INTO common_tenant.common_tenant (id, uid, slug, name, type, status, settings, demo_mode, is_active, created_at, updated_at, version) "
+                      + "VALUES (?, ?, ?, ?, ?, ?, '{}'::jsonb, true, true, now(), now(), 0)",
                   newTenantId,
                   uid,
                   slug,

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/TenantWriteGuardInterceptorTest.java
@@ -77,6 +77,16 @@ class TenantWriteGuardInterceptorTest {
   }
 
   @Test
+  @DisplayName("EXPIRED tenant playground impersonation passes through read-only guard")
+  void shouldAllowPlaygroundImpersonationForExpiredTenantWriteGuard() {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    assertThat(preHandle("POST", "/api/v1/playground/impersonate/" + UUID.randomUUID())).isTrue();
+    verify(tenantAccessPort, never()).isWritable(tenantId);
+  }
+
+  @Test
   @DisplayName("TRIAL or ACTIVE tenant write passes through")
   void shouldAllowWritableTenantWrite() {
     UUID tenantId = UUID.randomUUID();

--- a/src/test/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyExceptionHandlerTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/web/exception/TenantReadOnlyExceptionHandlerTest.java
@@ -3,9 +3,11 @@ package com.fabricmanagement.common.infrastructure.web.exception;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
 import jakarta.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseEntity;
 
 class TenantReadOnlyExceptionHandlerTest {
 
@@ -22,5 +24,25 @@ class TenantReadOnlyExceptionHandlerTest {
     assertThat(response.getStatus()).isEqualTo(403);
     assertThat(response.getCode()).isEqualTo("TENANT_READ_ONLY");
     assertThat(response.getDetail()).isEqualTo(TenantReadOnlyException.MESSAGE);
+  }
+
+  @Test
+  @DisplayName("handler emits 403 DEMO_MODE_REQUIRED")
+  void shouldEmitDemoModeRequiredProblemDetail() {
+    GlobalExceptionHandler handler = new GlobalExceptionHandler(null);
+    HttpServletRequest request = org.mockito.Mockito.mock(HttpServletRequest.class);
+    when(request.getRequestURI()).thenReturn("/api/v1/playground/personas");
+
+    ResponseEntity<ApiProblemDetail> response =
+        handler.handleDomain(
+            new PlatformDomainException(
+                "Demo mode is required to use playground impersonation", "DEMO_MODE_REQUIRED", 403),
+            request);
+
+    assertThat(response.getStatusCode().value()).isEqualTo(403);
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().getCode()).isEqualTo("DEMO_MODE_REQUIRED");
+    assertThat(response.getBody().getDetail())
+        .isEqualTo("Demo mode is required to use playground impersonation");
   }
 }

--- a/src/test/java/com/fabricmanagement/platform/auth/api/controller/PlaygroundAuthControllerIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/api/controller/PlaygroundAuthControllerIntegrationTest.java
@@ -5,11 +5,22 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fabricmanagement.common.infrastructure.security.AuthCookieSupport;
+import com.fabricmanagement.platform.auth.app.JwtService;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.domain.Department;
+import com.fabricmanagement.platform.user.domain.Role;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.domain.UserDepartment;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
 import com.jayway.jsonpath.JsonPath;
+import jakarta.servlet.http.Cookie;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +37,7 @@ class PlaygroundAuthControllerIntegrationTest extends AbstractIntegrationTest {
 
   @Autowired private MockMvc mockMvc;
   @Autowired private JdbcTemplate jdbc;
+  @Autowired private JwtService jwtService;
 
   @BeforeEach
   void setUpTemplateTenant() {
@@ -194,4 +206,227 @@ class PlaygroundAuthControllerIntegrationTest extends AbstractIntegrationTest {
                 .header("Authorization", "Bearer invalid-token"))
         .andExpect(status().isUnauthorized());
   }
+
+  @Test
+  @DisplayName("Authenticated demo session can list personas and impersonate")
+  void authenticatedDemoSessionCanUsePersonasAndImpersonate() throws Exception {
+    DemoTenantFixture fixture = createDemoTenantFixture(true, "TRIAL");
+    String token = jwtService.generateAccessToken(fixture.owner());
+
+    mockMvc
+        .perform(get("/api/v1/playground/personas").header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(2))));
+
+    mockMvc
+        .perform(
+            post("/api/v1/playground/impersonate/" + fixture.worker().getId())
+                .header("Authorization", "Bearer " + token)
+                .cookie(new Cookie(AuthCookieSupport.REFRESH_TOKEN_COOKIE_NAME, "refresh-token")))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.token").exists())
+        .andExpect(jsonPath("$.userId").value(fixture.worker().getId().toString()))
+        .andExpect(cookie().value(AuthCookieSupport.REFRESH_TOKEN_COOKIE_NAME, "refresh-token"));
+  }
+
+  @Test
+  @DisplayName("Anonymous playground impersonation keeps access-only cookie behavior")
+  void anonymousPlaygroundImpersonationKeepsAccessOnlyCookieBehavior() throws Exception {
+    DemoTenantFixture fixture = createDemoTenantFixture(true, "TRIAL");
+    String token =
+        jwtService.generatePlaygroundAccessToken(fixture.owner(), "guest-1", "owner@example.com");
+
+    mockMvc
+        .perform(
+            post("/api/v1/playground/impersonate/" + fixture.worker().getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isOk())
+        .andExpect(cookie().exists("access_token"))
+        .andExpect(cookie().doesNotExist(AuthCookieSupport.REFRESH_TOKEN_COOKIE_NAME));
+  }
+
+  @Test
+  @DisplayName("Authenticated non-demo ACTIVE tenant is refused with DEMO_MODE_REQUIRED")
+  void authenticatedActiveTenantCannotImpersonate() throws Exception {
+    DemoTenantFixture fixture = createDemoTenantFixture(false, "ACTIVE");
+    String token = jwtService.generateAccessToken(fixture.owner());
+
+    mockMvc
+        .perform(
+            post("/api/v1/playground/impersonate/" + fixture.worker().getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("DEMO_MODE_REQUIRED"));
+
+    mockMvc
+        .perform(get("/api/v1/playground/personas").header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("DEMO_MODE_REQUIRED"));
+  }
+
+  @Test
+  @DisplayName("ACTIVE and EXPIRED tenants cannot impersonate even with playground token claims")
+  void activeAndExpiredTenantsCannotImpersonateEvenWithPlaygroundClaims() throws Exception {
+    assertImpersonationRefusedForStatus("ACTIVE");
+    assertImpersonationRefusedForStatus("EXPIRED");
+  }
+
+  @Test
+  @DisplayName("Unauthenticated playground requests return 401")
+  void unauthenticatedPlaygroundRequestsReturn401() throws Exception {
+    mockMvc.perform(get("/api/v1/playground/personas")).andExpect(status().isUnauthorized());
+
+    mockMvc
+        .perform(post("/api/v1/playground/impersonate/" + UUID.randomUUID()))
+        .andExpect(status().isUnauthorized());
+  }
+
+  private void assertImpersonationRefusedForStatus(String status) throws Exception {
+    DemoTenantFixture fixture = createDemoTenantFixture(false, status);
+    String token =
+        jwtService.generatePlaygroundAccessToken(fixture.owner(), "guest-1", "owner@example.com");
+
+    mockMvc
+        .perform(
+            post("/api/v1/playground/impersonate/" + fixture.worker().getId())
+                .header("Authorization", "Bearer " + token))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value("DEMO_MODE_REQUIRED"));
+  }
+
+  private DemoTenantFixture createDemoTenantFixture(boolean demoMode, String tenantStatus) {
+    String unique = UUID.randomUUID().toString();
+    UUID tenantId = UUID.randomUUID();
+    UUID orgId = UUID.randomUUID();
+    UUID ownerRoleId = UUID.randomUUID();
+    UUID workerRoleId = UUID.randomUUID();
+    UUID departmentId = UUID.randomUUID();
+    UUID ownerId = UUID.randomUUID();
+    UUID workerId = UUID.randomUUID();
+
+    jdbc.update(
+        "INSERT INTO common_tenant.common_tenant (id, uid, slug, name, type, billing_email, status, settings, demo_mode, is_active, created_at, updated_at, version) VALUES (?, ?, ?, 'Demo Tenant', 'REGULAR', 'demo@example.com', ?, '{}', ?, true, now(), now(), 0)",
+        tenantId,
+        "TEN-" + unique.substring(0, 8),
+        "demo-" + unique,
+        tenantStatus,
+        demoMode);
+    jdbc.update(
+        "INSERT INTO common_company.common_organization (id, tenant_id, uid, name, tax_id, organization_type, is_active, created_at, updated_at, version) VALUES (?, ?, ?, 'Demo Org', ?, 'VERTICAL_MILL', true, now(), now(), 0)",
+        orgId,
+        tenantId,
+        "ORG-" + unique.substring(0, 8),
+        "TAX-" + unique.substring(0, 8));
+    jdbc.update(
+        "INSERT INTO common_user.common_role (id, tenant_id, uid, role_name, role_code, role_scope, is_system_role, is_active, created_at, updated_at, version) VALUES (?, ?, ?, 'Owner', 'ADMIN', 'INTERNAL', false, true, now(), now(), 0)",
+        ownerRoleId,
+        tenantId,
+        "ROLE-O-" + unique.substring(0, 8));
+    jdbc.update(
+        "INSERT INTO common_user.common_role (id, tenant_id, uid, role_name, role_code, role_scope, is_system_role, is_active, created_at, updated_at, version) VALUES (?, ?, ?, 'Worker', 'WORKER', 'INTERNAL', false, true, now(), now(), 0)",
+        workerRoleId,
+        tenantId,
+        "ROLE-W-" + unique.substring(0, 8));
+    jdbc.update(
+        "INSERT INTO common_company.common_department (id, tenant_id, uid, organization_id, department_name, department_code, description, is_active, created_at, updated_at, version) VALUES (?, ?, ?, ?, 'Production', 'PRODUCTION', 'Production', true, now(), now(), 0)",
+        departmentId,
+        tenantId,
+        "DEPT-" + unique.substring(0, 8),
+        orgId);
+
+    insertUserWithContact(
+        tenantId, orgId, ownerRoleId, departmentId, ownerId, "Owner", "User", "owner-" + unique);
+    insertUserWithContact(
+        tenantId,
+        orgId,
+        workerRoleId,
+        departmentId,
+        workerId,
+        "Worker",
+        "User",
+        "worker-" + unique);
+
+    User owner = tokenUser(tenantId, orgId, ownerId, ownerRoleId, "ADMIN", "owner-" + unique);
+    User worker = tokenUser(tenantId, orgId, workerId, workerRoleId, "WORKER", "worker-" + unique);
+    return new DemoTenantFixture(owner, worker);
+  }
+
+  private void insertUserWithContact(
+      UUID tenantId,
+      UUID orgId,
+      UUID roleId,
+      UUID departmentId,
+      UUID userId,
+      String firstName,
+      String lastName,
+      String emailPrefix) {
+    UUID contactId = UUID.randomUUID();
+    String email = emailPrefix + "@example.com";
+
+    jdbc.update(
+        "INSERT INTO common_user.common_user (id, tenant_id, uid, organization_id, role_id, first_name, last_name, user_type, is_active, created_at, updated_at, version) VALUES (?, ?, ?, ?, ?, ?, ?, 'INTERNAL', true, now(), now(), 0)",
+        userId,
+        tenantId,
+        "USER-" + userId.toString().substring(0, 8),
+        orgId,
+        roleId,
+        firstName,
+        lastName);
+    jdbc.update(
+        "INSERT INTO common_communication.common_contact (id, tenant_id, uid, contact_value, contact_type, is_verified, is_active, created_at, updated_at, version) VALUES (?, ?, ?, ?, 'EMAIL', true, true, now(), now(), 0)",
+        contactId,
+        tenantId,
+        "CONTACT-" + contactId.toString().substring(0, 8),
+        email);
+    jdbc.update(
+        "INSERT INTO common_user.common_user_contact (user_id, contact_id, tenant_id, uid, is_default, is_active, created_at, updated_at, version) VALUES (?, ?, ?, ?, true, true, now(), now(), 0)",
+        userId,
+        contactId,
+        tenantId,
+        "UCONTACT-" + contactId.toString().substring(0, 8));
+    jdbc.update(
+        "INSERT INTO common_user.common_user_department (user_id, department_id, tenant_id, is_primary, is_active, assigned_at, created_at, updated_at) VALUES (?, ?, ?, true, true, now(), now(), now())",
+        userId,
+        departmentId,
+        tenantId);
+  }
+
+  private User tokenUser(
+      UUID tenantId, UUID orgId, UUID userId, UUID roleId, String roleCode, String emailPrefix) {
+    Role role = Role.create(roleCode, roleCode, roleCode);
+    role.setId(roleId);
+    role.setTenantId(tenantId);
+
+    Department department = Department.create(orgId, "Production", "PRODUCTION", "Production");
+    department.setId(UUID.randomUUID());
+    department.setTenantId(tenantId);
+
+    Contact contact =
+        Contact.builder()
+            .contactType(ContactType.EMAIL)
+            .contactValue(emailPrefix + "@example.com")
+            .isVerified(true)
+            .build();
+
+    User user = User.create(roleCode, "User", orgId);
+    user.setId(userId);
+    user.setTenantId(tenantId);
+    user.setUid("USER-" + userId.toString().substring(0, 8));
+    user.setRole(role);
+    user.getUserContacts()
+        .add(UserContact.builder().user(user).contact(contact).isDefault(true).build());
+    user.getUserDepartments()
+        .add(
+            UserDepartment.builder()
+                .user(user)
+                .userId(userId)
+                .department(department)
+                .departmentId(department.getId())
+                .tenantId(tenantId)
+                .isPrimary(true)
+                .build());
+    return user;
+  }
+
+  private record DemoTenantFixture(User owner, User worker) {}
 }

--- a/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
@@ -7,9 +7,12 @@ import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
 import com.fabricmanagement.platform.communication.domain.Contact;
 import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.domain.Department;
 import com.fabricmanagement.platform.organization.infra.repository.OrganizationRepository;
+import com.fabricmanagement.platform.user.domain.Role;
 import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.domain.UserDepartment;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -70,6 +73,54 @@ class JwtServiceTest {
     assertTokenTtl(claims, PLAYGROUND_TOKEN_EXPIRATION);
     assertThat(claims.get("is_playground", Boolean.class)).isTrue();
     assertThat(claims.get("guest_id", String.class)).isEqualTo("guest-123");
+  }
+
+  @Test
+  @DisplayName("demo impersonation access token preserves normal session lifetime")
+  void generateDemoImpersonationAccessToken_usesRegularAccessTokenExpiration() {
+    User user = buildUser();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+    when(organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId()))
+        .thenReturn(Optional.empty());
+
+    Claims claims =
+        parse(
+            jwtService.generateDemoImpersonationAccessToken(
+                user, "guest-123", "guest@example.com"));
+
+    assertTokenTtl(claims, ACCESS_TOKEN_EXPIRATION);
+    assertThat(claims.get("is_playground", Boolean.class)).isNull();
+    assertThat(claims.get("demo_impersonation", Boolean.class)).isTrue();
+    assertThat(claims.get("guest_id", String.class)).isEqualTo("guest-123");
+  }
+
+  @Test
+  @DisplayName("demo impersonation context matches real login context for data-scope inputs")
+  void generateDemoImpersonationAccessToken_matchesRealLoginSecurityContextClaims() {
+    User user = buildWorkerUser();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+    when(organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId()))
+        .thenReturn(Optional.empty());
+
+    JwtService.AuthTokenClaims realLoginClaims =
+        jwtService.extractAuthContext(jwtService.generateAccessToken(user));
+    JwtService.AuthTokenClaims impersonationClaims =
+        jwtService.extractAuthContext(
+            jwtService.generateDemoImpersonationAccessToken(
+                user, "guest-123", "worker@example.com"));
+
+    assertThat(impersonationClaims.userId()).isEqualTo(realLoginClaims.userId());
+    assertThat(impersonationClaims.tenantId()).isEqualTo(realLoginClaims.tenantId());
+    assertThat(impersonationClaims.roleCode()).isEqualTo("WORKER");
+    assertThat(impersonationClaims.roleCode()).isEqualTo(realLoginClaims.roleCode());
+    assertThat(impersonationClaims.departmentCodes())
+        .containsExactlyElementsOf(realLoginClaims.departmentCodes());
+    assertThat(impersonationClaims.primaryDepartment())
+        .isEqualTo(realLoginClaims.primaryDepartment());
   }
 
   @Test
@@ -156,6 +207,32 @@ class JwtServiceTest {
     user.setTenantId(tenantId);
     user.setUid("TEST-001-USER-00001");
     user.getUserContacts().add(UserContact.builder().contact(contact).isDefault(true).build());
+    return user;
+  }
+
+  private static User buildWorkerUser() {
+    User user = buildUser();
+
+    Role role = Role.create("Worker", "WORKER", "Worker");
+    role.setId(UUID.randomUUID());
+    role.setTenantId(user.getTenantId());
+    user.setRole(role);
+
+    Department department =
+        Department.create(user.getOrganizationId(), "Production", "PRODUCTION", "Production");
+    department.setId(UUID.randomUUID());
+    department.setTenantId(user.getTenantId());
+
+    user.getUserDepartments()
+        .add(
+            UserDepartment.builder()
+                .user(user)
+                .userId(user.getId())
+                .department(department)
+                .departmentId(department.getId())
+                .tenantId(user.getTenantId())
+                .isPrimary(true)
+                .build());
     return user;
   }
 }

--- a/src/test/java/com/fabricmanagement/platform/auth/app/PlaygroundServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/PlaygroundServiceTest.java
@@ -1,0 +1,191 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.platform.auth.dto.PlaygroundImpersonateResponse;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.domain.Department;
+import com.fabricmanagement.platform.organization.domain.Organization;
+import com.fabricmanagement.platform.organization.domain.OrganizationType;
+import com.fabricmanagement.platform.organization.infra.repository.OrganizationRepository;
+import com.fabricmanagement.platform.tenant.app.TenantClonerService;
+import com.fabricmanagement.platform.user.domain.Role;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.domain.UserDepartment;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@DisplayName("PlaygroundService")
+class PlaygroundServiceTest {
+
+  private final TenantClonerService tenantClonerService =
+      org.mockito.Mockito.mock(TenantClonerService.class);
+  private final JwtService jwtService = org.mockito.Mockito.mock(JwtService.class);
+  private final UserRepository userRepository = org.mockito.Mockito.mock(UserRepository.class);
+  private final OrganizationRepository organizationRepository =
+      org.mockito.Mockito.mock(OrganizationRepository.class);
+  private final TransactionTemplate transactionTemplate =
+      org.mockito.Mockito.mock(TransactionTemplate.class);
+  private final TenantAccessPort tenantAccessPort =
+      org.mockito.Mockito.mock(TenantAccessPort.class);
+
+  private final PlaygroundService service =
+      new PlaygroundService(
+          tenantClonerService,
+          jwtService,
+          userRepository,
+          organizationRepository,
+          transactionTemplate,
+          tenantAccessPort);
+
+  @Test
+  @DisplayName("impersonate succeeds when tenant is in demo mode")
+  void impersonateSucceedsInDemoMode() {
+    UUID tenantId = UUID.randomUUID();
+    User user = user(tenantId, "Worker", "One", "worker@example.com");
+    when(tenantAccessPort.isDemoMode(tenantId)).thenReturn(true);
+    when(userRepository.findByTenantIdAndId(tenantId, user.getId())).thenReturn(Optional.of(user));
+    when(jwtService.generatePlaygroundAccessToken(user, "guest-1", "worker@example.com"))
+        .thenReturn("persona-token");
+
+    PlaygroundImpersonateResponse response = service.impersonate(tenantId, user.getId(), "guest-1");
+
+    assertThat(response.token()).isEqualTo("persona-token");
+    assertThat(response.userId()).isEqualTo(user.getId());
+  }
+
+  @Test
+  @DisplayName("impersonate uses normal-session token when preserving a real demo session")
+  void impersonatePreservesRealSessionTokenModel() {
+    UUID tenantId = UUID.randomUUID();
+    User user = user(tenantId, "Worker", "One", "worker@example.com");
+    when(tenantAccessPort.isDemoMode(tenantId)).thenReturn(true);
+    when(userRepository.findByTenantIdAndId(tenantId, user.getId())).thenReturn(Optional.of(user));
+    when(jwtService.generateDemoImpersonationAccessToken(user, null, "worker@example.com"))
+        .thenReturn("demo-impersonation-token");
+
+    PlaygroundImpersonateResponse response =
+        service.impersonate(tenantId, user.getId(), null, true);
+
+    assertThat(response.token()).isEqualTo("demo-impersonation-token");
+    verify(jwtService, never()).generatePlaygroundAccessToken(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("impersonate refuses when tenant is not in demo mode")
+  void impersonateRefusesOutsideDemoMode() {
+    UUID tenantId = UUID.randomUUID();
+    when(tenantAccessPort.isDemoMode(tenantId)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.impersonate(tenantId, UUID.randomUUID(), "guest-1"))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("DEMO_MODE_REQUIRED", 403);
+
+    verify(userRepository, never()).findByTenantIdAndId(any(), any());
+  }
+
+  @Test
+  @DisplayName("impersonate fails closed when demo mode cannot be resolved")
+  void impersonateFailsClosedWhenDemoModeResolutionFails() {
+    UUID tenantId = UUID.randomUUID();
+    when(tenantAccessPort.isDemoMode(tenantId)).thenThrow(new IllegalStateException("boom"));
+
+    assertThatThrownBy(() -> service.impersonate(tenantId, UUID.randomUUID(), "guest-1"))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("DEMO_MODE_REQUIRED", 403);
+  }
+
+  @Test
+  @DisplayName("listPersonas succeeds when tenant is in demo mode")
+  void listPersonasSucceedsInDemoMode() {
+    UUID tenantId = UUID.randomUUID();
+    User user = user(tenantId, "Worker", "One", "worker@example.com");
+    Organization org = organization(tenantId, user.getOrganizationId());
+    when(tenantAccessPort.isDemoMode(tenantId)).thenReturn(true);
+    when(userRepository.findByTenantIdWithRelations(tenantId)).thenReturn(List.of(user));
+    when(organizationRepository.findByTenantIdAndIsActiveTrue(tenantId)).thenReturn(List.of(org));
+
+    var personas = service.listPersonas(tenantId);
+
+    assertThat(personas).hasSize(1);
+    assertThat(personas.get(0).id()).isEqualTo(user.getId());
+  }
+
+  @Test
+  @DisplayName("listPersonas refuses when tenant is not in demo mode")
+  void listPersonasRefusesOutsideDemoMode() {
+    UUID tenantId = UUID.randomUUID();
+    when(tenantAccessPort.isDemoMode(tenantId)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.listPersonas(tenantId))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("DEMO_MODE_REQUIRED", 403);
+
+    verify(userRepository, never()).findByTenantIdWithRelations(any());
+  }
+
+  private static User user(UUID tenantId, String firstName, String lastName, String email) {
+    UUID organizationId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+
+    Role role = Role.create("Worker", "WORKER", "Worker");
+    role.setId(UUID.randomUUID());
+    role.setTenantId(tenantId);
+
+    Department department =
+        Department.create(organizationId, "Production", "PRODUCTION", "Production");
+    department.setId(UUID.randomUUID());
+    department.setTenantId(tenantId);
+
+    Contact contact =
+        Contact.builder()
+            .contactType(ContactType.EMAIL)
+            .contactValue(email)
+            .isVerified(true)
+            .build();
+
+    User user = User.create(firstName, lastName, organizationId);
+    user.setId(userId);
+    user.setTenantId(tenantId);
+    user.setUid("TEST-001-USER-" + userId.toString().substring(0, 8));
+    user.setRole(role);
+    user.getUserContacts()
+        .add(UserContact.builder().user(user).contact(contact).isDefault(true).build());
+    user.getUserDepartments()
+        .add(
+            UserDepartment.builder()
+                .user(user)
+                .userId(userId)
+                .department(department)
+                .departmentId(department.getId())
+                .tenantId(tenantId)
+                .isPrimary(true)
+                .build());
+    return user;
+  }
+
+  private static Organization organization(UUID tenantId, UUID organizationId) {
+    Organization org =
+        Organization.create("Demo Org", "1234567890", OrganizationType.VERTICAL_MILL);
+    org.setId(organizationId);
+    org.setTenantId(tenantId);
+    return org;
+  }
+}


### PR DESCRIPTION
Move "view as persona" authorization from the is_playground JWT claim to the tenant demoMode capability, enforced at the service layer, so the register-first demo experience (a real login into a demoMode tenant) can switch personas — not just the legacy anonymous playground.

- PlaygroundService: require demoMode (via TenantAccessPort.isDemoMode) in impersonate() and listPersonas(); fail-closed to PlatformDomainException DEMO_MODE_REQUIRED (403). The service gate is the single source of truth; the controller drops its is_playground check (keeps the auth-context guard).
- JwtService: add generateDemoImpersonationAccessToken — normal access-token lifetime with the same claims as a real login (so PERM-4 data-scope is identical under view-as) plus a demo_impersonation marker, no is_playground.
- PlaygroundAuthController: for a real session, mint the demo-impersonation token and preserve the refresh cookie (no 15-min access-only downgrade); legacy anonymous playground behaviour unchanged.
- TenantClonerService: anonymous playground clones now set demo_mode=true so the legacy init -> personas/impersonate path passes the new gate.
- TenantWriteGuardInterceptor: allow-list /api/v1/playground/impersonate/** so the demoMode gate (not the read-only write guard) decides, returning DEMO_MODE_REQUIRED for non-demo tenants.

Safety invariant (tested): demoMode=false (real trial after go-real, ACTIVE, EXPIRED) hard-refuses impersonation. Unblocks TRIAL-8 (learn-mode control panel).