### PR TITLE
feat(trial): reset/reseed demo (purge sandbox, restore fresh seed)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -12,6 +12,8 @@ servers:
 tags:
 - description: Mobile Offline Synchronization API
   name: Offline Sync
+- description: Demo tenant reset operations
+  name: Tenant Demo Reset
 - description: Payment operations
   name: Payment
 - description: Manage certifications for trading partners
@@ -39872,6 +39874,70 @@ paths:
           description: Internal Server Error
       tags:
       - Tenant Go Real
+  /api/v1/tenant/reset-demo:
+    post:
+      description: Requires a demo-mode tenant owner. Purges sandbox demo data and
+        restores fresh sample personas and business data while keeping the tenant
+        in demo mode.
+      operationId: resetDemo
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ResetDemoResponse"
+          description: Demo reset with fresh sample data
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content: {}
+          description: DEMO_MODE_REQUIRED or RESET_REQUIRES_OWNER
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Reset demo data
+      tags:
+      - Tenant Demo Reset
   /api/v1/webhooks/whatsapp:
     get:
       description: Meta webhook verification endpoint (GET)
@@ -53197,6 +53263,32 @@ components:
       required:
       - quantity
       - referenceType
+    ResetDemoResponse:
+      type: object
+      description: Summary returned after resetting a demo tenant with fresh sample
+        data
+      properties:
+        demoMode:
+          type: boolean
+          description: Whether the tenant remains in demo mode
+          example: true
+        purgedRows:
+          type: object
+          additionalProperties:
+            type: integer
+            format: int32
+          description: Rows purged by table or purge category
+        seededPersonaUsers:
+          type: integer
+          format: int32
+          description: Number of persona users seeded after the reset
+          example: 15
+        tenantId:
+          type: string
+          format: uuid
+          description: Tenant ID
+      required:
+      - tenantId
     RetireHrPolicyPackRequest:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/platform/tenant/api/controller/TenantResetController.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/api/controller/TenantResetController.java
@@ -1,0 +1,66 @@
+package com.fabricmanagement.platform.tenant.api.controller;
+
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.tenant.app.TenantResetService;
+import com.fabricmanagement.platform.tenant.dto.ResetDemoResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tenant")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "Tenant Demo Reset", description = "Demo tenant reset operations")
+public class TenantResetController {
+
+  private final TenantResetService tenantResetService;
+
+  @PostMapping("/reset-demo")
+  @PreAuthorize("isAuthenticated()")
+  @Operation(
+      summary = "Reset demo data",
+      description =
+          "Requires a demo-mode tenant owner. Purges sandbox demo data and restores fresh sample personas and business data while keeping the tenant in demo mode.")
+  @ApiResponses({
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "200",
+        description = "Demo reset with fresh sample data",
+        content = @Content(schema = @Schema(implementation = ResetDemoResponse.class))),
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+        responseCode = "403",
+        description = "DEMO_MODE_REQUIRED or RESET_REQUIRES_OWNER",
+        content = @Content)
+  })
+  public ResponseEntity<ApiResponse<ResetDemoResponse>> resetDemo() {
+    AuthenticatedUserContext ctx = currentUser();
+    log.info("Demo reset requested: tenantId={}, userId={}", ctx.tenantId(), ctx.userId());
+
+    ResetDemoResponse response = tenantResetService.reset(ctx);
+    return ResponseEntity.ok(ApiResponse.success(response, "Demo reset with fresh sample data"));
+  }
+
+  private AuthenticatedUserContext currentUser() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    if (auth != null && auth.getDetails() instanceof AuthenticatedUserContext ctx) {
+      return ctx;
+    }
+    if (auth != null && auth.getPrincipal() instanceof AuthenticatedUserContext ctx) {
+      return ctx;
+    }
+    throw new PlatformDomainException("User not authenticated", "USER_NOT_AUTHENTICATED", 401);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantResetService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantResetService.java
@@ -1,0 +1,164 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import com.fabricmanagement.common.infrastructure.bootstrap.DemoTransactionSeeder;
+import com.fabricmanagement.common.infrastructure.bootstrap.UserSeeder;
+import com.fabricmanagement.common.infrastructure.bootstrap.UserSeeder.PersonaSubset;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.tenant.dto.ResetDemoResponse;
+import com.fabricmanagement.platform.user.app.UserContactAssignmentService;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.CacheManager;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TenantResetService {
+
+  private static final String TENANT_DEMOMODE_CACHE = "tenant-demomode";
+  private static final String USERS_BY_TENANT_CACHE = "users-by-tenant";
+
+  private final TenantAccessPort tenantAccessPort;
+  private final UserRepository userRepository;
+  private final UserContactAssignmentService userContactAssignmentService;
+  private final TenantTransactionalPurgeService purgeService;
+  private final UserSeeder userSeeder;
+  private final DemoTransactionSeeder demoTransactionSeeder;
+  private final CacheManager cacheManager;
+
+  /**
+   * Resets a demo tenant in the same sequential model as registered demo provisioning: purge under
+   * the system transaction, then run the existing seeders. If reseeding fails after purge, the
+   * owner can retry because a later reset purges any partial demo_seed rows and reseeds again.
+   */
+  public ResetDemoResponse reset(AuthenticatedUserContext ctx) {
+    if (ctx == null || ctx.tenantId() == null || ctx.userId() == null) {
+      throw new PlatformDomainException("User not authenticated", "USER_NOT_AUTHENTICATED", 401);
+    }
+
+    UUID tenantId = ctx.tenantId();
+    UUID userId = ctx.userId();
+    requireDemoMode(tenantId);
+
+    User caller =
+        userRepository
+            .findByTenantIdAndId(tenantId, userId)
+            .orElseThrow(
+                () -> new PlatformDomainException("User not found", "USER_NOT_FOUND", 404));
+    ensureOwnerCanReset(caller);
+    String ownerEmail = resolveOwnerEmail(tenantId, userId);
+
+    TenantTransactionalPurgeService.PurgeDemoDataResult purgeResult =
+        purgeService.purgeDemoData(tenantId);
+
+    int seededPersonaUsers;
+    try {
+      seededPersonaUsers = userSeeder.seedFor(tenantId, ownerEmail, PersonaSubset.REPRESENTATIVE);
+      demoTransactionSeeder.seedFor(tenantId);
+    } catch (RuntimeException ex) {
+      log.error(
+          "Demo reset reseed failed after purge; tenant remains resettable: tenantId={}",
+          tenantId,
+          ex);
+      evictResetCaches(tenantId);
+      throw new PlatformDomainException(
+          "Demo reset failed while restoring sample data. Please retry reset.",
+          "DEMO_RESET_RESEED_FAILED",
+          500);
+    }
+
+    evictResetCaches(tenantId);
+    log.info(
+        "Demo reset completed: tenantId={}, userId={}, seededPersonaUsers={}, purgedRows={}",
+        tenantId,
+        userId,
+        seededPersonaUsers,
+        purgeResult.deletedRows());
+    return new ResetDemoResponse(tenantId, true, seededPersonaUsers, purgeResult.deletedRows());
+  }
+
+  private void requireDemoMode(UUID tenantId) {
+    boolean demoMode;
+    try {
+      demoMode = tenantAccessPort.isDemoMode(tenantId);
+    } catch (RuntimeException ex) {
+      log.warn("Could not resolve demo mode for tenant {}; refusing demo reset", tenantId);
+      demoMode = false;
+    }
+    if (!demoMode) {
+      throw new PlatformDomainException(
+          "Demo mode is required to reset sample data", "DEMO_MODE_REQUIRED", 403);
+    }
+  }
+
+  private void ensureOwnerCanReset(User caller) {
+    if (caller.isDemoSeed()) {
+      throw new PlatformDomainException(
+          "Seeded demo users cannot reset demo data", "RESET_REQUIRES_OWNER", 403);
+    }
+    String roleCode = caller.getRole() != null ? caller.getRole().getRoleCode() : null;
+    if (!"ADMIN".equalsIgnoreCase(roleCode) && !"PLATFORM_ADMIN".equalsIgnoreCase(roleCode)) {
+      throw new PlatformDomainException(
+          "Only a tenant owner or admin can reset demo data", "RESET_REQUIRES_OWNER", 403);
+    }
+  }
+
+  private String resolveOwnerEmail(UUID tenantId, UUID userId) {
+    List<UserContact> contacts =
+        TenantContext.executeInTenantContext(
+            tenantId, () -> userContactAssignmentService.getUserContacts(userId));
+    Comparator<UserContact> defaultFirst =
+        Comparator.comparing((UserContact uc) -> Boolean.TRUE.equals(uc.getIsDefault())).reversed();
+
+    return contacts.stream()
+        .filter(this::hasEmailContact)
+        .filter(uc -> Boolean.TRUE.equals(uc.getContact().getIsVerified()))
+        .sorted(defaultFirst)
+        .map(uc -> uc.getContact().getContactValue())
+        .filter(value -> value != null && !value.isBlank())
+        .findFirst()
+        .or(
+            () ->
+                contacts.stream()
+                    .filter(this::hasEmailContact)
+                    .filter(uc -> Boolean.TRUE.equals(uc.getIsDefault()))
+                    .map(uc -> uc.getContact().getContactValue())
+                    .filter(value -> value != null && !value.isBlank())
+                    .findFirst())
+        .orElseThrow(
+            () ->
+                new PlatformDomainException(
+                    "A verified owner email is required to reset demo data",
+                    "OWNER_EMAIL_REQUIRED",
+                    400));
+  }
+
+  private boolean hasEmailContact(UserContact userContact) {
+    Contact contact = userContact.getContact();
+    return contact != null && ContactType.EMAIL.equals(contact.getContactType());
+  }
+
+  private void evictResetCaches(UUID tenantId) {
+    evict(TENANT_DEMOMODE_CACHE, tenantId.toString());
+    evict(USERS_BY_TENANT_CACHE, tenantId.toString());
+  }
+
+  private void evict(String cacheName, String key) {
+    var cache = cacheManager.getCache(cacheName);
+    if (cache != null) {
+      cache.evict(key);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -108,7 +108,6 @@ public class TenantTransactionalPurgeService {
           "production.production_quality_fiber_test_result",
           "production.production_execution_batch_attribute",
           "production.production_execution_batch_certification",
-          "production.production_execution_batch_override_log",
           "production.production_execution_batch_reservation",
           "production.production_execution_inventory_transaction",
           "production.production_execution_inventory_balance",
@@ -127,7 +126,6 @@ public class TenantTransactionalPurgeService {
           "procurement.subcontract_order",
           "procurement.purchase_order_line",
           "procurement.purchase_order",
-          "sales_ord.sales_order_line_processed_shipments",
           "sales_ord.sales_order_line",
           "sales_ord.sales_order",
           "sales.sample_delivery",
@@ -229,9 +227,36 @@ public class TenantTransactionalPurgeService {
 
   private void deleteTransactionalRows(
       JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    deleteChildRowsWithoutTenantId(jdbc, tenantId, rows);
     for (String table : TRANSACTIONAL_TABLES) {
       delete(jdbc, rows, table, "DELETE FROM " + table + " WHERE tenant_id = ?", tenantId);
     }
+  }
+
+  private void deleteChildRowsWithoutTenantId(
+      JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    delete(
+        jdbc,
+        rows,
+        "production.production_execution_batch_override_log",
+        """
+        DELETE FROM production.production_execution_batch_override_log log
+        USING production.production_execution_batch batch
+        WHERE log.batch_id = batch.id
+          AND batch.tenant_id = ?
+        """,
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "sales_ord.sales_order_line_processed_shipments",
+        """
+        DELETE FROM sales_ord.sales_order_line_processed_shipments processed
+        USING sales_ord.sales_order_line line
+        WHERE processed.sales_order_line_id = line.id
+          AND line.tenant_id = ?
+        """,
+        tenantId);
   }
 
   private void deleteTradingPartnerRows(

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -166,11 +166,7 @@ public class TenantTransactionalPurgeService {
         systemExecutor.executeInTransaction(
             jdbc -> {
               ensureTenantIsDemoMode(jdbc, tenantId);
-              Map<String, Integer> rows = new LinkedHashMap<>();
-              deleteTransactionalRows(jdbc, tenantId, rows);
-              deleteSeedUsers(jdbc, tenantId, rows);
-              deleteTradingPartnerRows(jdbc, tenantId, rows);
-              deleteProductReferenceRows(jdbc, tenantId, rows);
+              Map<String, Integer> rows = purgeDemoData(jdbc, tenantId);
               flipDemoModeAndStartClock(jdbc, tenantId, now, trialEndsAt);
               return rows;
             });
@@ -182,6 +178,32 @@ public class TenantTransactionalPurgeService {
         trialEndsAt,
         deletedRows);
     return new PurgeResult(tenantId, deletedRows, now, trialEndsAt);
+  }
+
+  public PurgeDemoDataResult purgeDemoData(UUID tenantId) {
+    if (tenantId == null) {
+      throw new PlatformDomainException("Tenant not found", "TENANT_NOT_FOUND", 404);
+    }
+
+    Map<String, Integer> deletedRows =
+        systemExecutor.executeInTransaction(
+            jdbc -> {
+              ensureTenantIsDemoMode(jdbc, tenantId);
+              return purgeDemoData(jdbc, tenantId);
+            });
+
+    log.info(
+        "Tenant demo data purge completed: tenantId={}, deletedRows={}", tenantId, deletedRows);
+    return new PurgeDemoDataResult(tenantId, deletedRows);
+  }
+
+  private Map<String, Integer> purgeDemoData(JdbcTemplate jdbc, UUID tenantId) {
+    Map<String, Integer> rows = new LinkedHashMap<>();
+    deleteTransactionalRows(jdbc, tenantId, rows);
+    deleteSeedUsers(jdbc, tenantId, rows);
+    deleteTradingPartnerRows(jdbc, tenantId, rows);
+    deleteProductReferenceRows(jdbc, tenantId, rows);
+    return rows;
   }
 
   private void ensureTenantIsDemoMode(JdbcTemplate jdbc, UUID tenantId) {
@@ -560,4 +582,6 @@ public class TenantTransactionalPurgeService {
       Map<String, Integer> deletedRows,
       Instant trialStartedAt,
       Instant trialEndsAt) {}
+
+  public record PurgeDemoDataResult(UUID tenantId, Map<String, Integer> deletedRows) {}
 }

--- a/src/main/java/com/fabricmanagement/platform/tenant/dto/ResetDemoResponse.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/dto/ResetDemoResponse.java
@@ -1,0 +1,15 @@
+package com.fabricmanagement.platform.tenant.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import java.util.UUID;
+
+@Schema(description = "Summary returned after resetting a demo tenant with fresh sample data")
+public record ResetDemoResponse(
+    @Schema(description = "Tenant ID", requiredMode = Schema.RequiredMode.REQUIRED) UUID tenantId,
+    @Schema(description = "Whether the tenant remains in demo mode", example = "true")
+        boolean demoMode,
+    @Schema(description = "Number of persona users seeded after the reset", example = "15")
+        int seededPersonaUsers,
+    @Schema(description = "Rows purged by table or purge category")
+        Map<String, Integer> purgedRows) {}

--- a/src/test/java/com/fabricmanagement/platform/tenant/api/controller/TenantResetControllerTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/api/controller/TenantResetControllerTest.java
@@ -1,0 +1,57 @@
+package com.fabricmanagement.platform.tenant.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.platform.tenant.app.TenantResetService;
+import com.fabricmanagement.platform.tenant.dto.ResetDemoResponse;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+@ExtendWith(MockitoExtension.class)
+class TenantResetControllerTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+  @Mock private TenantResetService tenantResetService;
+
+  @AfterEach
+  void tearDown() {
+    SecurityContextHolder.clearContext();
+  }
+
+  @Test
+  void shouldResetDemoAndReturnWrappedSummary() {
+    TenantResetController controller = new TenantResetController(tenantResetService);
+    AuthenticatedUserContext ctx =
+        new AuthenticatedUserContext(USER_ID, "ADMIN", List.of(), null, TENANT_ID);
+    TestingAuthenticationToken authentication =
+        new TestingAuthenticationToken("principal", "credentials");
+    authentication.setDetails(ctx);
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+    ResetDemoResponse resetResponse =
+        new ResetDemoResponse(TENANT_ID, true, 15, Map.of("sales.quote", 2));
+    when(tenantResetService.reset(ctx)).thenReturn(resetResponse);
+
+    ResponseEntity<ApiResponse<ResetDemoResponse>> response = controller.resetDemo();
+
+    assertThat(response.getBody()).isNotNull();
+    assertThat(response.getBody().isSuccess()).isTrue();
+    assertThat(response.getBody().getData()).isEqualTo(resetResponse);
+    assertThat(response.getBody().getMessage()).isEqualTo("Demo reset with fresh sample data");
+    verify(tenantResetService).reset(ctx);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
@@ -1,0 +1,203 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.platform.communication.app.EmailTemplateRenderer;
+import com.fabricmanagement.platform.communication.app.NotificationService;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+@AutoConfigureMockMvc(addFilters = false)
+class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private MockMvc mockMvc;
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private TenantResetService tenantResetService;
+
+  @MockBean private NotificationService notificationService;
+  @MockBean private EmailTemplateRenderer emailTemplateRenderer;
+
+  @Test
+  @DisplayName("Reset demo restores registered demo seed while preserving tenant, owner, and clock")
+  void resetRegisteredDemo_restoresSeedAndKeepsDemoMode() throws Exception {
+    doNothing()
+        .when(notificationService)
+        .sendNotificationSync(anyString(), anyString(), anyString());
+    when(emailTemplateRenderer.renderSetupPassword(
+            anyString(), anyString(), anyString(), anyString()))
+        .thenReturn("Setup password email body");
+    when(emailTemplateRenderer.renderWelcome(anyString(), anyString(), anyString(), anyString()))
+        .thenReturn("Welcome email body");
+
+    long suffix = System.currentTimeMillis();
+    String ownerEmail = "reset-owner-" + suffix + "@example.com";
+    String ownerAliasPattern = "reset-owner-" + suffix + "+%@example.com";
+    String organizationName = "Reset Demo Company " + suffix;
+    String body =
+        """
+        {
+          "organizationName": "%s",
+          "taxId": "RESET%s",
+          "organizationType": "VERTICAL_MILL",
+          "firstName": "Reset",
+          "lastName": "Owner",
+          "email": "%s",
+          "acceptedTerms": true
+        }
+        """
+            .formatted(organizationName, suffix % 100000000, ownerEmail);
+
+    mockMvc
+        .perform(
+            post("/api/v1/public/signup")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+        .andExpect(status().isOk());
+
+    UUID tenantId =
+        jdbc.queryForObject(
+            "SELECT id FROM common_tenant.common_tenant WHERE name = ?",
+            UUID.class,
+            organizationName);
+    UUID ownerId = findUserIdByContact(ownerEmail);
+    UUID realUserId = insertRealUser(tenantId);
+    Timestamp trialStartedAt = tenantTimestamp(tenantId, "trial_started_at");
+    Timestamp trialEndsAt = tenantTimestamp(tenantId, "trial_ends_at");
+    UUID mutatedSeedUserId =
+        jdbc.queryForObject(
+            "SELECT id FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true LIMIT 1",
+            UUID.class,
+            tenantId);
+    jdbc.update(
+        "UPDATE common_user.common_user SET first_name = 'MutatedSeed' WHERE id = ?",
+        mutatedSeedUserId);
+
+    tenantResetService.reset(
+        new AuthenticatedUserContext(ownerId, "ADMIN", List.of(), null, tenantId));
+
+    assertThat(booleanTenantValue(tenantId, "demo_mode")).isTrue();
+    assertThat(tenantTimestamp(tenantId, "trial_started_at")).isEqualTo(trialStartedAt);
+    assertThat(tenantTimestamp(tenantId, "trial_ends_at")).isEqualTo(trialEndsAt);
+    assertThat(userExists(ownerId)).isTrue();
+    assertThat(userExists(realUserId)).isTrue();
+    assertThat(countSeedUsers(tenantId)).isGreaterThan(0);
+    assertThat(countUsersByFirstName(tenantId, "MutatedSeed")).isZero();
+    assertThat(countAliasUsers(ownerAliasPattern, true)).isGreaterThan(0);
+    assertThat(countAliasUsers(ownerAliasPattern, false)).isZero();
+    assertThat(countRows("common_company.common_trading_partner", tenantId)).isGreaterThan(0);
+  }
+
+  private UUID findUserIdByContact(String contactValue) {
+    return jdbc.queryForObject(
+        """
+        SELECT u.id
+        FROM common_user.common_user u
+        JOIN common_user.common_user_contact uc ON uc.user_id = u.id
+        JOIN common_communication.common_contact c ON c.id = uc.contact_id
+        WHERE lower(c.contact_value) = lower(?)
+        """,
+        UUID.class,
+        contactValue);
+  }
+
+  private UUID insertRealUser(UUID tenantId) {
+    UUID organizationId =
+        jdbc.queryForObject(
+            "SELECT id FROM common_company.common_organization WHERE tenant_id = ? LIMIT 1",
+            UUID.class,
+            tenantId);
+    UUID roleId =
+        jdbc.queryForObject(
+            "SELECT id FROM common_user.common_role WHERE tenant_id = ? AND role_code = 'WORKER' LIMIT 1",
+            UUID.class,
+            tenantId);
+    UUID userId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO common_user.common_user
+          (id, tenant_id, uid, organization_id, role_id, first_name, last_name, user_type,
+           is_active, demo_seed, created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, ?, 'Real', 'User', 'INTERNAL', true, false, now(), now(), 0)
+        """,
+        userId,
+        tenantId,
+        "REAL-" + UUID.randomUUID(),
+        organizationId,
+        roleId);
+    return userId;
+  }
+
+  private Timestamp tenantTimestamp(UUID tenantId, String column) {
+    return jdbc.queryForObject(
+        "SELECT " + column + " FROM common_tenant.common_tenant WHERE id = ?",
+        Timestamp.class,
+        tenantId);
+  }
+
+  private Boolean booleanTenantValue(UUID tenantId, String column) {
+    return jdbc.queryForObject(
+        "SELECT " + column + " FROM common_tenant.common_tenant WHERE id = ?",
+        Boolean.class,
+        tenantId);
+  }
+
+  private boolean userExists(UUID userId) {
+    Integer count =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM common_user.common_user WHERE id = ?", Integer.class, userId);
+    return count != null && count == 1;
+  }
+
+  private Integer countSeedUsers(UUID tenantId) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true",
+        Integer.class,
+        tenantId);
+  }
+
+  private Integer countUsersByFirstName(UUID tenantId, String firstName) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM common_user.common_user WHERE tenant_id = ? AND first_name = ?",
+        Integer.class,
+        tenantId,
+        firstName);
+  }
+
+  private Integer countAliasUsers(String aliasPattern, boolean demoSeed) {
+    return jdbc.queryForObject(
+        """
+        SELECT count(*)
+        FROM common_user.common_user u
+        JOIN common_user.common_user_contact uc ON uc.user_id = u.id
+        JOIN common_communication.common_contact c ON c.id = uc.contact_id
+        WHERE lower(c.contact_value) LIKE lower(?)
+          AND u.demo_seed = ?
+        """,
+        Integer.class,
+        aliasPattern,
+        demoSeed);
+  }
+
+  private Integer countRows(String table, UUID tenantId) {
+    return jdbc.queryForObject(
+        "SELECT count(*) FROM " + table + " WHERE tenant_id = ?", Integer.class, tenantId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceTest.java
@@ -1,0 +1,193 @@
+package com.fabricmanagement.platform.tenant.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.bootstrap.DemoTransactionSeeder;
+import com.fabricmanagement.common.infrastructure.bootstrap.UserSeeder;
+import com.fabricmanagement.common.infrastructure.bootstrap.UserSeeder.PersonaSubset;
+import com.fabricmanagement.common.infrastructure.security.AuthenticatedUserContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantAccessPort;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.tenant.dto.ResetDemoResponse;
+import com.fabricmanagement.platform.user.app.UserContactAssignmentService;
+import com.fabricmanagement.platform.user.domain.Role;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.CacheManager;
+
+@ExtendWith(MockitoExtension.class)
+class TenantResetServiceTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+  private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
+  private static final UUID CONTACT_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
+
+  @Mock private TenantAccessPort tenantAccessPort;
+  @Mock private UserRepository userRepository;
+  @Mock private UserContactAssignmentService userContactAssignmentService;
+  @Mock private TenantTransactionalPurgeService purgeService;
+  @Mock private UserSeeder userSeeder;
+  @Mock private DemoTransactionSeeder demoTransactionSeeder;
+  @Mock private CacheManager cacheManager;
+
+  private TenantResetService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new TenantResetService(
+            tenantAccessPort,
+            userRepository,
+            userContactAssignmentService,
+            purgeService,
+            userSeeder,
+            demoTransactionSeeder,
+            cacheManager);
+  }
+
+  @Test
+  void shouldPurgeAndReseedForDemoOwnerWithoutFlippingDemoMode() {
+    when(tenantAccessPort.isDemoMode(TENANT_ID)).thenReturn(true);
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(owner()));
+    when(userContactAssignmentService.getUserContacts(USER_ID))
+        .thenReturn(List.of(ownerEmail("owner@example.com")));
+    when(purgeService.purgeDemoData(TENANT_ID))
+        .thenReturn(
+            new TenantTransactionalPurgeService.PurgeDemoDataResult(
+                TENANT_ID,
+                Map.of("sales.quote", 2, "common_user.common_user(seed-demo-users)", 15)));
+    when(userSeeder.seedFor(TENANT_ID, "owner@example.com", PersonaSubset.REPRESENTATIVE))
+        .thenReturn(15);
+
+    ResetDemoResponse response = service.reset(context("ADMIN"));
+
+    assertThat(response.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(response.demoMode()).isTrue();
+    assertThat(response.seededPersonaUsers()).isEqualTo(15);
+    assertThat(response.purgedRows()).containsEntry("sales.quote", 2);
+
+    InOrder ordered = inOrder(purgeService, userSeeder, demoTransactionSeeder);
+    ordered.verify(purgeService).purgeDemoData(TENANT_ID);
+    ordered
+        .verify(userSeeder)
+        .seedFor(TENANT_ID, "owner@example.com", PersonaSubset.REPRESENTATIVE);
+    ordered.verify(demoTransactionSeeder).seedFor(TENANT_ID);
+  }
+
+  @Test
+  void shouldRefuseNonDemoTenantWithoutPurgingOrSeeding() {
+    when(tenantAccessPort.isDemoMode(TENANT_ID)).thenReturn(false);
+
+    assertThatThrownBy(() -> service.reset(context("ADMIN")))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("DEMO_MODE_REQUIRED", 403);
+
+    verifyNoInteractions(
+        userRepository,
+        userContactAssignmentService,
+        purgeService,
+        userSeeder,
+        demoTransactionSeeder);
+  }
+
+  @Test
+  void shouldFailClosedWhenDemoModeCannotBeResolved() {
+    when(tenantAccessPort.isDemoMode(TENANT_ID))
+        .thenThrow(new IllegalStateException("cache unavailable"));
+
+    assertThatThrownBy(() -> service.reset(context("ADMIN")))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("DEMO_MODE_REQUIRED", 403);
+
+    verifyNoInteractions(
+        userRepository,
+        userContactAssignmentService,
+        purgeService,
+        userSeeder,
+        demoTransactionSeeder);
+  }
+
+  @Test
+  void shouldRefuseDemoSeedCallerWithoutPurgingOrSeeding() {
+    User seeded = owner();
+    seeded.setDemoSeed(true);
+    when(tenantAccessPort.isDemoMode(TENANT_ID)).thenReturn(true);
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(seeded));
+
+    assertThatThrownBy(() -> service.reset(context("ADMIN")))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("RESET_REQUIRES_OWNER", 403);
+
+    verifyNoInteractions(
+        userContactAssignmentService, purgeService, userSeeder, demoTransactionSeeder);
+  }
+
+  @Test
+  void shouldRefuseNonAdminCallerWithoutPurgingOrSeeding() {
+    User worker = owner();
+    worker.setRole(Role.create("Worker", "WORKER", "Worker"));
+    when(tenantAccessPort.isDemoMode(TENANT_ID)).thenReturn(true);
+    when(userRepository.findByTenantIdAndId(TENANT_ID, USER_ID)).thenReturn(Optional.of(worker));
+
+    assertThatThrownBy(() -> service.reset(context("WORKER")))
+        .isInstanceOf(PlatformDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly("RESET_REQUIRES_OWNER", 403);
+
+    verifyNoInteractions(
+        userContactAssignmentService, purgeService, userSeeder, demoTransactionSeeder);
+  }
+
+  private AuthenticatedUserContext context(String roleCode) {
+    return new AuthenticatedUserContext(USER_ID, roleCode, List.of(), null, TENANT_ID);
+  }
+
+  private User owner() {
+    User user = User.create("Owner", "User", UUID.randomUUID());
+    user.setId(USER_ID);
+    user.setTenantId(TENANT_ID);
+    user.setRole(Role.create("Admin", "ADMIN", "Admin"));
+    user.setDemoSeed(false);
+    return user;
+  }
+
+  private UserContact ownerEmail(String email) {
+    Contact contact =
+        Contact.builder()
+            .contactValue(email)
+            .contactType(ContactType.EMAIL)
+            .isVerified(true)
+            .build();
+    contact.setId(CONTACT_ID);
+    contact.setTenantId(TENANT_ID);
+    UserContact userContact =
+        UserContact.builder()
+            .userId(USER_ID)
+            .contactId(CONTACT_ID)
+            .contact(contact)
+            .isDefault(true)
+            .build();
+    userContact.setTenantId(TENANT_ID);
+    return userContact;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -86,6 +86,8 @@ class TenantTransactionalPurgeServiceTest {
             "flowboard.task",
             "common_approval.approval_request",
             "notification.notification_queue",
+            "production.production_execution_batch_override_log",
+            "sales_ord.sales_order_line_processed_shipments",
             "common_company.common_organization(external-partners)",
             "common_company.common_trading_partner+unreferenced_registry",
             "human.human_employee_number_sequence",
@@ -96,6 +98,14 @@ class TenantTransactionalPurgeServiceTest {
             contains("DELETE FROM procurement.purchase_order WHERE tenant_id = ?"), eq(TENANT_ID));
     verify(jdbc)
         .update(contains("DELETE FROM production.prod_product WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM production.production_execution_batch_override_log log"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM sales_ord.sales_order_line_processed_shipments processed"),
+            eq(TENANT_ID));
     verify(jdbc)
         .update(
             contains(
@@ -156,8 +166,18 @@ class TenantTransactionalPurgeServiceTest {
             "sales.quote",
             "procurement.purchase_order",
             "production.prod_product",
+            "production.production_execution_batch_override_log",
+            "sales_ord.sales_order_line_processed_shipments",
             "common_user.common_user(seed-demo-users)");
     verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM production.production_execution_batch_override_log log"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM sales_ord.sales_order_line_processed_shipments processed"),
+            eq(TENANT_ID));
     verify(jdbc, never())
         .update(
             contains("UPDATE common_tenant.common_tenant"),

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -144,6 +144,31 @@ class TenantTransactionalPurgeServiceTest {
   }
 
   @Test
+  void purgeDemoDataShouldDeleteRowsWithoutFlippingDemoModeOrStartingTrialClock() {
+    stubSystemTransaction();
+    when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);
+
+    TenantTransactionalPurgeService.PurgeDemoDataResult result = service.purgeDemoData(TENANT_ID);
+
+    assertThat(result.tenantId()).isEqualTo(TENANT_ID);
+    assertThat(result.deletedRows())
+        .containsKeys(
+            "sales.quote",
+            "procurement.purchase_order",
+            "production.prod_product",
+            "common_user.common_user(seed-demo-users)");
+    verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc, never())
+        .update(
+            contains("UPDATE common_tenant.common_tenant"),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            any(Timestamp.class),
+            eq(TENANT_ID));
+    verify(cacheManager, never()).getCache("tenant-demomode");
+  }
+
+  @Test
   void shouldNotDeleteIdentityConfigurationTablesWholesale() {
     stubSystemTransaction();
     when(jdbc.queryForObject(anyString(), eq(Boolean.class), eq(TENANT_ID))).thenReturn(true);


### PR DESCRIPTION
Add a demoMode-gated "reset demo" that purges the sandbox/seed data and restores a fresh demo (seed personas + demo business data), keeping the tenant, owner, and owner-created users, and staying in demo mode — the 90-day trial clock is NOT started (that remains go-real only).

- TenantTransactionalPurgeService: extract purgeDemoData(tenantId) (deletes only); goReal() keeps purge + demo_mode flip + clock (behaviour unchanged).
- TenantResetService: demoMode gate (fail-closed, DEMO_MODE_REQUIRED) + owner/admin guard (RESET_REQUIRES_OWNER); purge then reseed via UserSeeder.seedFor(REPRESENTATIVE)
  + DemoTransactionSeeder.seedFor, mirroring register-first provisioning; reseed failure surfaces DEMO_RESET_RESEED_FAILED and stays re-runnable; evicts tenant-demomode + users-by-tenant caches.
- POST /api/v1/tenant/reset-demo (mirrors the go-real controller) + ResetDemoResponse.

Owner survives because purge targets only demo_seed=true rows. A real-DB integration test covers the provision -> mutate -> reset round-trip.