### PR TITLE
feat(security): enforce data-scope (OWN/DEPARTMENT/ORG) at service layer

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
@@ -6,6 +6,7 @@ import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
 import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
 import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
@@ -50,6 +51,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -76,6 +78,7 @@ public class ProcurementDemoSeeder {
   private final PurchaseOrderService purchaseOrderService;
   private final SubcontractOrderService subcontractOrderService;
   private final GoodsReceiptService goodsReceiptService;
+  private final UserRepository userRepository;
   private final Clock clock;
 
   public void seedFor(UUID tenantId) {
@@ -99,6 +102,7 @@ public class ProcurementDemoSeeder {
       ProductDto cotton = fibers.get(0);
       ProductDto blend = fibers.size() > 1 ? fibers.get(1) : cotton;
       LocalDate today = LocalDate.now(clock);
+      UUID procurementPersonaUserId = resolveProcurementPersonaUserId(tenantId);
 
       TradingPartnerDto anatolia =
           createPartner(
@@ -212,7 +216,11 @@ public class ProcurementDemoSeeder {
 
       PurchaseOrderResponse po =
           createConfirmedPurchaseOrder(
-              chainPurchaseWo.id(), anatolia.getId(), acceptedQuote.getId(), rfqLines);
+              chainPurchaseWo.id(),
+              anatolia.getId(),
+              acceptedQuote.getId(),
+              rfqLines,
+              procurementPersonaUserId);
       createConfirmedGoodsReceipt(po.getId());
 
       createInProgressSubcontract(chainSubcontractWo.id(), marmara.getId(), cotton, blend, today);
@@ -377,41 +385,66 @@ public class ProcurementDemoSeeder {
       UUID workOrderId,
       UUID supplierId,
       UUID quoteId,
-      List<SupplierRFQResponse.RfqLineResponse> rfqLines) {
+      List<SupplierRFQResponse.RfqLineResponse> rfqLines,
+      UUID ownerUserId) {
     PurchaseOrderResponse po =
-        purchaseOrderService.createPurchaseOrder(
-            CreatePurchaseOrderRequest.builder()
-                .workOrderId(workOrderId)
-                .tradingPartnerId(supplierId)
-                .supplierQuoteId(quoteId)
-                .currency("USD")
-                .paymentTerms("NET30")
-                .expectedDelivery(LocalDate.now(clock).plusDays(16))
-                .notes("Demo PO generated from accepted supplier quote")
-                .moduleType(PurchaseOrderModuleType.FIBER)
-                .moduleSpecs(fiberPurchaseSpecs())
-                .lines(
-                    rfqLines.stream()
-                        .map(
-                            line ->
-                                CreatePurchaseOrderRequest.PurchaseOrderLineRequest.builder()
-                                    .rfqLineId(line.getId())
-                                    .productId(line.getProductId())
-                                    .productDesc(line.getProductDesc())
-                                    .qty(line.getRequestedQty())
-                                    .unit(line.getUnit())
-                                    .unitPrice(new BigDecimal("3.78"))
-                                    .currency("USD")
-                                    .moduleSpecs(fiberPurchaseSpecs())
-                                    .build())
-                        .toList())
-                .build());
+        executeAsUser(
+            ownerUserId,
+            () ->
+                purchaseOrderService.createPurchaseOrder(
+                    CreatePurchaseOrderRequest.builder()
+                        .workOrderId(workOrderId)
+                        .tradingPartnerId(supplierId)
+                        .supplierQuoteId(quoteId)
+                        .currency("USD")
+                        .paymentTerms("NET30")
+                        .expectedDelivery(LocalDate.now(clock).plusDays(16))
+                        .notes("Demo PO generated from accepted supplier quote")
+                        .moduleType(PurchaseOrderModuleType.FIBER)
+                        .moduleSpecs(fiberPurchaseSpecs())
+                        .lines(
+                            rfqLines.stream()
+                                .map(
+                                    line ->
+                                        CreatePurchaseOrderRequest.PurchaseOrderLineRequest
+                                            .builder()
+                                            .rfqLineId(line.getId())
+                                            .productId(line.getProductId())
+                                            .productDesc(line.getProductDesc())
+                                            .qty(line.getRequestedQty())
+                                            .unit(line.getUnit())
+                                            .unitPrice(new BigDecimal("3.78"))
+                                            .currency("USD")
+                                            .moduleSpecs(fiberPurchaseSpecs())
+                                            .build())
+                                .toList())
+                        .build()));
 
     po = purchaseOrderService.changeStatus(po.getId(), PurchaseOrderStatus.SENT);
     if (po.getStatus() == PurchaseOrderStatus.PENDING_APPROVAL) {
       po = purchaseOrderService.changeStatusAsSystem(po.getId(), PurchaseOrderStatus.SENT);
     }
     return purchaseOrderService.changeStatus(po.getId(), PurchaseOrderStatus.CONFIRMED);
+  }
+
+  private UUID resolveProcurementPersonaUserId(UUID tenantId) {
+    return userRepository
+        .findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(tenantId, "Yolanda", "Bidwell")
+        .map(com.fabricmanagement.platform.user.domain.User::getId)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Procurement demo persona Yolanda Bidwell is required before seeding POs"));
+  }
+
+  private <T> T executeAsUser(UUID userId, Supplier<T> supplier) {
+    TenantContext.TenantSnapshot previous = TenantContext.capture();
+    try {
+      TenantContext.setCurrentUserId(userId);
+      return supplier.get();
+    } finally {
+      TenantContext.restore(previous);
+    }
   }
 
   private void createConfirmedGoodsReceipt(UUID poId) {

--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/AuthenticatedUserContextResolver.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/AuthenticatedUserContextResolver.java
@@ -1,0 +1,24 @@
+package com.fabricmanagement.common.infrastructure.security;
+
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class AuthenticatedUserContextResolver {
+
+  public Optional<AuthenticatedUserContext> resolve(Authentication authentication) {
+    if (authentication == null || !authentication.isAuthenticated()) {
+      return Optional.empty();
+    }
+
+    if (authentication.getPrincipal() instanceof AuthenticatedUserContext context) {
+      return Optional.of(context);
+    }
+
+    log.warn("Principal is not an instance of AuthenticatedUserContext");
+    return Optional.empty();
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuard.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuard.java
@@ -1,0 +1,187 @@
+package com.fabricmanagement.common.infrastructure.security;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.dto.PermissionResult;
+import com.fabricmanagement.platform.user.domain.DataScope;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import jakarta.persistence.criteria.Predicate;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestAttributes;
+import org.springframework.web.context.request.RequestContextHolder;
+
+@Component("scope")
+@RequiredArgsConstructor
+public class DataScopeGuard {
+
+  private static final String DEPARTMENT_MEMBER_IDS_CACHE =
+      DataScopeGuard.class.getName() + ".departmentMemberIds";
+
+  private final PermissionEvaluator permissionEvaluator;
+  private final AuthenticatedUserContextResolver contextResolver;
+  private final UserRepository userRepository;
+
+  public DataScope currentScope(String resource, String action) {
+    Optional<AuthenticatedUserContext> context = currentContext();
+    if (isSystemContext(context.orElse(null))) {
+      return DataScope.GLOBAL;
+    }
+
+    AuthenticatedUserContext authenticated =
+        context.orElseThrow(() -> forbidden(resource, "UNKNOWN"));
+    PermissionResult result =
+        permissionEvaluator.evaluate(
+            authenticated.tenantId(),
+            authenticated.roleCode(),
+            authenticated.departmentCodes(),
+            authenticated.userId());
+    return result.scopeOf(resource, action);
+  }
+
+  public void assertCanAccess(String resource, String action, BaseEntity entity) {
+    if (isSystemContext(currentContext().orElse(null))) {
+      return;
+    }
+    if (entity == null) {
+      throw forbidden(resource, "UNKNOWN");
+    }
+
+    DataScope scope = currentScope(resource, action);
+    UUID currentUserId = currentUserId();
+    if (scope == null || currentUserId == null) {
+      throw forbidden(resource, String.valueOf(scope));
+    }
+
+    if (scope == DataScope.GLOBAL || scope == DataScope.ORGANIZATION) {
+      return;
+    }
+
+    UUID createdBy = entity.getCreatedBy();
+    if (scope == DataScope.OWN && currentUserId.equals(createdBy)) {
+      return;
+    }
+
+    if (scope == DataScope.DEPARTMENT && departmentMemberIds().contains(createdBy)) {
+      return;
+    }
+
+    throw forbidden(resource, scope.name());
+  }
+
+  public <T> Specification<T> scopeFilter(String resource, String action) {
+    if (isSystemContext(currentContext().orElse(null))) {
+      return (root, query, cb) -> cb.conjunction();
+    }
+
+    DataScope scope = currentScope(resource, action);
+    UUID currentUserId = currentUserId();
+    if (scope == null || currentUserId == null) {
+      return (root, query, cb) -> cb.disjunction();
+    }
+
+    return switch (scope) {
+      case GLOBAL, ORGANIZATION -> (root, query, cb) -> cb.conjunction();
+      case OWN -> (root, query, cb) -> cb.equal(root.get("createdBy"), currentUserId);
+      case DEPARTMENT ->
+          (root, query, cb) -> {
+            Set<UUID> memberIds = departmentMemberIds();
+            if (memberIds.isEmpty()) {
+              return cb.disjunction();
+            }
+            Predicate predicate = root.get("createdBy").in(memberIds);
+            return predicate;
+          };
+    };
+  }
+
+  private Optional<AuthenticatedUserContext> currentContext() {
+    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    return contextResolver.resolve(authentication);
+  }
+
+  private UUID currentUserId() {
+    return currentContext()
+        .map(AuthenticatedUserContext::userId)
+        .orElse(TenantContext.getCurrentUserId());
+  }
+
+  private boolean isSystemContext(AuthenticatedUserContext context) {
+    UUID contextUserId = context != null ? context.userId() : null;
+    UUID tenantContextUserId = TenantContext.getCurrentUserId();
+    // Missing/anonymous authentication is not a bypass. Only explicit system execution may skip
+    // row-scope checks.
+    return SystemUser.ID.equals(contextUserId)
+        || SystemUser.ID.equals(tenantContextUserId)
+        || TenantContext.isSystemTenant();
+  }
+
+  @SuppressWarnings("unchecked")
+  private Set<UUID> departmentMemberIds() {
+    AuthenticatedUserContext context = currentContext().orElse(null);
+    UUID tenantId = context != null ? context.tenantId() : TenantContext.getCurrentTenantIdOrNull();
+    UUID userId = currentUserId();
+    List<String> departmentCodes =
+        context != null && context.departmentCodes() != null
+            ? context.departmentCodes()
+            : List.of();
+
+    Set<String> normalizedCodes = normalizeDepartmentCodes(departmentCodes);
+    if (tenantId == null || normalizedCodes.isEmpty()) {
+      return userId == null ? Set.of() : Set.of(userId);
+    }
+
+    String cacheKey = cacheKey(tenantId, normalizedCodes);
+    RequestAttributes requestAttributes = RequestContextHolder.getRequestAttributes();
+    if (requestAttributes != null) {
+      Object cached = requestAttributes.getAttribute(cacheKey, RequestAttributes.SCOPE_REQUEST);
+      if (cached instanceof Set<?> cachedSet) {
+        return (Set<UUID>) cachedSet;
+      }
+    }
+
+    Set<UUID> memberIds =
+        new HashSet<>(userRepository.findActiveUserIdsByDepartmentCodes(tenantId, normalizedCodes));
+    if (userId != null) {
+      memberIds.add(userId);
+    }
+    Set<UUID> immutableMemberIds = Set.copyOf(memberIds);
+
+    if (requestAttributes != null) {
+      requestAttributes.setAttribute(cacheKey, immutableMemberIds, RequestAttributes.SCOPE_REQUEST);
+    }
+    return immutableMemberIds;
+  }
+
+  private Set<String> normalizeDepartmentCodes(Collection<String> departmentCodes) {
+    return departmentCodes.stream()
+        .filter(code -> code != null && !code.isBlank())
+        .map(code -> code.toUpperCase(java.util.Locale.ROOT))
+        .collect(Collectors.toUnmodifiableSet());
+  }
+
+  private String cacheKey(UUID tenantId, Set<String> departmentCodes) {
+    return DEPARTMENT_MEMBER_IDS_CACHE
+        + ":"
+        + tenantId
+        + ":"
+        + departmentCodes.stream().sorted().collect(Collectors.joining(","));
+  }
+
+  private AccessDeniedException forbidden(String resource, String scope) {
+    return new AccessDeniedException(
+        "You do not have access to this " + resource + " record (scope: " + scope + ").");
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/SpELPermissionEvaluator.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/SpELPermissionEvaluator.java
@@ -2,16 +2,15 @@ package com.fabricmanagement.common.infrastructure.security;
 
 import com.fabricmanagement.common.infrastructure.security.dto.PermissionResult;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 
 @Component("auth")
 @RequiredArgsConstructor
-@Slf4j
 public class SpELPermissionEvaluator {
 
   private final PermissionEvaluator permissionEvaluator;
+  private final AuthenticatedUserContextResolver contextResolver;
 
   /** Used in SpEL expressions: @PreAuthorize("@auth.can(authentication, 'SALES', 'WRITE')") */
   public boolean can(Authentication authentication, String resource, String action) {
@@ -19,7 +18,7 @@ public class SpELPermissionEvaluator {
       return false;
     }
 
-    AuthenticatedUserContext ctx = extractContext(authentication);
+    AuthenticatedUserContext ctx = contextResolver.resolve(authentication).orElse(null);
     if (ctx == null) {
       return false;
     }
@@ -41,7 +40,7 @@ public class SpELPermissionEvaluator {
       return false;
     }
 
-    AuthenticatedUserContext ctx = extractContext(authentication);
+    AuthenticatedUserContext ctx = contextResolver.resolve(authentication).orElse(null);
     if (ctx == null) {
       return false;
     }
@@ -60,14 +59,5 @@ public class SpELPermissionEvaluator {
         com.fabricmanagement.platform.user.domain.DataScope.valueOf(requiredScope.toUpperCase());
 
     return userScope.compareTo(reqScope) >= 0;
-  }
-
-  private AuthenticatedUserContext extractContext(Authentication authentication) {
-    if (authentication.getPrincipal() instanceof AuthenticatedUserContext customDetails) {
-      return customDetails;
-    }
-
-    log.warn("Principal is not an instance of AuthenticatedUserContext");
-    return null;
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/user/infra/repository/UserRepository.java
+++ b/src/main/java/com/fabricmanagement/platform/user/infra/repository/UserRepository.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.platform.user.domain.User;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -165,6 +166,9 @@ public interface UserRepository extends JpaRepository<User, UUID> {
   boolean existsByTenantIdAndContactValue(
       @Param("tenantId") UUID tenantId, @Param("contactValue") String contactValue);
 
+  Optional<User> findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(
+      UUID tenantId, String firstName, String lastName);
+
   /**
    * Search users by name.
    *
@@ -198,6 +202,24 @@ public interface UserRepository extends JpaRepository<User, UUID> {
           + "AND ud.departmentId IN :departmentIds")
   List<User> findByTenantIdAndDepartmentIds(
       @Param("tenantId") UUID tenantId, @Param("departmentIds") java.util.Set<UUID> departmentIds);
+
+  /**
+   * Get active user IDs belonging to active department assignments by canonical department code.
+   */
+  @Query(
+      """
+      SELECT DISTINCT u.id FROM User u
+      JOIN u.userDepartments ud
+      JOIN ud.department d
+      WHERE u.tenantId = :tenantId
+        AND u.isActive = true
+        AND ud.tenantId = :tenantId
+        AND ud.isActive = true
+        AND UPPER(d.departmentCode) IN :departmentCodes
+      """)
+  Set<UUID> findActiveUserIdsByDepartmentCodes(
+      @Param("tenantId") UUID tenantId,
+      @Param("departmentCodes") Collection<String> departmentCodes);
 
   /** Count active users in tenant. */
   long countByTenantIdAndIsActiveTrue(UUID tenantId);

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.procurement.purchaseorder.app;
 import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
 import com.fabricmanagement.common.infrastructure.persistence.DocumentNumberGenerator;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
 import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.platform.user.domain.SystemUser;
@@ -44,9 +45,11 @@ public class PurchaseOrderService {
   private final PurchaseOrderValidationEngine validationEngine;
   private final ApprovalPort approvalPort;
   private final DocumentNumberGenerator documentNumberGenerator;
+  private final DataScopeGuard scopeGuard;
 
   public PurchaseOrderResponse getPurchaseOrder(UUID id) {
     PurchaseOrder po = findEntityById(id);
+    scopeGuard.assertCanAccess("procurement", "read", po);
     List<PurchaseOrderLine> lines =
         lineRepository.findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(id);
     return mapToResponse(po, lines);
@@ -73,7 +76,9 @@ public class PurchaseOrderService {
           return cb.and(predicates.toArray(new jakarta.persistence.criteria.Predicate[0]));
         };
 
-    Page<PurchaseOrder> poPage = poRepository.findAll(spec, pageable);
+    Page<PurchaseOrder> poPage =
+        poRepository.findAll(
+            spec.and(scopeGuard.<PurchaseOrder>scopeFilter("procurement", "read")), pageable);
 
     return PagedResponse.from(poPage, this::mapToSummaryResponse);
   }
@@ -154,6 +159,7 @@ public class PurchaseOrderService {
   @Transactional
   public PurchaseOrderResponse changeStatus(UUID id, PurchaseOrderStatus newStatus) {
     PurchaseOrder po = findEntityById(id);
+    scopeGuard.assertCanAccess("procurement", "write", po);
 
     if (!po.getStatus().canTransitionTo(newStatus)) {
       throw new ProcurementDomainException(

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
@@ -13,6 +13,8 @@ import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerService;
 import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
 import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
@@ -53,6 +55,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,6 +78,7 @@ class ProcurementDemoSeederTest {
   @Mock private PurchaseOrderService purchaseOrderService;
   @Mock private SubcontractOrderService subcontractOrderService;
   @Mock private GoodsReceiptService goodsReceiptService;
+  @Mock private UserRepository userRepository;
 
   private final List<TradingPartnerDto> partners = new ArrayList<>();
   private final Map<UUID, SupplierRFQ> rfqs = new HashMap<>();
@@ -94,6 +98,7 @@ class ProcurementDemoSeederTest {
             purchaseOrderService,
             subcontractOrderService,
             goodsReceiptService,
+            userRepository,
             clock);
   }
 
@@ -108,6 +113,9 @@ class ProcurementDemoSeederTest {
     ProductDto blend = product("Combed Cotton Blend");
     when(productFacade.findByType(eq(TenantContext.TEMPLATE_TENANT_ID), eq(ProductType.FIBER)))
         .thenReturn(List.of(cotton, blend));
+    when(userRepository.findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(
+            TENANT_ID, "Yolanda", "Bidwell"))
+        .thenReturn(Optional.of(user(UUID.randomUUID())));
 
     when(tradingPartnerService.searchByName(TENANT_ID, ProcurementDemoSeeder.SUPPLIER_ANATOLIA))
         .thenAnswer(
@@ -315,5 +323,11 @@ class ProcurementDemoSeederTest {
         .productType(ProductType.FIBER)
         .unit("KG")
         .build();
+  }
+
+  private User user(UUID id) {
+    User user = User.builder().firstName("Yolanda").lastName("Bidwell").build();
+    user.setId(id);
+    return user;
   }
 }

--- a/src/test/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuardTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuardTest.java
@@ -1,0 +1,230 @@
+package com.fabricmanagement.common.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.dto.PermissionResult;
+import com.fabricmanagement.platform.user.domain.DataScope;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Path;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+class DataScopeGuardTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
+  private static final UUID CURRENT_USER_ID =
+      UUID.fromString("20000000-0000-0000-0000-000000000001");
+  private static final UUID OTHER_USER_ID = UUID.fromString("20000000-0000-0000-0000-000000000002");
+  private static final UUID DEPARTMENT_MEMBER_ID =
+      UUID.fromString("20000000-0000-0000-0000-000000000003");
+
+  private final PermissionEvaluator permissionEvaluator = mock(PermissionEvaluator.class);
+  private final UserRepository userRepository = mock(UserRepository.class);
+  private final DataScopeGuard guard =
+      new DataScopeGuard(
+          permissionEvaluator, new AuthenticatedUserContextResolver(), userRepository);
+
+  @AfterEach
+  void clearContext() {
+    SecurityContextHolder.clearContext();
+    RequestContextHolder.resetRequestAttributes();
+    TenantContext.clear();
+  }
+
+  @Test
+  void ownScopeAllowsOnlyOwnRecords() {
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(permissionResult(DataScope.OWN));
+
+    assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
+        .doesNotThrowAnyException();
+    assertThatThrownBy(
+            () -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
+        .isInstanceOf(AccessDeniedException.class);
+  }
+
+  @Test
+  void ownScopeFilterUsesCurrentUserCreatedByPredicate() {
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(permissionResult(DataScope.OWN));
+    CriteriaMocks criteria = criteriaMocks();
+    when(criteria.criteriaBuilder.equal(criteria.createdByPath, CURRENT_USER_ID))
+        .thenReturn(criteria.expectedPredicate);
+
+    Predicate predicate =
+        guard
+            .scopeFilter("procurement", "read")
+            .toPredicate(criteria.root, criteria.query, criteria.criteriaBuilder);
+
+    assertThat(predicate).isSameAs(criteria.expectedPredicate);
+    verify(criteria.root).get("createdBy");
+  }
+
+  @Test
+  void departmentScopeAllowsDepartmentMembersAndCachesMemberIdsPerRequest() {
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(permissionResult(DataScope.DEPARTMENT));
+    when(userRepository.findActiveUserIdsByDepartmentCodes(TENANT_ID, Set.of("PROCUREMENT")))
+        .thenReturn(Set.of(DEPARTMENT_MEMBER_ID));
+
+    assertThatCode(
+            () -> guard.assertCanAccess("procurement", "write", poCreatedBy(DEPARTMENT_MEMBER_ID)))
+        .doesNotThrowAnyException();
+    assertThatThrownBy(
+            () -> guard.assertCanAccess("procurement", "write", poCreatedBy(OTHER_USER_ID)))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(userRepository).findActiveUserIdsByDepartmentCodes(TENANT_ID, Set.of("PROCUREMENT"));
+  }
+
+  @Test
+  void organizationAndGlobalScopesUseNoOpListPredicate() {
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(permissionResult(DataScope.ORGANIZATION), permissionResult(DataScope.GLOBAL));
+    CriteriaMocks organizationCriteria = criteriaMocks();
+    CriteriaMocks globalCriteria = criteriaMocks();
+    when(organizationCriteria.criteriaBuilder.conjunction())
+        .thenReturn(organizationCriteria.expectedPredicate);
+    when(globalCriteria.criteriaBuilder.conjunction()).thenReturn(globalCriteria.expectedPredicate);
+
+    Predicate organizationPredicate =
+        guard
+            .scopeFilter("procurement", "read")
+            .toPredicate(
+                organizationCriteria.root,
+                organizationCriteria.query,
+                organizationCriteria.criteriaBuilder);
+    Predicate globalPredicate =
+        guard
+            .scopeFilter("procurement", "read")
+            .toPredicate(globalCriteria.root, globalCriteria.query, globalCriteria.criteriaBuilder);
+
+    assertThat(organizationPredicate).isSameAs(organizationCriteria.expectedPredicate);
+    assertThat(globalPredicate).isSameAs(globalCriteria.expectedPredicate);
+  }
+
+  @Test
+  void missingPermissionDeniesEntityAccessAndReturnsImpossibleListPredicate() {
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(new PermissionResult(Map.of(), false));
+    CriteriaMocks criteria = criteriaMocks();
+    when(criteria.criteriaBuilder.disjunction()).thenReturn(criteria.expectedPredicate);
+
+    assertThatThrownBy(
+            () -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
+        .isInstanceOf(AccessDeniedException.class);
+    Predicate predicate =
+        guard
+            .scopeFilter("procurement", "read")
+            .toPredicate(criteria.root, criteria.query, criteria.criteriaBuilder);
+
+    assertThat(predicate).isSameAs(criteria.expectedPredicate);
+  }
+
+  @Test
+  void missingAuthenticationFailsClosedButExplicitSystemContextBypasses() {
+    assertThatThrownBy(
+            () -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
+        .isInstanceOf(AccessDeniedException.class);
+
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(SystemUser.ID);
+
+    assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
+        .doesNotThrowAnyException();
+    verify(permissionEvaluator, never()).evaluate(any(), any(), any(), any());
+  }
+
+  @Test
+  void systemTenantContextBypassesWithoutAuthentication() {
+    TenantContext.setCurrentTenantId(TenantContext.SYSTEM_TENANT_ID);
+
+    assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
+        .doesNotThrowAnyException();
+    verify(permissionEvaluator, never()).evaluate(any(), any(), any(), any());
+  }
+
+  @Test
+  void departmentScopeIncludesCurrentUserEvenWhenRepositoryDoesNotReturnThem() {
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(permissionResult(DataScope.DEPARTMENT));
+    when(userRepository.findActiveUserIdsByDepartmentCodes(TENANT_ID, Set.of("PROCUREMENT")))
+        .thenReturn(Set.of());
+
+    assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
+        .doesNotThrowAnyException();
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private CriteriaMocks criteriaMocks() {
+    Root<Object> root = mock(Root.class);
+    CriteriaQuery<?> query = mock(CriteriaQuery.class);
+    CriteriaBuilder criteriaBuilder = mock(CriteriaBuilder.class);
+    Path<Object> createdByPath = mock(Path.class);
+    Predicate expectedPredicate = mock(Predicate.class);
+    when(root.get("createdBy")).thenReturn((Path) createdByPath);
+    when(createdByPath.in(any(Collection.class))).thenReturn(expectedPredicate);
+    return new CriteriaMocks(root, query, criteriaBuilder, createdByPath, expectedPredicate);
+  }
+
+  private void authenticate(UUID userId, List<String> departmentCodes) {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(userId);
+    AuthenticatedUserContext context =
+        new AuthenticatedUserContext(
+            userId, "WORKER", departmentCodes, departmentCodes.get(0), TENANT_ID);
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken(context, "n/a", List.of()));
+  }
+
+  private PermissionResult permissionResult(DataScope scope) {
+    return new PermissionResult(
+        Map.of("procurement", Map.of("read", scope, "write", scope)), false);
+  }
+
+  private PurchaseOrder poCreatedBy(UUID createdBy) {
+    PurchaseOrder po = PurchaseOrder.builder().build();
+    po.setCreatedBy(createdBy);
+    return po;
+  }
+
+  private record CriteriaMocks(
+      Root<Object> root,
+      CriteriaQuery<?> query,
+      CriteriaBuilder criteriaBuilder,
+      Path<Object> createdByPath,
+      Predicate expectedPredicate) {}
+}

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
@@ -1,0 +1,169 @@
+package com.fabricmanagement.procurement.purchaseorder.app;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
+import com.fabricmanagement.common.infrastructure.persistence.DocumentNumberGenerator;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
+import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderLineRepository;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderServiceDataScopeTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
+  private static final UUID PO_ID = UUID.fromString("30000000-0000-0000-0000-000000000001");
+
+  @Mock private PurchaseOrderRepository poRepository;
+  @Mock private PurchaseOrderLineRepository lineRepository;
+  @Mock private PurchaseOrderValidationEngine validationEngine;
+  @Mock private ApprovalPort approvalPort;
+  @Mock private DocumentNumberGenerator documentNumberGenerator;
+  @Mock private DataScopeGuard scopeGuard;
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void listPurchaseOrdersComposesReadScopeFilter() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    PurchaseOrderService service = service();
+    PageRequest pageable = PageRequest.of(0, 20);
+    Specification<PurchaseOrder> scopeSpec = (root, query, cb) -> cb.conjunction();
+    when(scopeGuard.<PurchaseOrder>scopeFilter("procurement", "read")).thenReturn(scopeSpec);
+    when(poRepository.findAll(any(Specification.class), eq(pageable)))
+        .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+    service.listPurchaseOrders(null, null, pageable);
+
+    verify(scopeGuard).scopeFilter("procurement", "read");
+    verify(poRepository).findAll(any(Specification.class), eq(pageable));
+  }
+
+  @Test
+  void getPurchaseOrderAppliesReadScopeBeforeReturningLines() {
+    PurchaseOrder po = purchaseOrder(PurchaseOrderStatus.DRAFT);
+    PurchaseOrderService service = service();
+    when(poRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+    when(lineRepository.findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(PO_ID))
+        .thenReturn(List.of());
+
+    service.getPurchaseOrder(PO_ID);
+
+    verify(scopeGuard).assertCanAccess("procurement", "read", po);
+    verify(lineRepository).findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(PO_ID);
+  }
+
+  @Test
+  void changeStatusChecksWriteScopeBeforeMutating() {
+    PurchaseOrder po = purchaseOrder(PurchaseOrderStatus.DRAFT);
+    PurchaseOrderService service = service();
+    when(poRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+    doThrow(new AccessDeniedException("denied"))
+        .when(scopeGuard)
+        .assertCanAccess("procurement", "write", po);
+
+    assertThatThrownBy(() -> service.changeStatus(PO_ID, PurchaseOrderStatus.SENT))
+        .isInstanceOf(AccessDeniedException.class);
+
+    verify(validationEngine, never()).validateOnConfirm(any(), any());
+    verify(poRepository, never()).save(any(PurchaseOrder.class));
+  }
+
+  @Test
+  void createPurchaseOrderDoesNotApplyRowScopeGuard() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    PurchaseOrderService service = service();
+    when(documentNumberGenerator.generate(
+            eq(TENANT_ID), eq("PURCHASE_ORDER"), eq("PO"), any(), eq(5)))
+        .thenReturn("PO-20260630-00001");
+    when(poRepository.save(any(PurchaseOrder.class)))
+        .thenAnswer(
+            invocation -> {
+              PurchaseOrder po = invocation.getArgument(0);
+              po.setId(PO_ID);
+              return po;
+            });
+    when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.createPurchaseOrder(createRequest());
+
+    verifyNoInteractions(scopeGuard);
+  }
+
+  private PurchaseOrderService service() {
+    return new PurchaseOrderService(
+        poRepository,
+        lineRepository,
+        validationEngine,
+        approvalPort,
+        documentNumberGenerator,
+        scopeGuard);
+  }
+
+  private PurchaseOrder purchaseOrder(PurchaseOrderStatus status) {
+    PurchaseOrder po =
+        PurchaseOrder.builder()
+            .poNumber("PO-20260630-00001")
+            .workOrderId(UUID.randomUUID())
+            .tradingPartnerId(UUID.randomUUID())
+            .status(status)
+            .paymentTerms("NET30")
+            .expectedDelivery(LocalDate.now().plusDays(10))
+            .totalAmount(Money.of(BigDecimal.TEN, "USD"))
+            .moduleType(PurchaseOrderModuleType.GENERIC)
+            .build();
+    po.setId(PO_ID);
+    return po;
+  }
+
+  private CreatePurchaseOrderRequest createRequest() {
+    return CreatePurchaseOrderRequest.builder()
+        .workOrderId(UUID.randomUUID())
+        .tradingPartnerId(UUID.randomUUID())
+        .currency("USD")
+        .paymentTerms("NET30")
+        .expectedDelivery(LocalDate.now().plusDays(10))
+        .moduleType(PurchaseOrderModuleType.GENERIC)
+        .lines(
+            List.of(
+                CreatePurchaseOrderRequest.PurchaseOrderLineRequest.builder()
+                    .productDesc("Cotton")
+                    .qty(new BigDecimal("10.000"))
+                    .unit("KG")
+                    .unitPrice(new BigDecimal("3.500"))
+                    .currency("USD")
+                    .build()))
+        .build();
+  }
+}


### PR DESCRIPTION
Data-scope was modeled everywhere but enforced nowhere: controllers gated only on resource+action via @auth.can, so any user passing the coarse gate could act on every row in the tenant. A PROCUREMENT WORKER (scope OWN) could read/mutate other users' purchase orders (smoke-test F-80).

Add central, reusable DataScopeGuard (common/infrastructure/security):
- assertCanAccess(resource, action, entity): single-entity ownership check, throws AccessDeniedException (403) on violation.
- scopeFilter(resource, action): JPA Specification AND-ed into list queries.
- Matrix: OWN=createdBy==self, DEPARTMENT=createdBy in department members (derived, no schema change, request-cached), ORGANIZATION/GLOBAL=tenant boundary only.
- Fail-closed: missing/anonymous auth is denied; row-scope bypass only for SystemUser.ID / system tenant context.

Extract shared AuthenticatedUserContextResolver; SpELPermissionEvaluator and DataScopeGuard now share principal extraction.

Add UserRepository.findActiveUserIdsByDepartmentCodes (request-scoped cache, no N+1).

Wire procurement PurchaseOrderService: list -> scopeFilter, getById/changeStatus ->
assertCanAccess (before mutating); createPurchaseOrder and controller @PreAuthorize untouched. DataScopeGuard stays generic; only PO wired (other resources -> PERM-6+).

Seed demo PO under Yolanda persona so OWN enforcement doesn't empty the playground.

Tests: DataScopeGuardTest, PurchaseOrderServiceDataScopeTest, updated ProcurementDemoSeederTest. Full suite green (995), no API contract change.

Closes F-80.