### PR TITLE
feat(security): add non-throwing DataScopeGuard.canAccess + canEdit o…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -46529,6 +46529,29 @@ components:
           type: string
         origin:
           $ref: "#/components/schemas/Origin"
+    ConvertedMoneyDto:
+      type: object
+      description: Money converted from an original currency into a reporting currency
+      properties:
+        convertedAmount:
+          type: number
+          description: Converted amount
+        convertedCurrency:
+          type: string
+          description: Converted currency code
+        exchangeRate:
+          type: number
+          description: Exchange rate used for the conversion
+        originalAmount:
+          type: number
+          description: Original amount before conversion
+        originalCurrency:
+          type: string
+          description: Original currency code
+        rateDate:
+          type: string
+          format: date
+          description: Rate date used for the conversion
     CostCalculationResponse:
       type: object
       properties:
@@ -52585,6 +52608,8 @@ components:
           type: string
         poNumber:
           type: string
+        reportingTotal:
+          $ref: "#/components/schemas/ConvertedMoneyDto"
         revisionNumber:
           type: integer
           format: int32
@@ -54452,6 +54477,9 @@ components:
         quoteNumber:
           type: string
           description: Quote Number
+        reportingTotal:
+          $ref: "#/components/schemas/ConvertedMoneyDto"
+          description: Total amount converted to the tenant reporting currency
         rfqId:
           type: string
           format: uuid

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -52555,6 +52555,8 @@ components:
     PurchaseOrderResponse:
       type: object
       properties:
+        canEdit:
+          type: boolean
         currency:
           type: string
         expectedDelivery:

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -33,13 +33,22 @@
     </suppress>
 
     <suppress until="2026-09-01Z">
-        <notes>DOMPurify 3.3.2 bundled inside swagger-ui (via springdoc 2.8.17).
-        No upstream swagger-ui release with DOMPurify >= 3.4.0 yet.
-        Mitigated: swagger-ui disabled outside dev profile. Re-check at Q3 review.</notes>
-        <packageUrl regex="true">^pkg:javascript/DOMPurify@3\.3\.2$</packageUrl>
-        <cve>CVE-2026-41238</cve>
-        <cve>CVE-2026-41239</cve>
-        <cve>CVE-2026-41240</cve>
+        <notes>DOMPurify 3.4.0 bundled inside swagger-ui (via springdoc). Supersedes the prior 3.3.2
+        rule: swagger-ui was bumped and now ships DOMPurify 3.4.0, which closed the old CVEs
+        (41238/41239/41240) but carries new IN_PLACE-mode XSS findings — CVE-2026-49458 (Moderate),
+        CVE-2026-49459, CVE-2026-49978 (Low) plus aliased GHSAs — all below the CVSS 7 gate. DOMPurify's
+        version is controlled by swagger-ui, not pinned here, and no swagger-ui/springdoc release ships a
+        patched DOMPurify yet. Mitigated: swagger-ui disabled outside dev profile, so no production attack
+        surface. Re-check at Q3 review / on next springdoc upgrade.</notes>
+        <packageUrl regex="true">^pkg:javascript/DOMPurify@3\.4\.0$</packageUrl>
+        <cve>CVE-2026-49458</cve>
+        <cve>CVE-2026-49459</cve>
+        <cve>CVE-2026-49978</cve>
+        <vulnerabilityName>GHSA-76mc-f452-cxcm</vulnerabilityName>
+        <vulnerabilityName>GHSA-cmwh-pvxp-8882</vulnerabilityName>
+        <vulnerabilityName>GHSA-gvmj-g25r-r7wr</vulnerabilityName>
+        <vulnerabilityName>GHSA-vxr8-fq34-vvx9</vulnerabilityName>
+        <vulnerabilityName>GHSA-x4vx-rjvf-j5p4</vulnerabilityName>
     </suppress>
 
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,10 @@
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <effort>Max</effort>
+                    <!-- Analysis runs in a forked JVM; the 512MB default OOMs at effort=Max
+                         as the codebase grows. Give it room (GitHub runners have ~7GB). -->
+                    <fork>true</fork>
+                    <maxHeap>3072</maxHeap>
                     <threshold>High</threshold>
                     <failOnError>false</failOnError>
                     <excludeFilterFile>spotbugs-exclude.xml</excludeFilterFile>

--- a/src/main/java/com/fabricmanagement/common/dto/ConvertedMoneyDto.java
+++ b/src/main/java/com/fabricmanagement/common/dto/ConvertedMoneyDto.java
@@ -1,0 +1,31 @@
+package com.fabricmanagement.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+@Schema(description = "Money converted from an original currency into a reporting currency")
+public class ConvertedMoneyDto {
+
+  @Schema(description = "Original amount before conversion")
+  BigDecimal originalAmount;
+
+  @Schema(description = "Original currency code")
+  String originalCurrency;
+
+  @Schema(description = "Converted amount")
+  BigDecimal convertedAmount;
+
+  @Schema(description = "Converted currency code")
+  String convertedCurrency;
+
+  @Schema(description = "Exchange rate used for the conversion")
+  BigDecimal exchangeRate;
+
+  @Schema(description = "Rate date used for the conversion")
+  LocalDate rateDate;
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuard.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuard.java
@@ -52,33 +52,36 @@ public class DataScopeGuard {
   }
 
   public void assertCanAccess(String resource, String action, BaseEntity entity) {
-    if (isSystemContext(currentContext().orElse(null))) {
-      return;
+    if (!canAccess(resource, action, entity)) {
+      throw forbidden(resource, scopeLabel(resource, action));
+    }
+  }
+
+  public boolean canAccess(String resource, String action, BaseEntity entity) {
+    Optional<AuthenticatedUserContext> context = currentContext();
+    if (isSystemContext(context.orElse(null))) {
+      return true;
     }
     if (entity == null) {
-      throw forbidden(resource, "UNKNOWN");
+      return false;
     }
 
-    DataScope scope = currentScope(resource, action);
-    UUID currentUserId = currentUserId();
+    DataScope scope = scopeOf(context, resource, action).orElse(null);
+    UUID currentUserId =
+        context.map(AuthenticatedUserContext::userId).orElse(TenantContext.getCurrentUserId());
     if (scope == null || currentUserId == null) {
-      throw forbidden(resource, String.valueOf(scope));
+      return false;
     }
-
     if (scope == DataScope.GLOBAL || scope == DataScope.ORGANIZATION) {
-      return;
+      return true;
     }
 
     UUID createdBy = entity.getCreatedBy();
     if (scope == DataScope.OWN && currentUserId.equals(createdBy)) {
-      return;
+      return true;
     }
 
-    if (scope == DataScope.DEPARTMENT && departmentMemberIds().contains(createdBy)) {
-      return;
-    }
-
-    throw forbidden(resource, scope.name());
+    return scope == DataScope.DEPARTMENT && departmentMemberIds().contains(createdBy);
   }
 
   public <T> Specification<T> scopeFilter(String resource, String action) {
@@ -116,6 +119,28 @@ public class DataScopeGuard {
     return currentContext()
         .map(AuthenticatedUserContext::userId)
         .orElse(TenantContext.getCurrentUserId());
+  }
+
+  private Optional<DataScope> scopeOf(
+      Optional<AuthenticatedUserContext> context, String resource, String action) {
+    return context.map(
+        authenticated -> {
+          PermissionResult result =
+              permissionEvaluator.evaluate(
+                  authenticated.tenantId(),
+                  authenticated.roleCode(),
+                  authenticated.departmentCodes(),
+                  authenticated.userId());
+          return result.scopeOf(resource, action);
+        });
+  }
+
+  private String scopeLabel(String resource, String action) {
+    Optional<AuthenticatedUserContext> context = currentContext();
+    if (isSystemContext(context.orElse(null))) {
+      return DataScope.GLOBAL.name();
+    }
+    return scopeOf(context, resource, action).map(Enum::name).orElse("UNKNOWN");
   }
 
   private boolean isSystemContext(AuthenticatedUserContext context) {

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
@@ -1,11 +1,16 @@
 package com.fabricmanagement.procurement.purchaseorder.app;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
+import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
 import com.fabricmanagement.common.infrastructure.persistence.DocumentNumberGenerator;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredException;
 import com.fabricmanagement.platform.user.domain.SystemUser;
 import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
@@ -21,8 +26,8 @@ import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseO
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,6 +51,8 @@ public class PurchaseOrderService {
   private final ApprovalPort approvalPort;
   private final DocumentNumberGenerator documentNumberGenerator;
   private final DataScopeGuard scopeGuard;
+  private final ExchangeRateService exchangeRateService;
+  private final TenantReportingCurrencyPort tenantReportingCurrencyPort;
 
   public PurchaseOrderResponse getPurchaseOrder(UUID id) {
     PurchaseOrder po = findEntityById(id);
@@ -130,13 +137,11 @@ public class PurchaseOrderService {
             .toList();
     List<PurchaseOrderLine> savedLines = lineRepository.saveAll(lines);
 
-    // 3. Compute header total from saved lines' Money-rounded totalPrice values
-    BigDecimal total =
-        savedLines.stream()
-            .map(PurchaseOrderLine::getTotalPrice)
-            .filter(Objects::nonNull)
-            .reduce(BigDecimal.ZERO, BigDecimal::add);
-    saved.updateTotalAmount(Money.of(total, saved.getCurrency()));
+    FxTotals totals =
+        computeTotals(
+            TenantContext.requireTenantId(), saved.getCurrency(), savedLines, docDate(saved));
+    saved.updateTotalAmount(totals.nativeTotal());
+    saved.setReportingTotal(totals.reportingTotal());
     PurchaseOrder finalSaved = poRepository.save(saved);
 
     log.info(
@@ -274,6 +279,7 @@ public class PurchaseOrderService {
         .paymentTerms(po.getPaymentTerms())
         .expectedDelivery(po.getExpectedDelivery())
         .totalAmount(extractAmount(po.getTotalAmount()))
+        .reportingTotal(toDto(po.getReportingTotal()))
         .revisionNumber(po.getRevisionNumber())
         .notes(po.getNotes())
         .moduleType(po.getModuleType())
@@ -296,6 +302,7 @@ public class PurchaseOrderService {
         .paymentTerms(po.getPaymentTerms())
         .expectedDelivery(po.getExpectedDelivery())
         .totalAmount(extractAmount(po.getTotalAmount()))
+        .reportingTotal(toDto(po.getReportingTotal()))
         .revisionNumber(po.getRevisionNumber())
         .notes(po.getNotes())
         .moduleType(po.getModuleType())
@@ -312,4 +319,82 @@ public class PurchaseOrderService {
   private static String extractCurrencyCode(Money money) {
     return money != null ? money.getCurrency().getCurrencyCode() : null;
   }
+
+  private FxTotals computeTotals(
+      UUID tenantId, String headerCurrency, List<PurchaseOrderLine> lines, LocalDate documentDate) {
+    // Future PO line mutation endpoints must call this before saving the header.
+    BigDecimal nativeTotal =
+        lines.stream()
+            .map(line -> convertLineTotalToHeader(tenantId, line, headerCurrency, documentDate))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    ConvertedMoney reportingTotal =
+        convertToReportingTotal(tenantId, nativeTotal, headerCurrency, documentDate);
+    return new FxTotals(Money.of(nativeTotal, headerCurrency), reportingTotal);
+  }
+
+  private BigDecimal convertLineTotalToHeader(
+      UUID tenantId, PurchaseOrderLine line, String headerCurrency, LocalDate documentDate) {
+    if (line.getTotalPrice() == null || line.getUnitPrice() == null) {
+      return BigDecimal.ZERO;
+    }
+
+    String lineCurrency = line.getUnitPrice().getCurrency().getCurrencyCode();
+    BigDecimal lineAmount = line.getTotalPrice();
+    if (lineCurrency.equalsIgnoreCase(headerCurrency)) {
+      return lineAmount;
+    }
+
+    return convertMoney(tenantId, lineAmount, lineCurrency, headerCurrency, documentDate)
+        .getConvertedAmount();
+  }
+
+  private ConvertedMoney convertToReportingTotal(
+      UUID tenantId, BigDecimal nativeTotal, String headerCurrency, LocalDate documentDate) {
+    String reportingCurrency = tenantReportingCurrencyPort.getReportingCurrency(tenantId);
+    return convertMoney(tenantId, nativeTotal, headerCurrency, reportingCurrency, documentDate);
+  }
+
+  private ConvertedMoney convertMoney(
+      UUID tenantId,
+      BigDecimal amount,
+      String fromCurrency,
+      String toCurrency,
+      LocalDate documentDate) {
+    if (fromCurrency.equalsIgnoreCase(toCurrency)) {
+      return ConvertedMoney.of(
+          amount, fromCurrency, amount, toCurrency, BigDecimal.ONE, documentDate);
+    }
+
+    try {
+      return exchangeRateService.convert(tenantId, amount, fromCurrency, toCurrency, documentDate);
+    } catch (ExchangeRateRequiredException ex) {
+      throw new ProcurementDomainException(
+          String.format(
+              "No exchange rate for %s->%s on %s; seed a rate before creating this document",
+              fromCurrency, toCurrency, documentDate),
+          ex);
+    }
+  }
+
+  private LocalDate docDate(PurchaseOrder po) {
+    return po.getCreatedAt() != null
+        ? po.getCreatedAt().atZone(ZoneOffset.UTC).toLocalDate()
+        : LocalDate.now();
+  }
+
+  private static ConvertedMoneyDto toDto(ConvertedMoney money) {
+    if (money == null) {
+      return null;
+    }
+    return ConvertedMoneyDto.builder()
+        .originalAmount(money.getOriginalAmount())
+        .originalCurrency(money.getOriginalCurrency())
+        .convertedAmount(money.getConvertedAmount())
+        .convertedCurrency(money.getConvertedCurrency())
+        .exchangeRate(money.getExchangeRate())
+        .rateDate(money.getRateDate())
+        .build();
+  }
+
+  private record FxTotals(Money nativeTotal, ConvertedMoney reportingTotal) {}
 }

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
@@ -279,6 +279,7 @@ public class PurchaseOrderService {
         .moduleType(po.getModuleType())
         .moduleSpecs(po.getModuleSpecs())
         .lines(lineResps)
+        .canEdit(scopeGuard.canAccess("procurement", "write", po))
         .build();
   }
 
@@ -300,6 +301,7 @@ public class PurchaseOrderService {
         .moduleType(po.getModuleType())
         .moduleSpecs(po.getModuleSpecs())
         .lines(null) // Summary — lines loaded lazily via separate query
+        .canEdit(scopeGuard.canAccess("procurement", "write", po))
         .build();
   }
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/PurchaseOrder.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/PurchaseOrder.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.procurement.purchaseorder.domain;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.common.infrastructure.web.exception.CurrencyMismatchException;
 import com.fabricmanagement.common.util.Money;
@@ -78,6 +79,27 @@ public class PurchaseOrder extends BaseEntity {
   })
   @Setter(AccessLevel.NONE)
   private Money totalAmount;
+
+  @Embedded
+  @AttributeOverrides({
+    @AttributeOverride(
+        name = "originalAmount",
+        column = @Column(name = "reporting_total_original", precision = 18, scale = 4)),
+    @AttributeOverride(
+        name = "originalCurrency",
+        column = @Column(name = "reporting_total_orig_currency", length = 3)),
+    @AttributeOverride(
+        name = "convertedAmount",
+        column = @Column(name = "reporting_total_converted", precision = 18, scale = 4)),
+    @AttributeOverride(
+        name = "convertedCurrency",
+        column = @Column(name = "reporting_currency", length = 3)),
+    @AttributeOverride(
+        name = "exchangeRate",
+        column = @Column(name = "reporting_exchange_rate", precision = 20, scale = 8)),
+    @AttributeOverride(name = "rateDate", column = @Column(name = "reporting_rate_date"))
+  })
+  private ConvertedMoney reportingTotal;
 
   public void updateTotalAmount(Money amount) {
     if (amount == null) {

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.procurement.purchaseorder.dto;
 
+import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
@@ -25,6 +26,7 @@ public class PurchaseOrderResponse {
   String paymentTerms;
   LocalDate expectedDelivery;
   BigDecimal totalAmount;
+  ConvertedMoneyDto reportingTotal;
   Integer revisionNumber;
   String notes;
   PurchaseOrderModuleType moduleType;

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
@@ -30,6 +30,7 @@ public class PurchaseOrderResponse {
   PurchaseOrderModuleType moduleType;
   PurchaseOrderSpecs moduleSpecs;
   List<PurchaseOrderLineResponse> lines;
+  boolean canEdit;
 
   @Value
   @Builder

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
@@ -1,8 +1,12 @@
 package com.fabricmanagement.procurement.quote.app;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredException;
 import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
 import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
@@ -18,7 +22,10 @@ import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepo
 import com.fabricmanagement.procurement.quote.mapper.SupplierQuoteMapper;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.UUID;
@@ -42,6 +49,8 @@ public class SupplierQuoteService {
   private final TradingPartnerResolver partnerResolver;
   private final SupplierQuoteMapper quoteMapper;
   private final DomainEventPublisher eventPublisher;
+  private final ExchangeRateService exchangeRateService;
+  private final TenantReportingCurrencyPort tenantReportingCurrencyPort;
 
   public SupplierQuoteResponse getQuoteById(UUID quoteId) {
     return quoteMapper.toResponse(getActiveQuote(quoteId));
@@ -144,6 +153,7 @@ public class SupplierQuoteService {
     line.setNotes(req.notes());
 
     quote.addLine(line);
+    recomputeTotals(quote);
     return quoteMapper.toResponse(quoteRepository.save(quote));
   }
 
@@ -235,5 +245,63 @@ public class SupplierQuoteService {
     } catch (Exception e) {
       log.warn("Failed to publish SupplierQuoteReceivedEvent for quote {}", quote.getId(), e);
     }
+  }
+
+  private void recomputeTotals(SupplierQuote quote) {
+    LocalDate documentDate = docDate(quote);
+    String headerCurrency = quote.getCurrency();
+    BigDecimal nativeTotal =
+        quote.getLines().stream()
+            .map(
+                line ->
+                    convertLineTotalToHeader(
+                        quote.getTenantId(), line, headerCurrency, documentDate))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+    String reportingCurrency =
+        tenantReportingCurrencyPort.getReportingCurrency(quote.getTenantId());
+    quote.setReportingTotal(
+        convertMoney(
+            quote.getTenantId(), nativeTotal, headerCurrency, reportingCurrency, documentDate));
+  }
+
+  private BigDecimal convertLineTotalToHeader(
+      UUID tenantId, SupplierQuoteLine line, String headerCurrency, LocalDate documentDate) {
+    BigDecimal lineAmount = line.lineTotal();
+    String lineCurrency = line.getCurrency();
+    if (lineCurrency.equalsIgnoreCase(headerCurrency)) {
+      return lineAmount;
+    }
+
+    return convertMoney(tenantId, lineAmount, lineCurrency, headerCurrency, documentDate)
+        .getConvertedAmount();
+  }
+
+  private ConvertedMoney convertMoney(
+      UUID tenantId,
+      BigDecimal amount,
+      String fromCurrency,
+      String toCurrency,
+      LocalDate documentDate) {
+    if (fromCurrency.equalsIgnoreCase(toCurrency)) {
+      return ConvertedMoney.of(
+          amount, fromCurrency, amount, toCurrency, BigDecimal.ONE, documentDate);
+    }
+
+    try {
+      return exchangeRateService.convert(tenantId, amount, fromCurrency, toCurrency, documentDate);
+    } catch (ExchangeRateRequiredException ex) {
+      throw new ProcurementDomainException(
+          String.format(
+              "No exchange rate for %s->%s on %s; seed a rate before creating this document",
+              fromCurrency, toCurrency, documentDate),
+          ex);
+    }
+  }
+
+  private LocalDate docDate(SupplierQuote quote) {
+    Instant dateSource =
+        quote.getSubmittedAt() != null ? quote.getSubmittedAt() : quote.getCreatedAt();
+    return dateSource != null ? dateSource.atZone(ZoneOffset.UTC).toLocalDate() : LocalDate.now();
   }
 }

--- a/src/main/java/com/fabricmanagement/procurement/quote/domain/SupplierQuote.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/domain/SupplierQuote.java
@@ -1,9 +1,13 @@
 package com.fabricmanagement.procurement.quote.domain;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -51,6 +55,27 @@ public class SupplierQuote extends BaseEntity {
 
   @Column(name = "currency", nullable = false, length = 10)
   private String currency;
+
+  @Embedded
+  @AttributeOverrides({
+    @AttributeOverride(
+        name = "originalAmount",
+        column = @Column(name = "reporting_total_original", precision = 18, scale = 4)),
+    @AttributeOverride(
+        name = "originalCurrency",
+        column = @Column(name = "reporting_total_orig_currency", length = 3)),
+    @AttributeOverride(
+        name = "convertedAmount",
+        column = @Column(name = "reporting_total_converted", precision = 18, scale = 4)),
+    @AttributeOverride(
+        name = "convertedCurrency",
+        column = @Column(name = "reporting_currency", length = 3)),
+    @AttributeOverride(
+        name = "exchangeRate",
+        column = @Column(name = "reporting_exchange_rate", precision = 20, scale = 8)),
+    @AttributeOverride(name = "rateDate", column = @Column(name = "reporting_rate_date"))
+  })
+  private ConvertedMoney reportingTotal;
 
   @Column(name = "payment_terms", length = 50)
   private String paymentTerms;
@@ -113,6 +138,9 @@ public class SupplierQuote extends BaseEntity {
   }
 
   public BigDecimal computeTotalAmount() {
+    if (this.reportingTotal != null) {
+      return this.reportingTotal.getOriginalAmount();
+    }
     return this.lines.stream()
         .map(SupplierQuoteLine::lineTotal)
         .reduce(BigDecimal.ZERO, BigDecimal::add);

--- a/src/main/java/com/fabricmanagement/procurement/quote/dto/SupplierQuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/dto/SupplierQuoteResponse.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.procurement.quote.dto;
 
+import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.procurement.quote.domain.QuoteEntryMethod;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteModuleType;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteStatus;
@@ -64,6 +65,9 @@ public class SupplierQuoteResponse {
 
   @Schema(description = "Total Amount of the Quote")
   BigDecimal totalAmount;
+
+  @Schema(description = "Total amount converted to the tenant reporting currency")
+  ConvertedMoneyDto reportingTotal;
 
   @Schema(description = "Quote Lines")
   List<QuoteLineResponse> lines;

--- a/src/main/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapper.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapper.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.procurement.quote.mapper;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
+import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
@@ -15,4 +17,18 @@ public interface SupplierQuoteMapper {
 
   @Mapping(target = "lineTotal", expression = "java(line.lineTotal())")
   SupplierQuoteResponse.QuoteLineResponse toLineResponse(SupplierQuoteLine line);
+
+  default ConvertedMoneyDto toDto(ConvertedMoney money) {
+    if (money == null) {
+      return null;
+    }
+    return ConvertedMoneyDto.builder()
+        .originalAmount(money.getOriginalAmount())
+        .originalCurrency(money.getOriginalCurrency())
+        .convertedAmount(money.getConvertedAmount())
+        .convertedCurrency(money.getConvertedCurrency())
+        .exchangeRate(money.getExchangeRate())
+        .rateDate(money.getRateDate())
+        .build();
+  }
 }

--- a/src/main/resources/db/migration/V20260630100000__procurement_reporting_totals.sql
+++ b/src/main/resources/db/migration/V20260630100000__procurement_reporting_totals.sql
@@ -1,0 +1,15 @@
+ALTER TABLE procurement.purchase_order
+    ADD COLUMN IF NOT EXISTS reporting_total_original NUMERIC(18,4),
+    ADD COLUMN IF NOT EXISTS reporting_total_orig_currency VARCHAR(3),
+    ADD COLUMN IF NOT EXISTS reporting_total_converted NUMERIC(18,4),
+    ADD COLUMN IF NOT EXISTS reporting_currency VARCHAR(3),
+    ADD COLUMN IF NOT EXISTS reporting_exchange_rate NUMERIC(20,8),
+    ADD COLUMN IF NOT EXISTS reporting_rate_date DATE;
+
+ALTER TABLE procurement.supplier_quote
+    ADD COLUMN IF NOT EXISTS reporting_total_original NUMERIC(18,4),
+    ADD COLUMN IF NOT EXISTS reporting_total_orig_currency VARCHAR(3),
+    ADD COLUMN IF NOT EXISTS reporting_total_converted NUMERIC(18,4),
+    ADD COLUMN IF NOT EXISTS reporting_currency VARCHAR(3),
+    ADD COLUMN IF NOT EXISTS reporting_exchange_rate NUMERIC(20,8),
+    ADD COLUMN IF NOT EXISTS reporting_rate_date DATE;

--- a/src/test/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuardTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/security/DataScopeGuardTest.java
@@ -64,6 +64,8 @@ class DataScopeGuardTest {
 
     assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
         .doesNotThrowAnyException();
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID))).isTrue();
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(OTHER_USER_ID))).isFalse();
     assertThatThrownBy(
             () -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
         .isInstanceOf(AccessDeniedException.class);
@@ -100,6 +102,8 @@ class DataScopeGuardTest {
     assertThatCode(
             () -> guard.assertCanAccess("procurement", "write", poCreatedBy(DEPARTMENT_MEMBER_ID)))
         .doesNotThrowAnyException();
+    assertThat(guard.canAccess("procurement", "write", poCreatedBy(DEPARTMENT_MEMBER_ID))).isTrue();
+    assertThat(guard.canAccess("procurement", "write", poCreatedBy(OTHER_USER_ID))).isFalse();
     assertThatThrownBy(
             () -> guard.assertCanAccess("procurement", "write", poCreatedBy(OTHER_USER_ID)))
         .isInstanceOf(AccessDeniedException.class);
@@ -132,6 +136,35 @@ class DataScopeGuardTest {
 
     assertThat(organizationPredicate).isSameAs(organizationCriteria.expectedPredicate);
     assertThat(globalPredicate).isSameAs(globalCriteria.expectedPredicate);
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(OTHER_USER_ID))).isTrue();
+  }
+
+  @Test
+  void managerReadOrganizationWriteDepartmentCanSeeAllButEditOnlyDepartmentRecords() {
+    RequestContextHolder.setRequestAttributes(
+        new ServletRequestAttributes(new MockHttpServletRequest()));
+    authenticate(CURRENT_USER_ID, List.of("PROCUREMENT"));
+    PermissionResult managerPermissions =
+        new PermissionResult(
+            Map.of(
+                "procurement",
+                Map.of("read", DataScope.ORGANIZATION, "write", DataScope.DEPARTMENT)),
+            false);
+    when(permissionEvaluator.evaluate(TENANT_ID, "WORKER", List.of("PROCUREMENT"), CURRENT_USER_ID))
+        .thenReturn(managerPermissions);
+    when(userRepository.findActiveUserIdsByDepartmentCodes(TENANT_ID, Set.of("PROCUREMENT")))
+        .thenReturn(Set.of(DEPARTMENT_MEMBER_ID));
+    CriteriaMocks criteria = criteriaMocks();
+    when(criteria.criteriaBuilder.conjunction()).thenReturn(criteria.expectedPredicate);
+
+    Predicate readPredicate =
+        guard
+            .scopeFilter("procurement", "read")
+            .toPredicate(criteria.root, criteria.query, criteria.criteriaBuilder);
+
+    assertThat(readPredicate).isSameAs(criteria.expectedPredicate);
+    assertThat(guard.canAccess("procurement", "write", poCreatedBy(DEPARTMENT_MEMBER_ID))).isTrue();
+    assertThat(guard.canAccess("procurement", "write", poCreatedBy(OTHER_USER_ID))).isFalse();
   }
 
   @Test
@@ -145,6 +178,7 @@ class DataScopeGuardTest {
     assertThatThrownBy(
             () -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
         .isInstanceOf(AccessDeniedException.class);
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID))).isFalse();
     Predicate predicate =
         guard
             .scopeFilter("procurement", "read")
@@ -155,6 +189,7 @@ class DataScopeGuardTest {
 
   @Test
   void missingAuthenticationFailsClosedButExplicitSystemContextBypasses() {
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID))).isFalse();
     assertThatThrownBy(
             () -> guard.assertCanAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID)))
         .isInstanceOf(AccessDeniedException.class);
@@ -164,6 +199,16 @@ class DataScopeGuardTest {
 
     assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
         .doesNotThrowAnyException();
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(OTHER_USER_ID))).isTrue();
+    verify(permissionEvaluator, never()).evaluate(any(), any(), any(), any());
+  }
+
+  @Test
+  void anonymousPrincipalMakesCanAccessReturnFalseWithoutThrowing() {
+    SecurityContextHolder.getContext()
+        .setAuthentication(new UsernamePasswordAuthenticationToken("anonymous", "n/a", List.of()));
+
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(CURRENT_USER_ID))).isFalse();
     verify(permissionEvaluator, never()).evaluate(any(), any(), any(), any());
   }
 
@@ -173,6 +218,7 @@ class DataScopeGuardTest {
 
     assertThatCode(() -> guard.assertCanAccess("procurement", "read", poCreatedBy(OTHER_USER_ID)))
         .doesNotThrowAnyException();
+    assertThat(guard.canAccess("procurement", "read", poCreatedBy(OTHER_USER_ID))).isTrue();
     verify(permissionEvaluator, never()).evaluate(any(), any(), any(), any());
   }
 

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
@@ -13,7 +13,9 @@ import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
 import com.fabricmanagement.common.infrastructure.persistence.DocumentNumberGenerator;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
@@ -49,6 +51,8 @@ class PurchaseOrderServiceDataScopeTest {
   @Mock private ApprovalPort approvalPort;
   @Mock private DocumentNumberGenerator documentNumberGenerator;
   @Mock private DataScopeGuard scopeGuard;
+  @Mock private ExchangeRateService exchangeRateService;
+  @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
 
   @AfterEach
   void clearTenantContext() {
@@ -156,6 +160,7 @@ class PurchaseOrderServiceDataScopeTest {
     when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
     when(scopeGuard.canAccess(eq("procurement"), eq("write"), any(PurchaseOrder.class)))
         .thenReturn(true);
+    when(tenantReportingCurrencyPort.getReportingCurrency(TENANT_ID)).thenReturn("USD");
 
     PurchaseOrderResponse response = service.createPurchaseOrder(createRequest());
 
@@ -171,7 +176,9 @@ class PurchaseOrderServiceDataScopeTest {
         validationEngine,
         approvalPort,
         documentNumberGenerator,
-        scopeGuard);
+        scopeGuard,
+        exchangeRateService,
+        tenantReportingCurrencyPort);
   }
 
   private PurchaseOrder purchaseOrder(PurchaseOrderStatus status) {

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
@@ -1,12 +1,12 @@
 package com.fabricmanagement.procurement.purchaseorder.app;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
@@ -19,6 +19,7 @@ import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
+import com.fabricmanagement.procurement.purchaseorder.dto.PurchaseOrderResponse;
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderLineRepository;
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
 import java.math.BigDecimal;
@@ -71,17 +72,55 @@ class PurchaseOrderServiceDataScopeTest {
   }
 
   @Test
-  void getPurchaseOrderAppliesReadScopeBeforeReturningLines() {
+  void managerReadOrgWriteDepartmentListMapsCanEditFromWriteScopeDecision() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    PurchaseOrderService service = service();
+    PageRequest pageable = PageRequest.of(0, 20);
+    Specification<PurchaseOrder> scopeSpec = (root, query, cb) -> cb.conjunction();
+    PurchaseOrder editablePo = purchaseOrder(PurchaseOrderStatus.DRAFT);
+    PurchaseOrder readOnlyPo = purchaseOrder(PurchaseOrderStatus.DRAFT);
+    readOnlyPo.setId(UUID.fromString("30000000-0000-0000-0000-000000000002"));
+    when(scopeGuard.<PurchaseOrder>scopeFilter("procurement", "read")).thenReturn(scopeSpec);
+    when(scopeGuard.canAccess("procurement", "write", editablePo)).thenReturn(true);
+    when(scopeGuard.canAccess("procurement", "write", readOnlyPo)).thenReturn(false);
+    when(poRepository.findAll(any(Specification.class), eq(pageable)))
+        .thenReturn(new PageImpl<>(List.of(editablePo, readOnlyPo), pageable, 2));
+
+    List<PurchaseOrderResponse> content =
+        service.listPurchaseOrders(null, null, pageable).getContent();
+
+    assertThat(content).extracting(PurchaseOrderResponse::isCanEdit).containsExactly(true, false);
+  }
+
+  @Test
+  void managerReadOrgWriteDepartmentDetailMapsCanEditFalseForReadOnlyRecord() {
     PurchaseOrder po = purchaseOrder(PurchaseOrderStatus.DRAFT);
     PurchaseOrderService service = service();
     when(poRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+    when(scopeGuard.canAccess("procurement", "write", po)).thenReturn(false);
     when(lineRepository.findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(PO_ID))
         .thenReturn(List.of());
 
-    service.getPurchaseOrder(PO_ID);
+    PurchaseOrderResponse response = service.getPurchaseOrder(PO_ID);
 
     verify(scopeGuard).assertCanAccess("procurement", "read", po);
     verify(lineRepository).findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(PO_ID);
+    assertThat(response.isCanEdit()).isFalse();
+  }
+
+  @Test
+  void managerReadOrgWriteDepartmentDetailMapsCanEditTrueForEditableRecord() {
+    PurchaseOrder po = purchaseOrder(PurchaseOrderStatus.DRAFT);
+    PurchaseOrderService service = service();
+    when(poRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+    when(scopeGuard.canAccess("procurement", "write", po)).thenReturn(true);
+    when(lineRepository.findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(PO_ID))
+        .thenReturn(List.of());
+
+    PurchaseOrderResponse response = service.getPurchaseOrder(PO_ID);
+
+    verify(scopeGuard).assertCanAccess("procurement", "read", po);
+    assertThat(response.isCanEdit()).isTrue();
   }
 
   @Test
@@ -101,7 +140,7 @@ class PurchaseOrderServiceDataScopeTest {
   }
 
   @Test
-  void createPurchaseOrderDoesNotApplyRowScopeGuard() {
+  void createPurchaseOrderDoesNotApplyRowScopeGuardButReturnsCanEdit() {
     TenantContext.setCurrentTenantId(TENANT_ID);
     PurchaseOrderService service = service();
     when(documentNumberGenerator.generate(
@@ -115,10 +154,14 @@ class PurchaseOrderServiceDataScopeTest {
               return po;
             });
     when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(scopeGuard.canAccess(eq("procurement"), eq("write"), any(PurchaseOrder.class)))
+        .thenReturn(true);
 
-    service.createPurchaseOrder(createRequest());
+    PurchaseOrderResponse response = service.createPurchaseOrder(createRequest());
 
-    verifyNoInteractions(scopeGuard);
+    assertThat(response.isCanEdit()).isTrue();
+    verify(scopeGuard, never()).assertCanAccess(eq("procurement"), eq("write"), any());
+    verify(scopeGuard, never()).scopeFilter(eq("procurement"), eq("read"));
   }
 
   private PurchaseOrderService service() {

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceFxTotalTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceFxTotalTest.java
@@ -1,0 +1,210 @@
+package com.fabricmanagement.procurement.purchaseorder.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
+import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
+import com.fabricmanagement.common.infrastructure.persistence.DocumentNumberGenerator;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredException;
+import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
+import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
+import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
+import com.fabricmanagement.procurement.purchaseorder.dto.PurchaseOrderResponse;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderLineRepository;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderServiceFxTotalTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("10000000-0000-0000-0000-000000000001");
+  private static final UUID PO_ID = UUID.fromString("30000000-0000-0000-0000-000000000001");
+  private static final LocalDate DOC_DATE = LocalDate.of(2026, 6, 30);
+  private static final Instant DOC_INSTANT = Instant.parse("2026-06-30T10:00:00Z");
+
+  @Mock private PurchaseOrderRepository poRepository;
+  @Mock private PurchaseOrderLineRepository lineRepository;
+  @Mock private PurchaseOrderValidationEngine validationEngine;
+  @Mock private ApprovalPort approvalPort;
+  @Mock private DocumentNumberGenerator documentNumberGenerator;
+  @Mock private DataScopeGuard scopeGuard;
+  @Mock private ExchangeRateService exchangeRateService;
+  @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
+
+  private PurchaseOrderService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    service =
+        new PurchaseOrderService(
+            poRepository,
+            lineRepository,
+            validationEngine,
+            approvalPort,
+            documentNumberGenerator,
+            scopeGuard,
+            exchangeRateService,
+            tenantReportingCurrencyPort);
+    when(documentNumberGenerator.generate(
+            eq(TENANT_ID), eq("PURCHASE_ORDER"), eq("PO"), any(), eq(5)))
+        .thenReturn("PO-20260630-00001");
+    when(poRepository.save(any(PurchaseOrder.class)))
+        .thenAnswer(
+            invocation -> {
+              PurchaseOrder po = invocation.getArgument(0);
+              po.setId(PO_ID);
+              if (po.getCreatedAt() == null) {
+                po.setCreatedAt(DOC_INSTANT);
+              }
+              return po;
+            });
+    when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void createPurchaseOrderConvertsMixedCurrencyLinesIntoHeaderAndReportingCurrency() {
+    when(tenantReportingCurrencyPort.getReportingCurrency(TENANT_ID)).thenReturn("GBP");
+    when(exchangeRateService.convert(
+            eq(TENANT_ID), eq(new BigDecimal("100.000")), eq("USD"), eq("TRY"), eq(DOC_DATE)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("100.000"),
+                "USD",
+                new BigDecimal("3000.0000"),
+                "TRY",
+                new BigDecimal("30.00000000"),
+                DOC_DATE));
+    when(exchangeRateService.convert(
+            eq(TENANT_ID), eq(new BigDecimal("50.000")), eq("EUR"), eq("TRY"), eq(DOC_DATE)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("50.000"),
+                "EUR",
+                new BigDecimal("1750.0000"),
+                "TRY",
+                new BigDecimal("35.00000000"),
+                DOC_DATE));
+    when(exchangeRateService.convert(
+            eq(TENANT_ID), eq(new BigDecimal("4750.0000")), eq("TRY"), eq("GBP"), eq(DOC_DATE)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("4750.0000"),
+                "TRY",
+                new BigDecimal("95.0000"),
+                "GBP",
+                new BigDecimal("0.02000000"),
+                DOC_DATE));
+    when(scopeGuard.canAccess(eq("procurement"), eq("write"), any(PurchaseOrder.class)))
+        .thenReturn(true);
+
+    PurchaseOrderResponse response =
+        service.createPurchaseOrder(
+            createRequest(
+                "TRY", List.of(line("USD", "100.0000", "1.000"), line("EUR", "50.0000", "1.000"))));
+
+    assertThat(response.getTotalAmount()).isEqualByComparingTo("4750.0000");
+    assertThat(response.getReportingTotal()).isNotNull();
+    assertThat(response.getReportingTotal().getOriginalAmount()).isEqualByComparingTo("4750.0000");
+    assertThat(response.getReportingTotal().getOriginalCurrency()).isEqualTo("TRY");
+    assertThat(response.getReportingTotal().getConvertedAmount()).isEqualByComparingTo("95.0000");
+    assertThat(response.getReportingTotal().getConvertedCurrency()).isEqualTo("GBP");
+    assertThat(response.getReportingTotal().getExchangeRate()).isEqualByComparingTo("0.02000000");
+    assertThat(response.getReportingTotal().getRateDate()).isEqualTo(DOC_DATE);
+  }
+
+  @Test
+  void createPurchaseOrderKeepsSingleCurrencyNativeTotalAndPopulatesReportingTotal() {
+    when(tenantReportingCurrencyPort.getReportingCurrency(TENANT_ID)).thenReturn("USD");
+    when(scopeGuard.canAccess(eq("procurement"), eq("write"), any(PurchaseOrder.class)))
+        .thenReturn(true);
+
+    PurchaseOrderResponse response =
+        service.createPurchaseOrder(createRequest("USD", List.of(line("USD", "12.5000", "2.000"))));
+
+    assertThat(response.getTotalAmount()).isEqualByComparingTo("25.000");
+    assertThat(response.getReportingTotal()).isNotNull();
+    assertThat(response.getReportingTotal().getOriginalAmount()).isEqualByComparingTo("25.000");
+    assertThat(response.getReportingTotal().getOriginalCurrency()).isEqualTo("USD");
+    assertThat(response.getReportingTotal().getConvertedAmount()).isEqualByComparingTo("25.000");
+    assertThat(response.getReportingTotal().getConvertedCurrency()).isEqualTo("USD");
+    assertThat(response.getReportingTotal().getExchangeRate()).isEqualByComparingTo(BigDecimal.ONE);
+    assertThat(response.getReportingTotal().getRateDate()).isEqualTo(DOC_DATE);
+    verify(exchangeRateService, never())
+        .convert(
+            any(UUID.class),
+            any(BigDecimal.class),
+            any(String.class),
+            any(String.class),
+            any(LocalDate.class));
+  }
+
+  @Test
+  void createPurchaseOrderFailsClosedWhenLineExchangeRateIsMissing() {
+    when(exchangeRateService.convert(
+            eq(TENANT_ID), eq(new BigDecimal("100.000")), eq("USD"), eq("TRY"), eq(DOC_DATE)))
+        .thenThrow(new ExchangeRateRequiredException("USD", "TRY", DOC_DATE));
+
+    assertThatThrownBy(
+            () ->
+                service.createPurchaseOrder(
+                    createRequest("TRY", List.of(line("USD", "100.0000", "1.000")))))
+        .isInstanceOf(ProcurementDomainException.class)
+        .hasMessageContaining("USD->TRY")
+        .hasMessageContaining("2026-06-30");
+
+    verify(poRepository, times(1)).save(any(PurchaseOrder.class));
+  }
+
+  private CreatePurchaseOrderRequest createRequest(
+      String currency, List<CreatePurchaseOrderRequest.PurchaseOrderLineRequest> lines) {
+    return CreatePurchaseOrderRequest.builder()
+        .workOrderId(UUID.randomUUID())
+        .tradingPartnerId(UUID.randomUUID())
+        .currency(currency)
+        .paymentTerms("NET30")
+        .expectedDelivery(DOC_DATE.plusDays(10))
+        .moduleType(PurchaseOrderModuleType.GENERIC)
+        .lines(lines)
+        .build();
+  }
+
+  private CreatePurchaseOrderRequest.PurchaseOrderLineRequest line(
+      String currency, String unitPrice, String qty) {
+    return CreatePurchaseOrderRequest.PurchaseOrderLineRequest.builder()
+        .productDesc("Cotton")
+        .qty(new BigDecimal(qty))
+        .unit("KG")
+        .unitPrice(new BigDecimal(unitPrice))
+        .currency(currency)
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
@@ -4,14 +4,19 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
 import com.fabricmanagement.procurement.quote.domain.QuoteEntryMethod;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteStatus;
 import com.fabricmanagement.procurement.quote.dto.AddQuoteLineRequest;
 import com.fabricmanagement.procurement.quote.dto.CreateSupplierQuoteRequest;
@@ -21,6 +26,7 @@ import com.fabricmanagement.procurement.quote.mapper.SupplierQuoteMapper;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,6 +49,8 @@ class SupplierQuoteServiceTest {
   @Mock private TradingPartnerResolver partnerResolver;
   @Mock private SupplierQuoteMapper quoteMapper;
   @Mock private DomainEventPublisher eventPublisher;
+  @Mock private ExchangeRateService exchangeRateService;
+  @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
 
   @InjectMocks private SupplierQuoteService quoteService;
 
@@ -64,6 +72,7 @@ class SupplierQuoteServiceTest {
     mockQuote.setTradingPartnerId(partnerId);
     mockQuote.setQuoteNumber("SQ-2026-TEST");
     mockQuote.setStatus(SupplierQuoteStatus.RECEIVED);
+    mockQuote.setCurrency("USD");
 
     mockResponse =
         SupplierQuoteResponse.builder().id(quoteId).status(SupplierQuoteStatus.RECEIVED).build();
@@ -112,6 +121,7 @@ class SupplierQuoteServiceTest {
         .thenReturn(Optional.of(mockQuote));
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
     when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("USD");
 
     AddQuoteLineRequest req =
         new AddQuoteLineRequest(
@@ -129,6 +139,79 @@ class SupplierQuoteServiceTest {
     assertNotNull(updated);
     assertEquals(1, mockQuote.getLines().size());
     assertEquals(new BigDecimal("12.50"), mockQuote.getLines().get(0).getUnitPrice());
+    assertNotNull(mockQuote.getReportingTotal());
+    assertEquals("USD", mockQuote.getReportingTotal().getConvertedCurrency());
+    verify(quoteRepository).save(mockQuote);
+  }
+
+  @Test
+  @DisplayName("Should compute Supplier Quote native and reporting totals with FX")
+  void shouldComputeSupplierQuoteTotalsWithFx() {
+    LocalDate docDate = LocalDate.of(2026, 6, 30);
+    mockQuote.setCurrency("TRY");
+    mockQuote.setSubmittedAt(Instant.parse("2026-06-30T09:00:00Z"));
+    mockQuote.addLine(quoteLine("USD", "100.00", "1.000"));
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+    when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("GBP");
+    when(exchangeRateService.convert(
+            eq(tenantId), any(BigDecimal.class), eq("USD"), eq("TRY"), eq(docDate)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("100.00000"),
+                "USD",
+                new BigDecimal("3000.0000"),
+                "TRY",
+                new BigDecimal("30.00000000"),
+                docDate));
+    when(exchangeRateService.convert(
+            eq(tenantId), any(BigDecimal.class), eq("EUR"), eq("TRY"), eq(docDate)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("50.00000"),
+                "EUR",
+                new BigDecimal("1750.0000"),
+                "TRY",
+                new BigDecimal("35.00000000"),
+                docDate));
+    when(exchangeRateService.convert(
+            eq(tenantId), any(BigDecimal.class), eq("TRY"), eq("GBP"), eq(docDate)))
+        .thenReturn(
+            ConvertedMoney.of(
+                new BigDecimal("4750.0000"),
+                "TRY",
+                new BigDecimal("95.0000"),
+                "GBP",
+                new BigDecimal("0.02000000"),
+                docDate));
+
+    SupplierQuoteResponse updated =
+        quoteService.addLine(
+            quoteId,
+            new AddQuoteLineRequest(
+                UUID.randomUUID(),
+                new BigDecimal("50.00"),
+                "EUR",
+                new BigDecimal("1.000"),
+                "KG",
+                null,
+                null,
+                null));
+
+    assertNotNull(updated);
+    assertNotNull(mockQuote.getReportingTotal());
+    assertEquals(0, mockQuote.computeTotalAmount().compareTo(new BigDecimal("4750.0000")));
+    assertEquals("TRY", mockQuote.getReportingTotal().getOriginalCurrency());
+    assertEquals(
+        0,
+        mockQuote.getReportingTotal().getOriginalAmount().compareTo(new BigDecimal("4750.0000")));
+    assertEquals("GBP", mockQuote.getReportingTotal().getConvertedCurrency());
+    assertEquals(
+        0, mockQuote.getReportingTotal().getConvertedAmount().compareTo(new BigDecimal("95.0000")));
+    assertEquals(docDate, mockQuote.getReportingTotal().getRateDate());
     verify(quoteRepository).save(mockQuote);
   }
 
@@ -234,5 +317,16 @@ class SupplierQuoteServiceTest {
         assertThrows(IllegalStateException.class, () -> quoteService.markAsRejected(quoteId));
 
     assertEquals("Cannot transition quote from ACCEPTED to REJECTED", ex.getMessage());
+  }
+
+  private SupplierQuoteLine quoteLine(String currency, String unitPrice, String qty) {
+    SupplierQuoteLine line = new SupplierQuoteLine();
+    line.setTenantId(tenantId);
+    line.setRfqLineId(UUID.randomUUID());
+    line.setUnitPrice(new BigDecimal(unitPrice));
+    line.setCurrency(currency);
+    line.setQty(new BigDecimal(qty));
+    line.setUnit("KG");
+    return line;
   }
 }


### PR DESCRIPTION
…n PO response

After PERM-4, read scope can exceed write scope (procurement MANAGER: read=ORGANIZATION, write=DEPARTMENT) — a user can read a PO they cannot mutate. Expose that decision so the UI can hide actions that would 403, without duplicating scope logic on the client.

- DataScopeGuard: add non-throwing canAccess(resource, action, entity) holding the single scope rule; assertCanAccess now delegates (if !canAccess -> 403). Fail-closed: a missing/anonymous (non-system) context returns false and never throws; system bypass (SystemUser.ID / system tenant) unchanged; scopeFilter unchanged.
- PurchaseOrderResponse: add additive boolean canEdit, set in both mappers (detail + summary) via scopeGuard.canAccess("procurement","write", po). Reuses the per-request department-member cache (no extra N+1).
- OpenAPI regenerated; additive field, non-breaking.

Tests: DataScopeGuardTest (canAccess matrix incl. missing-context -> false, no throw), PurchaseOrderServiceDataScopeTest (MANAGER canEdit true/false on own vs other dept, list + detail). Backend build + OpenApiExportIT green.

Refs PERM-4. Part 1/2 of PERM-5 (backend).