### PR TITLE
fix(platform): use CGLIB async proxies so @Scheduled trial job is exp…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,7 @@ services:
       POSTGRES_APP_PASSWORD: ${POSTGRES_APP_PASSWORD:?error}
       POSTGRES_SYSTEM_PASSWORD: ${POSTGRES_SYSTEM_PASSWORD:?error}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      - "${POSTGRES_HOST_PORT:-5433}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./scripts/db/docker-init-roles.sh:/docker-entrypoint-initdb.d/01-init-roles.sh

--- a/src/main/java/com/fabricmanagement/common/infrastructure/config/AsyncConfig.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/config/AsyncConfig.java
@@ -12,7 +12,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * uncaught-exception logging. (Spring allows only one {@code AsyncConfigurer} bean.)
  */
 @Configuration
-@EnableAsync
+@EnableAsync(proxyTargetClass = true)
 public class AsyncConfig implements AsyncConfigurer {
 
   @Override


### PR DESCRIPTION
…osed

@EnableAsync defaulted to interface JDK proxies; refreshTrialWindows is not on TrialLifecyclePort, so the scheduler failed to bind it and startup broke. proxyTargetClass=true aligns async proxying with Boot's CGLIB default. Also publishes container Postgres on POSTGRES_HOST_PORT (default 5433) to avoid the local 5432 clash.