### PR TITLE
feat(auth): add login identity backfill foundation

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PartnerUserSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PartnerUserSeeder.java
@@ -1,7 +1,9 @@
 package com.fabricmanagement.common.infrastructure.bootstrap;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.auth.app.IdentityProvisioningService;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
+import com.fabricmanagement.platform.auth.domain.MfaType;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
 import com.fabricmanagement.platform.communication.infra.repository.ContactRepository;
 import com.fabricmanagement.platform.organization.domain.Organization;
@@ -45,6 +47,7 @@ public class PartnerUserSeeder implements DataSeeder {
   private final PasswordEncoder passwordEncoder;
   private final TransactionTemplate transactionTemplate;
   private final ContactRepository contactRepository;
+  private final IdentityProvisioningService identityProvisioningService;
 
   private static final String DEFAULT_PASSWORD = "password123";
 
@@ -205,8 +208,6 @@ public class PartnerUserSeeder implements DataSeeder {
     entity.setRole(role);
     userRepository.save(entity);
 
-    setupAuthUser(user.getId(), tenantId);
-
     // Mark contact as verified
     contactRepository
         .findByTenantIdAndContactValue(tenantId, profile.email())
@@ -215,6 +216,8 @@ public class PartnerUserSeeder implements DataSeeder {
               contact.verify();
               contactRepository.save(contact);
             });
+
+    setupAuthUser(user.getId(), tenantId, profile.email());
 
     log.debug(
         "Created external user: {} {} — {} ({}) linked to {}",
@@ -226,12 +229,15 @@ public class PartnerUserSeeder implements DataSeeder {
     return true;
   }
 
-  private void setupAuthUser(UUID userId, UUID tenantId) {
+  private void setupAuthUser(UUID userId, UUID tenantId, String email) {
     if (!authUserRepository.existsByUserId(userId)) {
-      AuthUser authUser = AuthUser.create(userId, passwordEncoder.encode(DEFAULT_PASSWORD));
+      String passwordHash = passwordEncoder.encode(DEFAULT_PASSWORD);
+      AuthUser authUser = AuthUser.create(userId, passwordHash);
       authUser.setTenantId(tenantId);
       authUser.verify();
       authUserRepository.save(authUser);
+      identityProvisioningService.provisionCredential(
+          email, passwordHash, false, MfaType.NONE, null, true, tenantId, userId);
     }
   }
 

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/UserSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/UserSeeder.java
@@ -1,7 +1,9 @@
 package com.fabricmanagement.common.infrastructure.bootstrap;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.auth.app.IdentityProvisioningService;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
+import com.fabricmanagement.platform.auth.domain.MfaType;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
 import com.fabricmanagement.platform.communication.infra.repository.ContactRepository;
 import com.fabricmanagement.platform.organization.app.OrganizationService;
@@ -51,6 +53,7 @@ public class UserSeeder implements DataSeeder {
   private final PasswordEncoder passwordEncoder;
   private final TransactionTemplate transactionTemplate;
   private final ContactRepository contactRepository;
+  private final IdentityProvisioningService identityProvisioningService;
 
   private static final String DEFAULT_PASSWORD = "password123";
 
@@ -462,10 +465,7 @@ public class UserSeeder implements DataSeeder {
     UserDto user = userCreationService.createInternalUser(req);
     stampDemoSeed(user.getId(), tenantId);
 
-    // 3. Setup Password System ByPass
-    setupAuthUser(user.getId(), tenantId);
-
-    // 4. Mark all auto-assigned contacts as verified to allow login
+    // 3. Mark all auto-assigned contacts as verified to allow login
     contactRepository
         .findByTenantIdAndContactValue(tenantId, profile.email())
         .ifPresent(
@@ -473,6 +473,9 @@ public class UserSeeder implements DataSeeder {
               contact.verify();
               contactRepository.save(contact);
             });
+
+    // 4. Setup Password System ByPass + platform identity dual-write
+    setupAuthUser(user.getId(), tenantId, profile.email());
 
     log.debug(
         "Created user: {} {} — {} ({})",
@@ -493,12 +496,15 @@ public class UserSeeder implements DataSeeder {
     userRepository.save(seededUser);
   }
 
-  private void setupAuthUser(UUID userId, UUID tenantId) {
+  private void setupAuthUser(UUID userId, UUID tenantId, String email) {
     if (!authUserRepository.existsByUserId(userId)) {
-      AuthUser authUser = AuthUser.create(userId, passwordEncoder.encode(DEFAULT_PASSWORD));
+      String passwordHash = passwordEncoder.encode(DEFAULT_PASSWORD);
+      AuthUser authUser = AuthUser.create(userId, passwordHash);
       authUser.setTenantId(tenantId);
       authUser.verify();
       authUserRepository.save(authUser);
+      identityProvisioningService.provisionCredential(
+          email, passwordHash, false, MfaType.NONE, null, true, tenantId, userId);
     }
   }
 

--- a/src/main/java/com/fabricmanagement/platform/auth/app/AuthUserResolutionService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/AuthUserResolutionService.java
@@ -2,7 +2,9 @@ package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.platform.auth.config.AuthProperties;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
+import com.fabricmanagement.platform.auth.infra.repository.LoginIdentityRepository;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthUserResolutionService {
 
   private final AuthUserRepository authUserRepository;
+  private final LoginIdentityRepository loginIdentityRepository;
   private final AuthProperties authProperties;
 
   private int maxAttempts() {
@@ -62,6 +65,23 @@ public class AuthUserResolutionService {
     return AuthValidationResult.valid();
   }
 
+  /** Validate LoginIdentity: verified, active, not locked, and not collision-reset blocked. */
+  public AuthValidationResult validate(LoginIdentity identity) {
+    if (!Boolean.TRUE.equals(identity.getEmailVerified())) {
+      return AuthValidationResult.notVerified();
+    }
+    if (identity.isLocked()) {
+      return AuthValidationResult.locked(identity.getLockedUntil());
+    }
+    if (!Boolean.TRUE.equals(identity.getIsActive())) {
+      return AuthValidationResult.inactive();
+    }
+    if (Boolean.TRUE.equals(identity.getRequiresPasswordReset())) {
+      return AuthValidationResult.passwordResetRequired();
+    }
+    return AuthValidationResult.valid();
+  }
+
   /** Record a failed login attempt; lock account if max attempts reached. */
   @Transactional
   public void recordFailedAttempt(AuthUser authUser) {
@@ -77,11 +97,33 @@ public class AuthUserResolutionService {
     authUserRepository.save(authUser);
   }
 
+  /** Record a failed identity login attempt; lock account if max attempts reached. */
+  @Transactional
+  public void recordFailedAttempt(LoginIdentity identity) {
+    identity.recordFailedLogin(maxAttempts(), lockDurationSeconds());
+
+    if (identity.isLocked()) {
+      log.warn(
+          "LoginIdentity locked: identityId={}, attempts={}, until={}",
+          identity.getId(),
+          identity.getFailedLoginAttempts(),
+          identity.getLockedUntil());
+    }
+    loginIdentityRepository.save(identity);
+  }
+
   /** Reset failed attempts and set last login. */
   @Transactional
   public void resetFailedAttempts(AuthUser authUser) {
     authUser.recordSuccessfulLogin();
     authUserRepository.save(authUser);
+  }
+
+  /** Reset failed identity login attempts after a successful password check. */
+  @Transactional
+  public void resetFailedAttempts(LoginIdentity identity) {
+    identity.recordSuccessfulLogin();
+    loginIdentityRepository.save(identity);
   }
 
   /** Check if user has password (AuthUser exists) by user ID. */

--- a/src/main/java/com/fabricmanagement/platform/auth/app/AuthValidationResult.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/AuthValidationResult.java
@@ -39,4 +39,8 @@ public class AuthValidationResult {
   public static AuthValidationResult inactive() {
     return new AuthValidationResult(false, "Account is deactivated", null);
   }
+
+  public static AuthValidationResult passwordResetRequired() {
+    return new AuthValidationResult(false, "Password reset required", null);
+  }
 }

--- a/src/main/java/com/fabricmanagement/platform/auth/app/IdentityProvisioningService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/IdentityProvisioningService.java
@@ -1,0 +1,183 @@
+package com.fabricmanagement.platform.auth.app;
+
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.domain.MembershipStatus;
+import com.fabricmanagement.platform.auth.domain.MfaType;
+import com.fabricmanagement.platform.auth.infra.repository.LoginIdentityRepository;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Central dual-write service for platform identities and tenant memberships. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class IdentityProvisioningService {
+
+  private final LoginIdentityRepository loginIdentityRepository;
+  private final MembershipRepository membershipRepository;
+
+  @Transactional
+  public LoginIdentity provisionCredential(
+      String email,
+      String passwordHash,
+      boolean mfaEnabled,
+      MfaType mfaType,
+      String mfaSecret,
+      boolean emailVerified,
+      UUID tenantId,
+      UUID userId) {
+    String normalizedEmail = normalizeEmailOrThrow(email);
+
+    LoginIdentity identity;
+    boolean existingIdentity;
+    long membershipCount;
+
+    var existingIdentityOpt = loginIdentityRepository.findByEmail(normalizedEmail);
+    if (existingIdentityOpt.isPresent()) {
+      identity = existingIdentityOpt.get();
+      existingIdentity = true;
+      membershipCount = membershipRepository.countByLoginIdentityId(identity.getId());
+    } else {
+      identity =
+          LoginIdentity.builder()
+              .email(normalizedEmail)
+              .passwordHash(passwordHash)
+              .isMfaEnabled(mfaEnabled)
+              .primaryMfaType(mfaType != null ? mfaType : MfaType.NONE)
+              .mfaSecret(mfaSecret)
+              .isActive(true)
+              .emailVerified(emailVerified)
+              .failedLoginAttempts(0)
+              .requiresPasswordReset(false)
+              .build();
+      identity = loginIdentityRepository.save(identity);
+      existingIdentity = false;
+      membershipCount = 0;
+    }
+
+    var existingMembershipForUser = membershipRepository.findByUserId(userId);
+    if (existingMembershipForUser.isPresent()) {
+      Membership membership = existingMembershipForUser.get();
+      if (!membership.getLoginIdentityId().equals(identity.getId())) {
+        throw new PlatformDomainException(
+            "User is already linked to a different login identity",
+            "AUTH_IDENTITY_MEMBERSHIP_CONFLICT",
+            409);
+      }
+      return identity;
+    }
+
+    if (existingIdentity && membershipCount > 0) {
+      identity.setRequiresPasswordReset(true);
+      identity = loginIdentityRepository.save(identity);
+      log.warn(
+          "LoginIdentity collision for email={} tenantId={} userId={}; password reset required.",
+          normalizedEmail,
+          tenantId,
+          userId);
+    }
+
+    var existingMembershipForTenant =
+        membershipRepository.findByLoginIdentityIdAndTenantId(identity.getId(), tenantId);
+    if (existingMembershipForTenant.isPresent()) {
+      Membership membership = existingMembershipForTenant.get();
+      if (!membership.getUserId().equals(userId)) {
+        throw new PlatformDomainException(
+            "Tenant membership is already linked to a different user",
+            "AUTH_IDENTITY_MEMBERSHIP_CONFLICT",
+            409);
+      }
+      return identity;
+    }
+
+    boolean firstMembership = membershipCount == 0;
+    membershipRepository.save(
+        Membership.builder()
+            .loginIdentityId(identity.getId())
+            .tenantId(tenantId)
+            .userId(userId)
+            .status(MembershipStatus.ACTIVE)
+            .isDefault(firstMembership)
+            .build());
+
+    return identity;
+  }
+
+  @Transactional
+  public void updatePassword(String email, String newPasswordHash) {
+    String normalizedEmail = normalizeEmailOrThrow(email);
+    LoginIdentity identity =
+        loginIdentityRepository
+            .findByEmail(normalizedEmail)
+            .orElseThrow(
+                () ->
+                    new PlatformDomainException(
+                        "Login identity not found", "AUTH_IDENTITY_NOT_FOUND", 404));
+
+    identity.changePassword(newPasswordHash);
+    loginIdentityRepository.save(identity);
+  }
+
+  @Transactional
+  public void updatePasswordForUser(UUID userId, String newPasswordHash) {
+    LoginIdentity identity = findIdentityByUserId(userId);
+    identity.changePassword(newPasswordHash);
+    loginIdentityRepository.save(identity);
+  }
+
+  @Transactional
+  public void updateMfa(String email, boolean mfaEnabled, MfaType mfaType, String mfaSecret) {
+    String normalizedEmail = normalizeEmailOrThrow(email);
+    LoginIdentity identity =
+        loginIdentityRepository
+            .findByEmail(normalizedEmail)
+            .orElseThrow(
+                () ->
+                    new PlatformDomainException(
+                        "Login identity not found", "AUTH_IDENTITY_NOT_FOUND", 404));
+    updateMfa(identity, mfaEnabled, mfaType, mfaSecret);
+  }
+
+  @Transactional
+  public void updateMfaForUser(UUID userId, boolean mfaEnabled, MfaType mfaType, String mfaSecret) {
+    updateMfa(findIdentityByUserId(userId), mfaEnabled, mfaType, mfaSecret);
+  }
+
+  private LoginIdentity findIdentityByUserId(UUID userId) {
+    Membership membership =
+        membershipRepository
+            .findByUserId(userId)
+            .orElseThrow(
+                () ->
+                    new PlatformDomainException(
+                        "Login membership not found", "AUTH_MEMBERSHIP_NOT_FOUND", 404));
+    return loginIdentityRepository
+        .findById(membership.getLoginIdentityId())
+        .orElseThrow(
+            () ->
+                new PlatformDomainException(
+                    "Login identity not found", "AUTH_IDENTITY_NOT_FOUND", 404));
+  }
+
+  private void updateMfa(
+      LoginIdentity identity, boolean mfaEnabled, MfaType mfaType, String mfaSecret) {
+    identity.setIsMfaEnabled(mfaEnabled);
+    identity.setPrimaryMfaType(mfaType != null ? mfaType : MfaType.NONE);
+    identity.setMfaSecret(mfaSecret);
+    loginIdentityRepository.save(identity);
+  }
+
+  private String normalizeEmailOrThrow(String email) {
+    if (email == null || email.isBlank()) {
+      throw new PlatformDomainException("Email is required", "AUTH_EMAIL_REQUIRED", 400);
+    }
+    return email.trim().toLowerCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/app/LoginIdentityBackfillRunner.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/LoginIdentityBackfillRunner.java
@@ -1,0 +1,354 @@
+package com.fabricmanagement.platform.auth.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.auth.domain.MfaType;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Backfills platform login identities and memberships from existing tenant-scoped AuthUser rows.
+ *
+ * <p>CRITICAL: Source tables are RLS-protected. This runner executes entirely through {@link
+ * SystemTransactionExecutor} (fabric_system BYPASSRLS) and uses JDBC only, mirroring the Finance
+ * permission backfill pattern.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LoginIdentityBackfillRunner {
+
+  private static final String SOURCE_ROWS_SQL =
+      """
+      SELECT
+          au.id AS auth_user_id,
+          au.tenant_id,
+          au.user_id,
+          au.password_hash,
+          au.is_mfa_enabled,
+          au.primary_mfa_type,
+          au.mfa_secret,
+          au.is_active,
+          au.is_verified AS email_verified,
+          au.failed_login_attempts,
+          au.locked_until,
+          lower(btrim(email_contact.contact_value)) AS email
+      FROM common_auth.common_auth_user au
+      JOIN common_user.common_user u
+        ON u.id = au.user_id
+       AND u.tenant_id = au.tenant_id
+      LEFT JOIN LATERAL (
+          SELECT c.contact_value
+          FROM common_user.common_user_contact uc
+          JOIN common_communication.common_contact c
+            ON c.id = uc.contact_id
+           AND c.tenant_id = uc.tenant_id
+          WHERE uc.user_id = au.user_id
+            AND uc.tenant_id = au.tenant_id
+            AND c.contact_type = 'EMAIL'
+            AND c.contact_value IS NOT NULL
+            AND btrim(c.contact_value) <> ''
+            AND (uc.is_default = TRUE OR c.is_verified = TRUE)
+          ORDER BY
+            CASE WHEN uc.is_default = TRUE THEN 0 ELSE 1 END,
+            CASE WHEN c.is_verified = TRUE THEN 0 ELSE 1 END,
+            c.created_at ASC,
+            c.id ASC
+          LIMIT 1
+      ) email_contact ON TRUE
+      ORDER BY lower(btrim(email_contact.contact_value)) NULLS LAST, au.created_at ASC, au.id ASC
+      """;
+
+  private static final String FIND_IDENTITY_SQL =
+      """
+      SELECT id, requires_password_reset
+      FROM common_auth.login_identity
+      WHERE email = ?
+      """;
+
+  private static final String INSERT_IDENTITY_SQL =
+      """
+      INSERT INTO common_auth.login_identity (
+          id, email, password_hash, is_mfa_enabled, primary_mfa_type, mfa_secret, is_active,
+          email_verified, failed_login_attempts, locked_until, requires_password_reset, created_at,
+          updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, FALSE, NOW(), NOW())
+      """;
+
+  private static final String MEMBERSHIP_EXISTS_BY_USER_SQL =
+      """
+      SELECT COUNT(*) > 0
+      FROM common_auth.membership
+      WHERE user_id = ?
+      """;
+
+  private static final String INSERT_MEMBERSHIP_SQL =
+      """
+      INSERT INTO common_auth.membership (
+          id, login_identity_id, tenant_id, user_id, status, is_default, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, 'ACTIVE', ?, NOW(), NOW())
+      ON CONFLICT DO NOTHING
+      """;
+
+  private static final String MARK_REQUIRES_PASSWORD_RESET_SQL =
+      """
+      UPDATE common_auth.login_identity
+      SET requires_password_reset = TRUE,
+          updated_at = NOW()
+      WHERE id = ?
+        AND requires_password_reset = FALSE
+      """;
+
+  private final SystemTransactionExecutor systemTransactionExecutor;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void runBackfill() {
+    log.info("Starting LoginIdentityBackfillRunner cross-tenant backfill...");
+
+    try {
+      BackfillStats stats =
+          systemTransactionExecutor.executeInTransaction(
+              jdbcTemplate -> {
+                List<AuthUserIdentitySource> sourceRows =
+                    jdbcTemplate.query(SOURCE_ROWS_SQL, LoginIdentityBackfillRunner::mapSourceRow);
+                return backfillRows(sourceRows, new JdbcIdentityBackfillGateway(jdbcTemplate));
+              });
+
+      log.info(
+          "LoginIdentityBackfillRunner completed. identities={}, memberships={}, collisions={}, "
+              + "existingMemberships={}, missingEmail={}",
+          stats.createdIdentities(),
+          stats.createdMemberships(),
+          stats.collisions(),
+          stats.existingMemberships(),
+          stats.missingEmailSkipped());
+    } catch (Exception e) {
+      log.error("CRITICAL: Failed to execute LoginIdentityBackfillRunner.", e);
+      throw new IllegalStateException(
+          "LoginIdentityBackfillRunner failed during cross-tenant backfill", e);
+    }
+  }
+
+  BackfillStats backfillRows(
+      List<AuthUserIdentitySource> sourceRows, IdentityBackfillGateway gateway) {
+    int createdIdentities = 0;
+    int createdMemberships = 0;
+    int collisions = 0;
+    int existingMemberships = 0;
+    int missingEmailSkipped = 0;
+
+    for (AuthUserIdentitySource source : sourceRows) {
+      String email = normalizeEmail(source.email());
+      if (email == null) {
+        missingEmailSkipped++;
+        log.warn(
+            "Skipping LoginIdentity backfill for authUserId={} userId={} tenantId={} because no "
+                + "default or verified EMAIL contact exists.",
+            source.authUserId(),
+            source.userId(),
+            source.tenantId());
+        continue;
+      }
+
+      if (gateway.membershipExistsByUserId(source.userId())) {
+        existingMemberships++;
+        continue;
+      }
+
+      Optional<IdentityRow> existingIdentity = gateway.findIdentityByEmail(email);
+      UUID identityId;
+      boolean defaultMembership;
+
+      if (existingIdentity.isPresent()) {
+        identityId = existingIdentity.get().id();
+        defaultMembership = false;
+        collisions++;
+        gateway.markRequiresPasswordReset(identityId);
+        log.warn(
+            "LoginIdentity collision for email={} authUserId={} tenantId={} userId={}; adding "
+                + "membership and requiring password reset.",
+            email,
+            source.authUserId(),
+            source.tenantId(),
+            source.userId());
+      } else {
+        identityId = gateway.insertIdentity(source, email);
+        defaultMembership = true;
+        createdIdentities++;
+      }
+
+      if (gateway.insertMembership(identityId, source, defaultMembership)) {
+        createdMemberships++;
+      }
+    }
+
+    return new BackfillStats(
+        createdIdentities,
+        createdMemberships,
+        collisions,
+        existingMemberships,
+        missingEmailSkipped);
+  }
+
+  private static AuthUserIdentitySource mapSourceRow(ResultSet rs, int rowNum) throws SQLException {
+    return new AuthUserIdentitySource(
+        rs.getObject("auth_user_id", UUID.class),
+        rs.getObject("tenant_id", UUID.class),
+        rs.getObject("user_id", UUID.class),
+        rs.getString("email"),
+        rs.getString("password_hash"),
+        rs.getBoolean("is_mfa_enabled"),
+        parseMfaType(rs.getString("primary_mfa_type"), rs.getObject("auth_user_id", UUID.class)),
+        rs.getString("mfa_secret"),
+        rs.getBoolean("is_active"),
+        rs.getBoolean("email_verified"),
+        rs.getInt("failed_login_attempts"),
+        toInstant(rs.getTimestamp("locked_until")));
+  }
+
+  private static Instant toInstant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  private static Timestamp toTimestamp(Instant instant) {
+    return instant == null ? null : Timestamp.from(instant);
+  }
+
+  private static MfaType parseMfaType(String value, UUID authUserId) {
+    if (value == null || value.isBlank()) {
+      return MfaType.NONE;
+    }
+
+    try {
+      return MfaType.valueOf(value);
+    } catch (IllegalArgumentException e) {
+      log.warn(
+          "Unknown primary_mfa_type={} for authUserId={}; defaulting LoginIdentity MFA type to NONE.",
+          value,
+          authUserId);
+      return MfaType.NONE;
+    }
+  }
+
+  private static String normalizeEmail(String email) {
+    if (email == null || email.isBlank()) {
+      return null;
+    }
+    return email.trim().toLowerCase(Locale.ROOT);
+  }
+
+  interface IdentityBackfillGateway {
+    Optional<IdentityRow> findIdentityByEmail(String email);
+
+    UUID insertIdentity(AuthUserIdentitySource source, String email);
+
+    boolean membershipExistsByUserId(UUID userId);
+
+    boolean insertMembership(
+        UUID identityId, AuthUserIdentitySource source, boolean defaultMembership);
+
+    void markRequiresPasswordReset(UUID identityId);
+  }
+
+  record AuthUserIdentitySource(
+      UUID authUserId,
+      UUID tenantId,
+      UUID userId,
+      String email,
+      String passwordHash,
+      boolean mfaEnabled,
+      MfaType primaryMfaType,
+      String mfaSecret,
+      boolean active,
+      boolean emailVerified,
+      int failedLoginAttempts,
+      Instant lockedUntil) {}
+
+  record IdentityRow(UUID id, boolean requiresPasswordReset) {}
+
+  record BackfillStats(
+      int createdIdentities,
+      int createdMemberships,
+      int collisions,
+      int existingMemberships,
+      int missingEmailSkipped) {}
+
+  private static final class JdbcIdentityBackfillGateway implements IdentityBackfillGateway {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    private JdbcIdentityBackfillGateway(JdbcTemplate jdbcTemplate) {
+      this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Optional<IdentityRow> findIdentityByEmail(String email) {
+      return jdbcTemplate
+          .query(
+              FIND_IDENTITY_SQL,
+              (rs, rowNum) ->
+                  new IdentityRow(
+                      rs.getObject("id", UUID.class), rs.getBoolean("requires_password_reset")),
+              email)
+          .stream()
+          .findFirst();
+    }
+
+    @Override
+    public UUID insertIdentity(AuthUserIdentitySource source, String email) {
+      UUID identityId = UUID.randomUUID();
+      jdbcTemplate.update(
+          INSERT_IDENTITY_SQL,
+          identityId,
+          email,
+          source.passwordHash(),
+          source.mfaEnabled(),
+          source.primaryMfaType().name(),
+          source.mfaSecret(),
+          source.active(),
+          source.emailVerified(),
+          source.failedLoginAttempts(),
+          toTimestamp(source.lockedUntil()));
+      return identityId;
+    }
+
+    @Override
+    public boolean membershipExistsByUserId(UUID userId) {
+      Boolean exists =
+          jdbcTemplate.queryForObject(MEMBERSHIP_EXISTS_BY_USER_SQL, Boolean.class, userId);
+      return Boolean.TRUE.equals(exists);
+    }
+
+    @Override
+    public boolean insertMembership(
+        UUID identityId, AuthUserIdentitySource source, boolean defaultMembership) {
+      int rows =
+          jdbcTemplate.update(
+              INSERT_MEMBERSHIP_SQL,
+              UUID.randomUUID(),
+              identityId,
+              source.tenantId(),
+              source.userId(),
+              defaultMembership);
+      return rows > 0;
+    }
+
+    @Override
+    public void markRequiresPasswordReset(UUID identityId) {
+      jdbcTemplate.update(MARK_REQUIRES_PASSWORD_RESET_SQL, identityId);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/app/LoginService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/LoginService.java
@@ -2,9 +2,12 @@ package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
 import com.fabricmanagement.common.util.DeviceInfoUtil;
 import com.fabricmanagement.common.util.PiiMaskingUtil;
-import com.fabricmanagement.platform.auth.domain.AuthUser;
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.domain.MembershipStatus;
 import com.fabricmanagement.platform.auth.domain.MfaType;
 import com.fabricmanagement.platform.auth.domain.RefreshToken;
 import com.fabricmanagement.platform.auth.domain.VerificationType;
@@ -12,7 +15,8 @@ import com.fabricmanagement.platform.auth.domain.event.UserLoginEvent;
 import com.fabricmanagement.platform.auth.dto.LoginRequest;
 import com.fabricmanagement.platform.auth.dto.LoginResponse;
 import com.fabricmanagement.platform.auth.dto.VerifyMfaRequest;
-import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
+import com.fabricmanagement.platform.auth.infra.repository.LoginIdentityRepository;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
 import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
 import com.fabricmanagement.platform.common.exception.PlatformDomainException;
 import com.fabricmanagement.platform.communication.app.ContactService;
@@ -22,11 +26,15 @@ import com.fabricmanagement.platform.user.api.facade.UserFacade;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
 import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -48,8 +56,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class LoginService {
 
-  private final AuthUserRepository authUserRepository;
   private final AuthUserResolutionService resolutionService;
+  private final LoginIdentityRepository loginIdentityRepository;
+  private final MembershipRepository membershipRepository;
   private final RefreshTokenRepository refreshTokenRepository;
   private final UserFacade userFacade;
   private final UserRepository userRepository;
@@ -63,6 +72,7 @@ public class LoginService {
   private final TrustedDeviceService trustedDeviceService;
   private final MfaRateLimitService mfaRateLimitService;
   private final MfaEventService mfaEventService;
+  private final TenantSessionBinder tenantSessionBinder;
 
   @Value("${application.jwt.expiration:900000}")
   private long accessTokenExpiration;
@@ -79,167 +89,150 @@ public class LoginService {
       log.debug("Login attempt (unmasked): contactValue={}", request.getContactValue());
     }
 
-    // ✅ Find AuthUser by contact value (user-based authentication)
-    Optional<AuthUser> authUserOpt = resolutionService.resolveByContact(request.getContactValue());
+    String normalizedEmail = normalizeEmail(request.getContactValue());
+    Optional<LoginIdentity> identityOpt = loginIdentityRepository.findByEmail(normalizedEmail);
 
-    // ✅ If AuthUser doesn't exist, check if contact belongs to user with password
-    if (authUserOpt.isEmpty()) {
-      log.debug(
-          "AuthUser not found for contactValue={}, checking if user exists",
-          PiiMaskingUtil.maskEmail(request.getContactValue()));
-
-      Optional<UserDto> userOpt = userFacade.findByContactValue(request.getContactValue());
-      if (userOpt.isPresent()) {
-        UserDto user = userOpt.get();
-        log.debug(
-            "User found: userId={}, tenantId={}, checking for password",
-            user.getId(),
-            user.getTenantId());
-
-        // ✅ Check if user has AuthUser (password exists) - simple user-based check
-        boolean userHasPassword = resolutionService.existsByUserId(user.getId());
-
-        log.debug("User has password: {}", userHasPassword);
-
-        if (userHasPassword) {
-          // User has password but this contact is not verified
-          TenantContext.executeInTenantContext(
-              user.getTenantId(), () -> checkUnverifiedContact(request.getContactValue()));
-        }
-      }
-
-      // Contact doesn't exist or user doesn't have password
+    if (identityOpt.isEmpty()) {
       log.warn(
-          "Login failed: User not found or has no password. contactValue={}",
+          "Login failed: LoginIdentity not found. contactValue={}",
           PiiMaskingUtil.maskEmail(request.getContactValue()));
       throw createContextAwareNotFoundException(request.getContactValue());
     }
 
-    AuthUser authUser = authUserOpt.get();
+    LoginIdentity identity = identityOpt.get();
 
-    AuthValidationResult validation = resolutionService.validate(authUser);
+    AuthValidationResult validation = resolutionService.validate(identity);
     if (!validation.isValid()) {
       log.warn(
           "Auth validation failed: contactValue={}, reason={}",
           PiiMaskingUtil.maskEmail(request.getContactValue()),
           validation.getReason());
+      if (Boolean.TRUE.equals(identity.getRequiresPasswordReset())) {
+        throw new PlatformDomainException(
+            "Password reset required", "AUTH_PASSWORD_RESET_REQUIRED", 409);
+      }
       throw new PlatformDomainException(
           validation.getReason(), "AUTH_LOGIN_VALIDATION_FAILED", 400);
     }
 
-    if (!passwordEncoder.matches(request.getPassword(), authUser.getPasswordHash())) {
-      resolutionService.recordFailedAttempt(authUser);
+    if (!passwordEncoder.matches(request.getPassword(), identity.getPasswordHash())) {
+      resolutionService.recordFailedAttempt(identity);
       log.warn(
           "Invalid password: contactValue={}, attempts={}",
           PiiMaskingUtil.maskEmail(request.getContactValue()),
-          authUser.getFailedLoginAttempts());
+          identity.getFailedLoginAttempts());
       throw new PlatformDomainException("Invalid credentials", "AUTH_INVALID_CREDENTIALS", 401);
     }
 
-    resolutionService.resetFailedAttempts(authUser);
+    resolutionService.resetFailedAttempts(identity);
 
-    // ✅ Get User from AuthUser (user-based authentication)
-    // AuthUser.user is already loaded via LEFT JOIN FETCH in repository query
-    UUID userId = authUser.getUserId();
-    UserDto user =
-        userFacade
-            .findById(authUser.getTenantId(), userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    Membership membership = selectLoginMembership(identity);
+    UUID tenantId = membership.getTenantId();
+    UUID userId = membership.getUserId();
 
-    if (!user.getIsActive()) {
-      throw new PlatformDomainException(
-          "User account is deactivated", "AUTH_USER_DEACTIVATED", 403);
-    }
+    TenantContext.setCurrentTenantId(tenantId);
+    tenantSessionBinder.bindToCurrentSession(tenantId);
 
-    // Get User entity with contacts/departments loaded for JWT generation
-    com.fabricmanagement.platform.user.domain.User userEntity =
-        userRepository
-            .findByTenantIdAndId(user.getTenantId(), user.getId())
-            .orElseThrow(() -> new IllegalArgumentException("User entity not found"));
+    try {
+      UserDto user = userFacade.findById(tenantId, userId).orElseThrow();
 
-    // Check if MFA is enabled and handle it
-    boolean bypassMfa = false;
-
-    // Check trusted device token with full context binding (IP + User-Agent)
-    if (request.getTrustedDeviceToken() != null && !request.getTrustedDeviceToken().isBlank()) {
-      bypassMfa =
-          trustedDeviceService.validateDevice(
-              request.getTrustedDeviceToken(), user.getId(), ipAddress, userAgent);
-      if (bypassMfa) {
-        log.info(
-            "MFA bypassed due to valid trusted device token for user: {}",
-            PiiMaskingUtil.maskEmail(request.getContactValue()));
-      } else {
-        log.warn(
-            "Invalid or expired trusted device token for user: {}",
-            PiiMaskingUtil.maskEmail(request.getContactValue()));
+      if (!user.getIsActive()) {
+        throw new PlatformDomainException(
+            "User account is deactivated", "AUTH_USER_DEACTIVATED", 403);
       }
-    }
 
-    if (!bypassMfa && Boolean.TRUE.equals(authUser.getIsMfaEnabled())) {
-      MfaType mfaType =
-          authUser.getPrimaryMfaType() != null ? authUser.getPrimaryMfaType() : MfaType.NONE;
+      // Get User entity with contacts/departments loaded for JWT generation
+      com.fabricmanagement.platform.user.domain.User userEntity =
+          userRepository
+              .findByTenantIdAndId(tenantId, userId)
+              .orElseThrow(() -> new IllegalArgumentException("User entity not found"));
 
-      if (mfaType != MfaType.NONE) {
-        String preAuthToken = jwtService.generatePreAuthToken(userEntity);
+      // Check if MFA is enabled and handle it
+      boolean bypassMfa = false;
 
-        String maskedContact = null;
-        if (mfaType == MfaType.EMAIL || mfaType == MfaType.SMS || mfaType == MfaType.WHATSAPP) {
-          VerificationCodeManager.MfaCodeIssuanceResult mfaResult =
-              verificationCodeManager.issueMfaCode(user.getId(), user.getTenantId(), mfaType);
-          maskedContact = mfaResult.maskedContact();
+      // Check trusted device token with full context binding (IP + User-Agent)
+      if (request.getTrustedDeviceToken() != null && !request.getTrustedDeviceToken().isBlank()) {
+        bypassMfa =
+            trustedDeviceService.validateDevice(
+                request.getTrustedDeviceToken(), user.getId(), ipAddress, userAgent);
+        if (bypassMfa) {
+          log.info(
+              "MFA bypassed due to valid trusted device token for user: {}",
+              PiiMaskingUtil.maskEmail(request.getContactValue()));
+        } else {
+          log.warn(
+              "Invalid or expired trusted device token for user: {}",
+              PiiMaskingUtil.maskEmail(request.getContactValue()));
         }
-
-        log.info(
-            "MFA required for user: {}, mfaType={}",
-            PiiMaskingUtil.maskEmail(request.getContactValue()),
-            mfaType);
-        return LoginResponse.builder()
-            .mfaRequired(true)
-            .mfaToken(preAuthToken)
-            .mfaType(mfaType)
-            .maskedContact(maskedContact)
-            .build();
       }
+
+      if (!bypassMfa && Boolean.TRUE.equals(identity.getIsMfaEnabled())) {
+        MfaType mfaType =
+            identity.getPrimaryMfaType() != null ? identity.getPrimaryMfaType() : MfaType.NONE;
+
+        if (mfaType != MfaType.NONE) {
+          String preAuthToken = jwtService.generatePreAuthToken(userEntity);
+
+          String maskedContact = null;
+          if (mfaType == MfaType.EMAIL || mfaType == MfaType.SMS || mfaType == MfaType.WHATSAPP) {
+            VerificationCodeManager.MfaCodeIssuanceResult mfaResult =
+                verificationCodeManager.issueMfaCode(user.getId(), user.getTenantId(), mfaType);
+            maskedContact = mfaResult.maskedContact();
+          }
+
+          log.info(
+              "MFA required for user: {}, mfaType={}",
+              PiiMaskingUtil.maskEmail(request.getContactValue()),
+              mfaType);
+          return LoginResponse.builder()
+              .mfaRequired(true)
+              .mfaToken(preAuthToken)
+              .mfaType(mfaType)
+              .maskedContact(maskedContact)
+              .build();
+        }
+      }
+
+      String accessToken = jwtService.generateAccessToken(userEntity);
+      String refreshToken = jwtService.generateRefreshToken(userEntity);
+
+      RefreshToken refreshTokenEntity =
+          RefreshToken.create(
+              user.getId(),
+              refreshToken,
+              Instant.now().plusMillis(refreshTokenExpiration),
+              ipAddress,
+              userAgent,
+              DeviceInfoUtil.extractDeviceName(userAgent));
+      TenantContext.executeInTenantContext(
+          user.getTenantId(), () -> refreshTokenRepository.save(refreshTokenEntity));
+
+      // Get contact value from Contact entity
+      String contactValue =
+          userEntity
+              .getAnyVerifiedContact()
+              .map(contact -> contact.getContactValue())
+              .orElse(request.getContactValue());
+
+      eventPublisher.publish(
+          new UserLoginEvent(user.getTenantId(), user.getId(), contactValue, ipAddress));
+
+      log.info(
+          "Login successful: contactValue={}, userId={}, uid={}",
+          PiiMaskingUtil.maskEmail(request.getContactValue()),
+          user.getId(),
+          user.getUid());
+
+      return LoginResponse.builder()
+          .accessToken(accessToken)
+          .refreshToken(refreshToken)
+          .expiresIn(accessTokenExpiration / 1000)
+          .user(user)
+          .needsOnboarding(!Boolean.TRUE.equals(user.getHasCompletedOnboarding()))
+          .build();
+    } finally {
+      TenantContext.clear();
     }
-
-    String accessToken = jwtService.generateAccessToken(userEntity);
-    String refreshToken = jwtService.generateRefreshToken(userEntity);
-
-    RefreshToken refreshTokenEntity =
-        RefreshToken.create(
-            user.getId(),
-            refreshToken,
-            Instant.now().plusMillis(refreshTokenExpiration),
-            ipAddress,
-            userAgent,
-            DeviceInfoUtil.extractDeviceName(userAgent));
-    TenantContext.executeInTenantContext(
-        user.getTenantId(), () -> refreshTokenRepository.save(refreshTokenEntity));
-
-    // Get contact value from Contact entity
-    String contactValue =
-        userEntity
-            .getAnyVerifiedContact()
-            .map(contact -> contact.getContactValue())
-            .orElse(request.getContactValue());
-
-    eventPublisher.publish(
-        new UserLoginEvent(user.getTenantId(), user.getId(), contactValue, ipAddress));
-
-    log.info(
-        "Login successful: contactValue={}, userId={}, uid={}",
-        PiiMaskingUtil.maskEmail(request.getContactValue()),
-        user.getId(),
-        user.getUid());
-
-    return LoginResponse.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .expiresIn(accessTokenExpiration / 1000)
-        .user(user)
-        .needsOnboarding(!Boolean.TRUE.equals(user.getHasCompletedOnboarding()))
-        .build();
   }
 
   @Transactional
@@ -260,76 +253,125 @@ public class LoginService {
     // Brute-force protection: reject if user exceeded max failed MFA attempts
     mfaRateLimitService.checkRateLimit(userId);
 
-    AuthUser authUser =
-        authUserRepository
-            .findByTenantIdAndUserId(tenantId, userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
+    Membership membership =
+        membershipRepository
+            .findByUserId(userId)
+            .filter(
+                m -> m.getTenantId().equals(tenantId) && m.getStatus() == MembershipStatus.ACTIVE)
+            .orElseThrow(() -> new IllegalArgumentException("Login membership not found"));
+    LoginIdentity identity =
+        loginIdentityRepository
+            .findById(membership.getLoginIdentityId())
+            .orElseThrow(() -> new IllegalArgumentException("Login identity not found"));
 
-    com.fabricmanagement.platform.user.domain.User userEntity =
-        userRepository
-            .findByTenantIdAndId(tenantId, userId)
-            .orElseThrow(() -> new IllegalArgumentException("User entity not found"));
-
-    MfaType mfaType = authUser.getPrimaryMfaType();
+    TenantContext.setCurrentTenantId(tenantId);
+    tenantSessionBinder.bindToCurrentSession(tenantId);
 
     try {
-      if (mfaType == MfaType.TOTP) {
-        boolean isValid = totpMfaService.verifyCode(authUser.getMfaSecret(), request.getCode());
-        if (!isValid) {
-          throw new PlatformDomainException("Invalid TOTP code", "AUTH_MFA_INVALID_CODE", 400);
+      com.fabricmanagement.platform.user.domain.User userEntity =
+          userRepository
+              .findByTenantIdAndId(tenantId, userId)
+              .orElseThrow(() -> new IllegalArgumentException("User entity not found"));
+
+      MfaType mfaType = identity.getPrimaryMfaType();
+
+      try {
+        if (mfaType == MfaType.TOTP) {
+          boolean isValid = totpMfaService.verifyCode(identity.getMfaSecret(), request.getCode());
+          if (!isValid) {
+            throw new PlatformDomainException("Invalid TOTP code", "AUTH_MFA_INVALID_CODE", 400);
+          }
+        } else if (mfaType == MfaType.EMAIL
+            || mfaType == MfaType.SMS
+            || mfaType == MfaType.WHATSAPP) {
+          verificationCodeManager.validateMfaCode(userId, tenantId, mfaType, request.getCode());
+        } else {
+          throw new PlatformDomainException(
+              "MFA is not enabled or type is invalid", "AUTH_MFA_NOT_ENABLED", 400);
         }
-      } else if (mfaType == MfaType.EMAIL
-          || mfaType == MfaType.SMS
-          || mfaType == MfaType.WHATSAPP) {
-        verificationCodeManager.validateMfaCode(userId, tenantId, mfaType, request.getCode());
-      } else {
-        throw new PlatformDomainException(
-            "MFA is not enabled or type is invalid", "AUTH_MFA_NOT_ENABLED", 400);
+      } catch (IllegalArgumentException e) {
+        mfaRateLimitService.recordFailedAttempt(userId);
+        throw e;
       }
-    } catch (IllegalArgumentException e) {
-      mfaRateLimitService.recordFailedAttempt(userId);
-      throw e;
+
+      mfaRateLimitService.clearAttempts(userId);
+      mfaEventService.pushCompletionEvent(userId);
+
+      // Success! Generate actual tokens
+      String accessToken = jwtService.generateAccessToken(userEntity);
+      String refreshToken = jwtService.generateRefreshToken(userEntity);
+
+      RefreshToken refreshTokenEntity =
+          RefreshToken.create(
+              userId,
+              refreshToken,
+              Instant.now().plusMillis(refreshTokenExpiration),
+              ipAddress,
+              userAgent,
+              DeviceInfoUtil.extractDeviceName(userAgent));
+      TenantContext.executeInTenantContext(
+          tenantId, () -> refreshTokenRepository.save(refreshTokenEntity));
+
+      String newTrustedDeviceToken = null;
+      if (Boolean.TRUE.equals(request.getRememberDevice())) {
+        newTrustedDeviceToken =
+            trustedDeviceService.createTrustedDevice(userId, ipAddress, userAgent);
+      }
+
+      UserDto userDto = userFacade.findById(tenantId, userId).orElseThrow();
+
+      String contactValue = jwtService.getContactValueFromToken(request.getMfaToken());
+
+      eventPublisher.publish(new UserLoginEvent(tenantId, userId, contactValue, ipAddress));
+
+      return LoginResponse.builder()
+          .accessToken(accessToken)
+          .refreshToken(refreshToken)
+          .expiresIn(accessTokenExpiration / 1000)
+          .user(userDto)
+          .mfaRequired(false)
+          .trustedDeviceToken(newTrustedDeviceToken)
+          .needsOnboarding(!Boolean.TRUE.equals(userDto.getHasCompletedOnboarding()))
+          .build();
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  private Membership selectLoginMembership(LoginIdentity identity) {
+    List<Membership> activeMemberships =
+        membershipRepository.findByLoginIdentityIdAndStatus(
+            identity.getId(), MembershipStatus.ACTIVE);
+
+    if (activeMemberships.isEmpty()) {
+      throw new PlatformDomainException(
+          "No active organization membership found", "AUTH_NO_ACTIVE_MEMBERSHIP", 403);
     }
 
-    mfaRateLimitService.clearAttempts(userId);
-    mfaEventService.pushCompletionEvent(userId);
-
-    // Success! Generate actual tokens
-    String accessToken = jwtService.generateAccessToken(userEntity);
-    String refreshToken = jwtService.generateRefreshToken(userEntity);
-
-    RefreshToken refreshTokenEntity =
-        RefreshToken.create(
-            userId,
-            refreshToken,
-            Instant.now().plusMillis(refreshTokenExpiration),
-            ipAddress,
-            userAgent,
-            DeviceInfoUtil.extractDeviceName(userAgent));
-    TenantContext.executeInTenantContext(
-        tenantId, () -> refreshTokenRepository.save(refreshTokenEntity));
-
-    String newTrustedDeviceToken = null;
-    if (Boolean.TRUE.equals(request.getRememberDevice())) {
-      newTrustedDeviceToken =
-          trustedDeviceService.createTrustedDevice(userId, ipAddress, userAgent);
+    if (activeMemberships.size() == 1) {
+      return activeMemberships.getFirst();
     }
 
-    UserDto userDto = userFacade.findById(tenantId, userId).orElseThrow();
+    return activeMemberships.stream()
+        .filter(membership -> Boolean.TRUE.equals(membership.getIsDefault()))
+        .min(
+            Comparator.comparing(
+                Membership::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+        .orElseGet(
+            () -> {
+              log.warn(
+                  "LoginIdentity {} has {} active memberships but no default; using first membership.",
+                  identity.getId(),
+                  activeMemberships.size());
+              return activeMemberships.getFirst();
+            });
+  }
 
-    String contactValue = jwtService.getContactValueFromToken(request.getMfaToken());
-
-    eventPublisher.publish(new UserLoginEvent(tenantId, userId, contactValue, ipAddress));
-
-    return LoginResponse.builder()
-        .accessToken(accessToken)
-        .refreshToken(refreshToken)
-        .expiresIn(accessTokenExpiration / 1000)
-        .user(userDto)
-        .mfaRequired(false)
-        .trustedDeviceToken(newTrustedDeviceToken)
-        .needsOnboarding(!Boolean.TRUE.equals(userDto.getHasCompletedOnboarding()))
-        .build();
+  private String normalizeEmail(String contactValue) {
+    if (contactValue == null || contactValue.isBlank()) {
+      throw new PlatformDomainException("Invalid credentials", "AUTH_INVALID_CREDENTIALS", 401);
+    }
+    return contactValue.trim().toLowerCase(Locale.ROOT);
   }
 
   /**
@@ -424,7 +466,14 @@ public class LoginService {
     String normalizedDomain = domain.trim().toLowerCase();
     log.trace("Finding any user with domain: {}", normalizedDomain);
 
-    return userRepository.findAnyByEmailDomain(normalizedDomain).map(UserDto::from);
+    try {
+      return userRepository.findAnyByEmailDomain(normalizedDomain).map(UserDto::from);
+    } catch (IncorrectResultSizeDataAccessException ex) {
+      log.warn(
+          "Multiple users found for email domain {}; skipping context-aware login guidance.",
+          normalizedDomain);
+      return Optional.empty();
+    }
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/platform/auth/app/MfaSetupService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/MfaSetupService.java
@@ -31,6 +31,7 @@ public class MfaSetupService {
   private final TotpMfaService totpMfaService;
   private final UserRepository userRepository;
   private final LocalizationService localizationService;
+  private final IdentityProvisioningService identityProvisioningService;
 
   /**
    * Initiate MFA setup for user.
@@ -93,6 +94,8 @@ public class MfaSetupService {
     authUser.setIsMfaEnabled(false);
 
     authUserRepository.save(authUser);
+    identityProvisioningService.updateMfaForUser(
+        authUser.getUserId(), false, authUser.getPrimaryMfaType(), authUser.getMfaSecret());
 
     log.info("TOTP MFA setup initiated for user: {}", authUser.getUserId());
 
@@ -117,6 +120,8 @@ public class MfaSetupService {
     authUser.setMfaSecret(null);
 
     authUserRepository.save(authUser);
+    identityProvisioningService.updateMfaForUser(
+        authUser.getUserId(), false, authUser.getPrimaryMfaType(), authUser.getMfaSecret());
 
     log.info("{} MFA setup initiated for user: {}", mfaType, authUser.getUserId());
 
@@ -167,6 +172,8 @@ public class MfaSetupService {
 
     authUser.setIsMfaEnabled(true);
     authUserRepository.save(authUser);
+    identityProvisioningService.updateMfaForUser(
+        authUser.getUserId(), true, authUser.getPrimaryMfaType(), authUser.getMfaSecret());
 
     log.info("✅ MFA enabled for user: {}, type={}", userId, authUser.getPrimaryMfaType());
   }
@@ -192,6 +199,8 @@ public class MfaSetupService {
     authUser.setMfaSecret(null);
 
     authUserRepository.save(authUser);
+    identityProvisioningService.updateMfaForUser(
+        authUser.getUserId(), false, authUser.getPrimaryMfaType(), authUser.getMfaSecret());
 
     trustedDeviceRepository.deleteByUserId(userId);
 

--- a/src/main/java/com/fabricmanagement/platform/auth/app/PasswordResetService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/PasswordResetService.java
@@ -77,6 +77,7 @@ public class PasswordResetService {
   private final PasswordEncoder passwordEncoder;
   private final JwtService jwtService;
   private final DomainEventPublisher eventPublisher;
+  private final IdentityProvisioningService identityProvisioningService;
 
   @Value("${application.jwt.expiration:900000}")
   private long accessTokenExpiration;
@@ -316,6 +317,7 @@ public class PasswordResetService {
     authUser.unlock();
 
     authUserRepository.save(authUser);
+    identityProvisioningService.updatePasswordForUser(userId, newPasswordHash);
 
     // ✅ Get User DTO (user-based authentication)
     UserDto user =

--- a/src/main/java/com/fabricmanagement/platform/auth/app/PasswordSetupService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/PasswordSetupService.java
@@ -81,6 +81,7 @@ public class PasswordSetupService {
   private final EmployeeProjectionPort employeeProjectionPort;
   private final TrialLifecyclePort trialLifecyclePort;
   private final TenantSessionBinder tenantSessionBinder;
+  private final IdentityProvisioningService identityProvisioningService;
 
   @Value("${application.jwt.refresh-expiration:604800000}")
   private long refreshTokenExpiration;
@@ -196,6 +197,16 @@ public class PasswordSetupService {
 
     authUserRepository.save(authUser);
     log.info("✅ Password setup: Created AuthUser for user: userId={}", user.getId());
+
+    identityProvisioningService.provisionCredential(
+        token.getContactValue(),
+        passwordHash,
+        Boolean.TRUE.equals(authUser.getIsMfaEnabled()),
+        authUser.getPrimaryMfaType(),
+        authUser.getMfaSecret(),
+        true,
+        user.getTenantId(),
+        user.getId());
 
     token.markAsUsed();
     tokenRepository.save(token);

--- a/src/main/java/com/fabricmanagement/platform/auth/app/RegistrationService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/RegistrationService.java
@@ -74,6 +74,7 @@ public class RegistrationService {
   private final TenantQueryPort tenantQueryPort;
   private final VerificationCodeManager verificationCodeManager;
   private final OrganizationRepository organizationRepository;
+  private final IdentityProvisioningService identityProvisioningService;
 
   // VerificationService no longer injected - VerificationCodeManager.issueCode sends via dispatcher
 
@@ -162,6 +163,15 @@ public class RegistrationService {
     authUser.setTenantId(user.getTenantId());
     authUser.verify();
     authUserRepository.save(authUser);
+    identityProvisioningService.provisionCredential(
+        contact.getContactValue(),
+        passwordHash,
+        Boolean.TRUE.equals(authUser.getIsMfaEnabled()),
+        authUser.getPrimaryMfaType(),
+        authUser.getMfaSecret(),
+        true,
+        user.getTenantId(),
+        user.getId());
 
     com.fabricmanagement.platform.user.domain.User userEntity =
         userRepository

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/LoginIdentity.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/LoginIdentity.java
@@ -1,0 +1,90 @@
+package com.fabricmanagement.platform.auth.domain;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Platform-level authentication principal.
+ *
+ * <p>This entity deliberately does not extend BaseEntity: it has no tenant_id, is not tenant
+ * scoped, and must remain usable before a tenant context exists.
+ */
+@Entity
+@Table(
+    name = "login_identity",
+    schema = "common_auth",
+    indexes = {@Index(name = "idx_login_identity_email", columnList = "email")},
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_login_identity_email",
+          columnNames = {"email"})
+    })
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginIdentity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "id", updatable = false, nullable = false)
+  private UUID id;
+
+  @Column(name = "email", nullable = false, length = 255)
+  private String email;
+
+  @Column(name = "password_hash", nullable = false, length = 255)
+  private String passwordHash;
+
+  @Column(name = "is_mfa_enabled", nullable = false)
+  @Builder.Default
+  private Boolean isMfaEnabled = false;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "primary_mfa_type", nullable = false, length = 30)
+  @Builder.Default
+  private MfaType primaryMfaType = MfaType.NONE;
+
+  @Column(name = "mfa_secret", length = 64)
+  private String mfaSecret;
+
+  @Column(name = "is_active", nullable = false)
+  @Builder.Default
+  private Boolean isActive = true;
+
+  @Column(name = "email_verified", nullable = false)
+  @Builder.Default
+  private Boolean emailVerified = false;
+
+  @Column(name = "failed_login_attempts", nullable = false)
+  @Builder.Default
+  private Integer failedLoginAttempts = 0;
+
+  @Column(name = "locked_until")
+  private Instant lockedUntil;
+
+  @Column(name = "requires_password_reset", nullable = false)
+  @Builder.Default
+  private Boolean requiresPasswordReset = false;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+
+  @PrePersist
+  @PreUpdate
+  void normalizeEmail() {
+    if (email != null) {
+      email = email.trim().toLowerCase(java.util.Locale.ROOT);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/LoginIdentity.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/LoginIdentity.java
@@ -87,4 +87,27 @@ public class LoginIdentity {
       email = email.trim().toLowerCase(java.util.Locale.ROOT);
     }
   }
+
+  public boolean isLocked() {
+    return lockedUntil != null && lockedUntil.isAfter(Instant.now());
+  }
+
+  public void recordFailedLogin(int maxAttempts, int lockDurationSeconds) {
+    this.failedLoginAttempts =
+        (this.failedLoginAttempts != null ? this.failedLoginAttempts : 0) + 1;
+    if (this.failedLoginAttempts >= maxAttempts) {
+      this.lockedUntil = Instant.now().plusSeconds(lockDurationSeconds);
+    }
+  }
+
+  public void recordSuccessfulLogin() {
+    this.failedLoginAttempts = 0;
+    this.lockedUntil = null;
+  }
+
+  public void changePassword(String newPasswordHash) {
+    this.passwordHash = newPasswordHash;
+    this.requiresPasswordReset = false;
+    recordSuccessfulLogin();
+  }
 }

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/Membership.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/Membership.java
@@ -1,0 +1,73 @@
+package com.fabricmanagement.platform.auth.domain;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Platform-level link from one login identity to one tenant user.
+ *
+ * <p>This entity deliberately does not extend BaseEntity. Its tenant_id is a plain FK used for
+ * membership selection during pre-auth login, not an RLS isolation column.
+ */
+@Entity
+@Table(
+    name = "membership",
+    schema = "common_auth",
+    indexes = {
+      @Index(name = "idx_membership_login_identity", columnList = "login_identity_id"),
+      @Index(name = "idx_membership_tenant", columnList = "tenant_id")
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_membership_identity_tenant",
+          columnNames = {"login_identity_id", "tenant_id"}),
+      @UniqueConstraint(
+          name = "uk_membership_user",
+          columnNames = {"user_id"})
+    })
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Membership {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.UUID)
+  @Column(name = "id", updatable = false, nullable = false)
+  private UUID id;
+
+  @Column(name = "login_identity_id", nullable = false)
+  private UUID loginIdentityId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "login_identity_id", insertable = false, updatable = false)
+  private LoginIdentity loginIdentity;
+
+  @Column(name = "tenant_id", nullable = false)
+  private UUID tenantId;
+
+  @Column(name = "user_id", nullable = false)
+  private UUID userId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  @Builder.Default
+  private MembershipStatus status = MembershipStatus.ACTIVE;
+
+  @Column(name = "is_default", nullable = false)
+  @Builder.Default
+  private Boolean isDefault = false;
+
+  @CreationTimestamp
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @UpdateTimestamp
+  @Column(name = "updated_at", nullable = false)
+  private Instant updatedAt;
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/MembershipStatus.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/MembershipStatus.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.platform.auth.domain;
+
+public enum MembershipStatus {
+  ACTIVE,
+  SUSPENDED
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/infra/repository/LoginIdentityRepository.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/infra/repository/LoginIdentityRepository.java
@@ -1,0 +1,15 @@
+package com.fabricmanagement.platform.auth.infra.repository;
+
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LoginIdentityRepository extends JpaRepository<LoginIdentity, UUID> {
+
+  Optional<LoginIdentity> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/infra/repository/MembershipRepository.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/infra/repository/MembershipRepository.java
@@ -1,0 +1,16 @@
+package com.fabricmanagement.platform.auth.infra.repository;
+
+import com.fabricmanagement.platform.auth.domain.Membership;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MembershipRepository extends JpaRepository<Membership, UUID> {
+
+  List<Membership> findByLoginIdentityId(UUID loginIdentityId);
+
+  Optional<Membership> findByUserId(UUID userId);
+}

--- a/src/main/java/com/fabricmanagement/platform/auth/infra/repository/MembershipRepository.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/infra/repository/MembershipRepository.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.platform.auth.infra.repository;
 
 import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.domain.MembershipStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -12,5 +13,11 @@ public interface MembershipRepository extends JpaRepository<Membership, UUID> {
 
   List<Membership> findByLoginIdentityId(UUID loginIdentityId);
 
+  List<Membership> findByLoginIdentityIdAndStatus(UUID loginIdentityId, MembershipStatus status);
+
   Optional<Membership> findByUserId(UUID userId);
+
+  Optional<Membership> findByLoginIdentityIdAndTenantId(UUID loginIdentityId, UUID tenantId);
+
+  long countByLoginIdentityId(UUID loginIdentityId);
 }

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
@@ -439,6 +439,11 @@ public class TenantClonerService {
                   },
                   templateTenantId);
 
+              // Do not clone common_auth_user/login_identity/membership here. Playground access
+              // currently uses impersonation, and provisioning cloned users with the same emails
+              // would intentionally merge into the global LoginIdentity rows until org-picker and
+              // identity lifecycle rules are implemented.
+
               // 4. Clone Reference Data Tables (No internal hierarchical dependencies)
 
               // 5. PRODUCTION MASTERDATA

--- a/src/main/resources/db/migration/V20260701130000__platform_login_identity_membership.sql
+++ b/src/main/resources/db/migration/V20260701130000__platform_login_identity_membership.sql
@@ -1,0 +1,77 @@
+-- IDENTITY-1: platform-level login identity and tenant memberships.
+--
+-- RLS-ALL EXEMPTION:
+-- Authentication is pre-auth and cross-tenant. At login there is no selected tenant context, so
+-- login_identity must not carry tenant_id and membership.tenant_id is a plain FK used to choose a
+-- tenant after the identity is authenticated. Both tables are deliberately RLS-exempt and must be
+-- excluded from future RLS-all sweeps.
+
+CREATE TABLE IF NOT EXISTS common_auth.login_identity (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) NOT NULL,
+    password_hash VARCHAR(255) NOT NULL,
+    is_mfa_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    primary_mfa_type VARCHAR(30) NOT NULL DEFAULT 'NONE',
+    mfa_secret VARCHAR(64),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    email_verified BOOLEAN NOT NULL DEFAULT FALSE,
+    failed_login_attempts INTEGER NOT NULL DEFAULT 0,
+    locked_until TIMESTAMPTZ,
+    requires_password_reset BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT uk_login_identity_email UNIQUE (email),
+    CONSTRAINT chk_login_identity_email_lowercase CHECK (email = lower(btrim(email)) AND btrim(email) <> ''),
+    CONSTRAINT chk_login_identity_mfa_type CHECK (primary_mfa_type IN ('NONE', 'TOTP', 'EMAIL', 'SMS', 'WHATSAPP'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_login_identity_email ON common_auth.login_identity(email);
+
+COMMENT ON TABLE common_auth.login_identity IS
+    'RLS-all exempt platform authentication principal. No tenant_id and no RLS because login is pre-auth/cross-tenant; exclude from future RLS-all sweeps.';
+COMMENT ON COLUMN common_auth.login_identity.email IS
+    'Global lowercase email login handle.';
+
+CREATE TABLE IF NOT EXISTS common_auth.membership (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    login_identity_id UUID NOT NULL,
+    tenant_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE',
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_membership_login_identity FOREIGN KEY (login_identity_id)
+        REFERENCES common_auth.login_identity(id) ON DELETE CASCADE,
+    CONSTRAINT fk_membership_tenant FOREIGN KEY (tenant_id)
+        REFERENCES common_tenant.common_tenant(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_membership_user FOREIGN KEY (user_id)
+        REFERENCES common_user.common_user(id) ON DELETE CASCADE,
+    CONSTRAINT uk_membership_identity_tenant UNIQUE (login_identity_id, tenant_id),
+    CONSTRAINT uk_membership_user UNIQUE (user_id),
+    CONSTRAINT chk_membership_status CHECK (status IN ('ACTIVE', 'SUSPENDED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_membership_login_identity ON common_auth.membership(login_identity_id);
+CREATE INDEX IF NOT EXISTS idx_membership_tenant ON common_auth.membership(tenant_id);
+
+COMMENT ON TABLE common_auth.membership IS
+    'RLS-all exempt identity-to-tenant membership table. tenant_id is a plain FK, not an RLS isolation column, because memberships are read cross-tenant during login; exclude from future RLS-all sweeps.';
+COMMENT ON COLUMN common_auth.membership.tenant_id IS
+    'Plain FK to common_tenant.common_tenant(id); deliberately not an RLS isolation column.';
+
+ALTER TABLE common_auth.login_identity DISABLE ROW LEVEL SECURITY;
+ALTER TABLE common_auth.membership DISABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE common_auth.login_identity TO fabric_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE common_auth.membership TO fabric_app;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_system') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE common_auth.login_identity TO fabric_system;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE common_auth.membership TO fabric_system;
+  END IF;
+END $$;

--- a/src/main/resources/db/migration/V20260701140000__membership_fk_cascade.sql
+++ b/src/main/resources/db/migration/V20260701140000__membership_fk_cascade.sql
@@ -1,0 +1,29 @@
+-- IDENTITY-2: membership rows belong to tenant lifecycle for hard deletes/TTL cleanup.
+-- Keep common_auth.membership RLS-free; only change the tenant FK action.
+
+DO $$
+BEGIN
+  IF to_regclass('common_auth.membership') IS NOT NULL THEN
+    ALTER TABLE common_auth.membership DROP CONSTRAINT IF EXISTS fk_membership_tenant;
+
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_constraint c
+      JOIN pg_class cls ON cls.oid = c.conrelid
+      JOIN pg_namespace ns ON ns.oid = cls.relnamespace
+      WHERE ns.nspname = 'common_auth'
+        AND cls.relname = 'membership'
+        AND c.conname = 'fk_membership_tenant'
+    ) THEN
+      ALTER TABLE common_auth.membership ADD CONSTRAINT fk_membership_tenant
+        FOREIGN KEY (tenant_id)
+        REFERENCES common_tenant.common_tenant(id)
+        ON DELETE CASCADE;
+    END IF;
+
+    EXECUTE $comment$
+      COMMENT ON COLUMN common_auth.membership.tenant_id IS
+        'Plain FK to common_tenant.common_tenant(id) with ON DELETE CASCADE; deliberately not an RLS isolation column.'
+    $comment$;
+  END IF;
+END $$;

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -213,6 +213,9 @@ class ConstitutionArchTest {
       //   - ProcessedEventEntry     : Durable event processing entry; BaseEntity semantics N/A
       //   - TaskLabelAssignment     : Minimal junction table; NOTE [X1] - intentional, no audit
       //                               trail needed
+      //   - LoginIdentity           : Platform-level pre-auth principal; no tenant_id by design
+      //   - Membership              : Platform-level identity→tenant link; tenant_id is a plain FK,
+      //                               not BaseEntity's RLS isolation column
 
       ArchRule rule =
           classes()
@@ -236,6 +239,10 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("Lead")
               .and()
               .doNotHaveSimpleName("ProcessedEventEntry")
+              .and()
+              .doNotHaveSimpleName("LoginIdentity")
+              .and()
+              .doNotHaveSimpleName("Membership")
               .should()
               .beAssignableTo(
                   com.fabricmanagement.common.infrastructure.persistence.BaseEntity.class)
@@ -815,6 +822,7 @@ class ConstitutionArchTest {
       //   - TenantTransactionalPurgeService : Go-real purge, atomic tenant-scoped seed/data wipe
       //   - TenantQueryAdapter           : Port/Adapter: tenant lookup (auth, event yolu)
       //   - CloneTemplateRolesStep       : Onboarding: TEMPLATE rollerini yeni tenant'a kopyala
+      //   - LoginIdentityBackfillRunner  : IDENTITY-1 startup backfill from RLS source tables
       //   - SystemDataSourceConfig       : Altyapı: DataSource bean konfigürasyonu
       //   - SystemTransactionExecutor    : Self-reference (class itself)
 
@@ -840,6 +848,8 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("SystemDataSourceConfig")
               .and()
               .doNotHaveSimpleName("FinancePermissionBackfillRunner")
+              .and()
+              .doNotHaveSimpleName("LoginIdentityBackfillRunner")
               .and()
               .doNotHaveSimpleName("SystemTransactionExecutor")
               .should()

--- a/src/test/java/com/fabricmanagement/architecture/RlsAllowlistArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/RlsAllowlistArchTest.java
@@ -50,6 +50,10 @@ class RlsAllowlistArchTest {
           "common_tenant",
           "trading_partner_registry",
 
+          // Platform identity tables (IDENTITY-1): pre-auth/cross-tenant, deliberately no RLS
+          "login_identity",
+          "membership",
+
           // Permanent marketing lead; tenant-independent with nullable trial_tenant_id link
           "common_lead",
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PartnerUserSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PartnerUserSeederTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
+import com.fabricmanagement.platform.auth.app.IdentityProvisioningService;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
 import com.fabricmanagement.platform.communication.domain.Contact;
@@ -47,6 +48,7 @@ class PartnerUserSeederTest {
   @Mock private PasswordEncoder passwordEncoder;
   @Mock private TransactionTemplate transactionTemplate;
   @Mock private ContactRepository contactRepository;
+  @Mock private IdentityProvisioningService identityProvisioningService;
 
   @InjectMocks private PartnerUserSeeder partnerUserSeeder;
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/UserSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/UserSeederTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.bootstrap.UserSeeder.PersonaSubset;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.auth.app.IdentityProvisioningService;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
 import com.fabricmanagement.platform.communication.infra.repository.ContactRepository;
 import com.fabricmanagement.platform.organization.app.OrganizationService;
@@ -48,6 +49,8 @@ class UserSeederTest {
   private final PasswordEncoder passwordEncoder = Mockito.mock(PasswordEncoder.class);
   private final TransactionTemplate transactionTemplate = Mockito.mock(TransactionTemplate.class);
   private final ContactRepository contactRepository = Mockito.mock(ContactRepository.class);
+  private final IdentityProvisioningService identityProvisioningService =
+      Mockito.mock(IdentityProvisioningService.class);
 
   private final UserSeeder userSeeder =
       new UserSeeder(
@@ -60,7 +63,8 @@ class UserSeederTest {
           authUserRepository,
           passwordEncoder,
           transactionTemplate,
-          contactRepository);
+          contactRepository,
+          identityProvisioningService);
 
   @AfterEach
   void tearDown() {

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/RlsPolicyEnforcementIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/RlsPolicyEnforcementIT.java
@@ -56,6 +56,10 @@ class RlsPolicyEnforcementIT {
         JOIN pg_namespace pn ON pn.oid = pc.relnamespace AND pn.nspname = c.table_schema
         WHERE c.column_name = 'tenant_id'
           AND c.table_schema NOT IN ('information_schema', 'pg_catalog')
+          -- IDENTITY-1/2: common_auth.membership.tenant_id is a plain membership FK used
+          -- during pre-auth organization selection. The table is deliberately RLS-free so login
+          -- can resolve active memberships before TenantContext exists.
+          AND NOT (c.table_schema = 'common_auth' AND c.table_name = 'membership')
           AND (
             pc.relrowsecurity = false
             OR pc.relforcerowsecurity = false

--- a/src/test/java/com/fabricmanagement/platform/auth/JwtRoundTripIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/JwtRoundTripIntegrationTest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.auth.app.IdentityProvisioningService;
 import com.fabricmanagement.platform.auth.app.JwtService;
 import com.fabricmanagement.platform.auth.domain.AuthUser;
 import com.fabricmanagement.platform.auth.infra.repository.AuthUserRepository;
@@ -91,6 +92,7 @@ class JwtRoundTripIntegrationTest {
   @Autowired private OrganizationRepository organizationRepository;
   @Autowired private UserRepository userRepository;
   @Autowired private AuthUserRepository authUserRepository;
+  @Autowired private IdentityProvisioningService identityProvisioningService;
   @Autowired private PasswordEncoder passwordEncoder;
   @Autowired private ObjectMapper objectMapper;
   @Autowired private SystemTransactionExecutor systemExecutor;
@@ -159,9 +161,19 @@ class JwtRoundTripIntegrationTest {
         signupTenantId);
     try {
       // Create AuthUser with password (user-based auth: one AuthUser per User)
-      AuthUser authUser = AuthUser.create(signupUserId, passwordEncoder.encode(password));
+      String passwordHash = passwordEncoder.encode(password);
+      AuthUser authUser = AuthUser.create(signupUserId, passwordHash);
       authUser.verify();
       authUserRepository.save(authUser);
+      identityProvisioningService.provisionCredential(
+          email,
+          passwordHash,
+          Boolean.TRUE.equals(authUser.getIsMfaEnabled()),
+          authUser.getPrimaryMfaType(),
+          authUser.getMfaSecret(),
+          true,
+          signupTenantId,
+          signupUserId);
 
       // Verify the contact directly in the DB
       systemExecutor.executeUpdate(
@@ -286,9 +298,19 @@ class JwtRoundTripIntegrationTest {
     com.fabricmanagement.common.infrastructure.persistence.TenantContext.setCurrentTenantId(
         signupTenantId);
     try {
-      AuthUser authUser = AuthUser.create(signupUserId, passwordEncoder.encode(password));
+      String passwordHash = passwordEncoder.encode(password);
+      AuthUser authUser = AuthUser.create(signupUserId, passwordHash);
       authUser.verify();
       authUserRepository.save(authUser);
+      identityProvisioningService.provisionCredential(
+          email,
+          passwordHash,
+          Boolean.TRUE.equals(authUser.getIsMfaEnabled()),
+          authUser.getPrimaryMfaType(),
+          authUser.getMfaSecret(),
+          true,
+          signupTenantId,
+          signupUserId);
 
       // Verify the contact directly in the DB
       systemExecutor.executeUpdate(

--- a/src/test/java/com/fabricmanagement/platform/auth/app/IdentityProvisioningServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/IdentityProvisioningServiceTest.java
@@ -1,0 +1,142 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.domain.MembershipStatus;
+import com.fabricmanagement.platform.auth.domain.MfaType;
+import com.fabricmanagement.platform.auth.infra.repository.LoginIdentityRepository;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class IdentityProvisioningServiceTest {
+
+  @Mock private LoginIdentityRepository loginIdentityRepository;
+  @Mock private MembershipRepository membershipRepository;
+
+  @Test
+  void shouldProvisionNewIdentityAndDefaultMembership() {
+    UUID identityId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    IdentityProvisioningService service =
+        new IdentityProvisioningService(loginIdentityRepository, membershipRepository);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com")).thenReturn(Optional.empty());
+    when(loginIdentityRepository.save(any(LoginIdentity.class)))
+        .thenAnswer(
+            invocation -> {
+              LoginIdentity identity = invocation.getArgument(0);
+              identity.setId(identityId);
+              return identity;
+            });
+    when(membershipRepository.findByUserId(userId)).thenReturn(Optional.empty());
+    when(membershipRepository.findByLoginIdentityIdAndTenantId(identityId, tenantId))
+        .thenReturn(Optional.empty());
+
+    service.provisionCredential(
+        " Admin@Example.COM ", "hash", false, MfaType.NONE, null, true, tenantId, userId);
+
+    ArgumentCaptor<LoginIdentity> identityCaptor = ArgumentCaptor.forClass(LoginIdentity.class);
+    verify(loginIdentityRepository).save(identityCaptor.capture());
+    assertThat(identityCaptor.getValue().getEmail()).isEqualTo("admin@example.com");
+    assertThat(identityCaptor.getValue().getPasswordHash()).isEqualTo("hash");
+    assertThat(identityCaptor.getValue().getRequiresPasswordReset()).isFalse();
+
+    ArgumentCaptor<Membership> membershipCaptor = ArgumentCaptor.forClass(Membership.class);
+    verify(membershipRepository).save(membershipCaptor.capture());
+    assertThat(membershipCaptor.getValue().getLoginIdentityId()).isEqualTo(identityId);
+    assertThat(membershipCaptor.getValue().getTenantId()).isEqualTo(tenantId);
+    assertThat(membershipCaptor.getValue().getUserId()).isEqualTo(userId);
+    assertThat(membershipCaptor.getValue().getStatus()).isEqualTo(MembershipStatus.ACTIVE);
+    assertThat(membershipCaptor.getValue().getIsDefault()).isTrue();
+  }
+
+  @Test
+  void shouldBeIdempotentWhenUserMembershipAlreadyExists() {
+    UUID identityId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    LoginIdentity identity = identity(identityId, "admin@example.com", "old-hash");
+    Membership membership =
+        Membership.builder()
+            .loginIdentityId(identityId)
+            .tenantId(tenantId)
+            .userId(userId)
+            .status(MembershipStatus.ACTIVE)
+            .isDefault(true)
+            .build();
+    IdentityProvisioningService service =
+        new IdentityProvisioningService(loginIdentityRepository, membershipRepository);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(membershipRepository.countByLoginIdentityId(identityId)).thenReturn(1L);
+    when(membershipRepository.findByUserId(userId)).thenReturn(Optional.of(membership));
+
+    service.provisionCredential(
+        "admin@example.com", "new-hash", false, MfaType.NONE, null, true, tenantId, userId);
+
+    assertThat(identity.getPasswordHash()).isEqualTo("old-hash");
+    assertThat(identity.getRequiresPasswordReset()).isFalse();
+    verify(loginIdentityRepository, never()).save(any(LoginIdentity.class));
+    verify(membershipRepository, never()).save(any(Membership.class));
+  }
+
+  @Test
+  void shouldMergeEmailCollisionWithoutOverwritingPassword() {
+    UUID identityId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    LoginIdentity identity = identity(identityId, "admin@example.com", "old-hash");
+    IdentityProvisioningService service =
+        new IdentityProvisioningService(loginIdentityRepository, membershipRepository);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(membershipRepository.countByLoginIdentityId(identityId)).thenReturn(1L);
+    when(membershipRepository.findByUserId(userId)).thenReturn(Optional.empty());
+    when(loginIdentityRepository.save(identity)).thenReturn(identity);
+    when(membershipRepository.findByLoginIdentityIdAndTenantId(identityId, tenantId))
+        .thenReturn(Optional.empty());
+
+    service.provisionCredential(
+        "admin@example.com", "new-hash", false, MfaType.NONE, null, true, tenantId, userId);
+
+    assertThat(identity.getPasswordHash()).isEqualTo("old-hash");
+    assertThat(identity.getRequiresPasswordReset()).isTrue();
+
+    ArgumentCaptor<Membership> membershipCaptor = ArgumentCaptor.forClass(Membership.class);
+    verify(membershipRepository).save(membershipCaptor.capture());
+    assertThat(membershipCaptor.getValue().getLoginIdentityId()).isEqualTo(identityId);
+    assertThat(membershipCaptor.getValue().getTenantId()).isEqualTo(tenantId);
+    assertThat(membershipCaptor.getValue().getUserId()).isEqualTo(userId);
+    assertThat(membershipCaptor.getValue().getIsDefault()).isFalse();
+  }
+
+  private LoginIdentity identity(UUID identityId, String email, String passwordHash) {
+    return LoginIdentity.builder()
+        .id(identityId)
+        .email(email)
+        .passwordHash(passwordHash)
+        .isMfaEnabled(false)
+        .primaryMfaType(MfaType.NONE)
+        .isActive(true)
+        .emailVerified(true)
+        .failedLoginAttempts(0)
+        .requiresPasswordReset(false)
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/LoginIdentityBackfillRunnerTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/LoginIdentityBackfillRunnerTest.java
@@ -1,0 +1,234 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.platform.auth.app.LoginIdentityBackfillRunner.AuthUserIdentitySource;
+import com.fabricmanagement.platform.auth.app.LoginIdentityBackfillRunner.BackfillStats;
+import com.fabricmanagement.platform.auth.app.LoginIdentityBackfillRunner.IdentityBackfillGateway;
+import com.fabricmanagement.platform.auth.app.LoginIdentityBackfillRunner.IdentityRow;
+import com.fabricmanagement.platform.auth.domain.MfaType;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class LoginIdentityBackfillRunnerTest {
+
+  private final LoginIdentityBackfillRunner runner = new LoginIdentityBackfillRunner(null);
+
+  @Test
+  void backfillCreatesIdentityAndDefaultMembershipWithCopiedCredentials() {
+    InMemoryGateway gateway = new InMemoryGateway();
+    AuthUserIdentitySource source =
+        source(
+            "User@Example.COM",
+            "hash-1",
+            UUID.fromString("10000000-0000-0000-0000-000000000001"),
+            UUID.fromString("20000000-0000-0000-0000-000000000001"));
+
+    BackfillStats stats = runner.backfillRows(List.of(source), gateway);
+
+    assertThat(stats).isEqualTo(new BackfillStats(1, 1, 0, 0, 0));
+    assertThat(gateway.identities).containsOnlyKeys("user@example.com");
+    IdentityState identity = gateway.identities.get("user@example.com");
+    assertThat(identity.passwordHash).isEqualTo("hash-1");
+    assertThat(identity.mfaEnabled).isTrue();
+    assertThat(identity.primaryMfaType).isEqualTo(MfaType.TOTP);
+    assertThat(identity.emailVerified).isTrue();
+    assertThat(identity.requiresPasswordReset).isFalse();
+    assertThat(gateway.membershipsByUserId.values())
+        .singleElement()
+        .satisfies(
+            membership -> {
+              assertThat(membership.loginIdentityId).isEqualTo(identity.id);
+              assertThat(membership.tenantId).isEqualTo(source.tenantId());
+              assertThat(membership.userId).isEqualTo(source.userId());
+              assertThat(membership.defaultMembership).isTrue();
+            });
+  }
+
+  @Test
+  void backfillIsIdempotentWhenMembershipAlreadyExists() {
+    InMemoryGateway gateway = new InMemoryGateway();
+    AuthUserIdentitySource source =
+        source(
+            "idempotent@example.com",
+            "hash-1",
+            UUID.fromString("10000000-0000-0000-0000-000000000002"),
+            UUID.fromString("20000000-0000-0000-0000-000000000002"));
+
+    BackfillStats firstRun = runner.backfillRows(List.of(source), gateway);
+    BackfillStats secondRun = runner.backfillRows(List.of(source), gateway);
+
+    assertThat(firstRun).isEqualTo(new BackfillStats(1, 1, 0, 0, 0));
+    assertThat(secondRun).isEqualTo(new BackfillStats(0, 0, 0, 1, 0));
+    assertThat(gateway.identities).hasSize(1);
+    assertThat(gateway.membershipsByUserId).hasSize(1);
+    assertThat(gateway.identities.get("idempotent@example.com").requiresPasswordReset).isFalse();
+  }
+
+  @Test
+  void backfillMergesDuplicateEmailAcrossTenantsAndRequiresPasswordReset() {
+    InMemoryGateway gateway = new InMemoryGateway();
+    AuthUserIdentitySource firstTenant =
+        source(
+            "owner@example.com",
+            "hash-first",
+            UUID.fromString("10000000-0000-0000-0000-000000000003"),
+            UUID.fromString("20000000-0000-0000-0000-000000000003"));
+    AuthUserIdentitySource secondTenant =
+        source(
+            "OWNER@example.com",
+            "hash-second",
+            UUID.fromString("10000000-0000-0000-0000-000000000004"),
+            UUID.fromString("20000000-0000-0000-0000-000000000004"));
+
+    BackfillStats stats = runner.backfillRows(List.of(firstTenant, secondTenant), gateway);
+
+    assertThat(stats).isEqualTo(new BackfillStats(1, 2, 1, 0, 0));
+    assertThat(gateway.identities).hasSize(1);
+    IdentityState identity = gateway.identities.get("owner@example.com");
+    assertThat(identity.passwordHash).isEqualTo("hash-first");
+    assertThat(identity.requiresPasswordReset).isTrue();
+    assertThat(gateway.membershipsByUserId.values())
+        .extracting(membership -> membership.loginIdentityId)
+        .containsExactly(identity.id, identity.id);
+    assertThat(gateway.membershipsByUserId.values())
+        .extracting(membership -> membership.defaultMembership)
+        .containsExactly(true, false);
+  }
+
+  @Test
+  void backfillSkipsAuthUsersWithoutResolvableEmail() {
+    InMemoryGateway gateway = new InMemoryGateway();
+
+    BackfillStats stats =
+        runner.backfillRows(
+            List.of(
+                source(
+                    null,
+                    "hash-1",
+                    UUID.fromString("10000000-0000-0000-0000-000000000005"),
+                    UUID.fromString("20000000-0000-0000-0000-000000000005")),
+                source(
+                    "   ",
+                    "hash-2",
+                    UUID.fromString("10000000-0000-0000-0000-000000000006"),
+                    UUID.fromString("20000000-0000-0000-0000-000000000006"))),
+            gateway);
+
+    assertThat(stats).isEqualTo(new BackfillStats(0, 0, 0, 0, 2));
+    assertThat(gateway.identities).isEmpty();
+    assertThat(gateway.membershipsByUserId).isEmpty();
+  }
+
+  private static AuthUserIdentitySource source(
+      String email, String passwordHash, UUID tenantId, UUID userId) {
+    return new AuthUserIdentitySource(
+        UUID.randomUUID(),
+        tenantId,
+        userId,
+        email,
+        passwordHash,
+        true,
+        MfaType.TOTP,
+        "secret",
+        true,
+        true,
+        2,
+        Instant.parse("2026-07-01T10:15:30Z"));
+  }
+
+  private static final class InMemoryGateway implements IdentityBackfillGateway {
+
+    private final Map<String, IdentityState> identities = new LinkedHashMap<>();
+    private final Map<UUID, MembershipState> membershipsByUserId = new LinkedHashMap<>();
+
+    @Override
+    public Optional<IdentityRow> findIdentityByEmail(String email) {
+      return Optional.ofNullable(identities.get(email))
+          .map(identity -> new IdentityRow(identity.id, identity.requiresPasswordReset));
+    }
+
+    @Override
+    public UUID insertIdentity(AuthUserIdentitySource source, String email) {
+      UUID id = UUID.randomUUID();
+      identities.put(
+          email,
+          new IdentityState(
+              id,
+              source.passwordHash(),
+              source.mfaEnabled(),
+              source.primaryMfaType(),
+              source.emailVerified(),
+              false));
+      return id;
+    }
+
+    @Override
+    public boolean membershipExistsByUserId(UUID userId) {
+      return membershipsByUserId.containsKey(userId);
+    }
+
+    @Override
+    public boolean insertMembership(
+        UUID identityId, AuthUserIdentitySource source, boolean defaultMembership) {
+      if (membershipsByUserId.containsKey(source.userId())) {
+        return false;
+      }
+
+      boolean identityTenantAlreadyLinked =
+          membershipsByUserId.values().stream()
+              .anyMatch(
+                  membership ->
+                      membership.loginIdentityId.equals(identityId)
+                          && membership.tenantId.equals(source.tenantId()));
+      if (identityTenantAlreadyLinked) {
+        return false;
+      }
+
+      membershipsByUserId.put(
+          source.userId(),
+          new MembershipState(identityId, source.tenantId(), source.userId(), defaultMembership));
+      return true;
+    }
+
+    @Override
+    public void markRequiresPasswordReset(UUID identityId) {
+      identities.values().stream()
+          .filter(identity -> identity.id.equals(identityId))
+          .findFirst()
+          .ifPresent(identity -> identity.requiresPasswordReset = true);
+    }
+  }
+
+  private static final class IdentityState {
+    private final UUID id;
+    private final String passwordHash;
+    private final boolean mfaEnabled;
+    private final MfaType primaryMfaType;
+    private final boolean emailVerified;
+    private boolean requiresPasswordReset;
+
+    private IdentityState(
+        UUID id,
+        String passwordHash,
+        boolean mfaEnabled,
+        MfaType primaryMfaType,
+        boolean emailVerified,
+        boolean requiresPasswordReset) {
+      this.id = id;
+      this.passwordHash = passwordHash;
+      this.mfaEnabled = mfaEnabled;
+      this.primaryMfaType = primaryMfaType;
+      this.emailVerified = emailVerified;
+      this.requiresPasswordReset = requiresPasswordReset;
+    }
+  }
+
+  private record MembershipState(
+      UUID loginIdentityId, UUID tenantId, UUID userId, boolean defaultMembership) {}
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/LoginServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/LoginServiceTest.java
@@ -1,0 +1,254 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.platform.auth.domain.LoginIdentity;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.domain.MembershipStatus;
+import com.fabricmanagement.platform.auth.domain.MfaType;
+import com.fabricmanagement.platform.auth.domain.RefreshToken;
+import com.fabricmanagement.platform.auth.dto.LoginRequest;
+import com.fabricmanagement.platform.auth.dto.LoginResponse;
+import com.fabricmanagement.platform.auth.infra.repository.LoginIdentityRepository;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
+import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.communication.app.ContactService;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.organization.api.facade.OrganizationFacade;
+import com.fabricmanagement.platform.user.api.facade.UserFacade;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class LoginServiceTest {
+
+  @Mock private AuthUserResolutionService resolutionService;
+  @Mock private LoginIdentityRepository loginIdentityRepository;
+  @Mock private MembershipRepository membershipRepository;
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private UserFacade userFacade;
+  @Mock private UserRepository userRepository;
+  @Mock private OrganizationFacade organizationFacade;
+  @Mock private PasswordEncoder passwordEncoder;
+  @Mock private JwtService jwtService;
+  @Mock private DomainEventPublisher eventPublisher;
+  @Mock private ContactService contactService;
+  @Mock private VerificationCodeManager verificationCodeManager;
+  @Mock private TotpMfaService totpMfaService;
+  @Mock private TrustedDeviceService trustedDeviceService;
+  @Mock private MfaRateLimitService mfaRateLimitService;
+  @Mock private MfaEventService mfaEventService;
+  @Mock private TenantSessionBinder tenantSessionBinder;
+
+  @InjectMocks private LoginService loginService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(loginService, "accessTokenExpiration", 900_000L);
+    ReflectionTestUtils.setField(loginService, "refreshTokenExpiration", 604_800_000L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void shouldLoginViaLoginIdentityWithSingleMembership() {
+    UUID identityId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    LoginIdentity identity = identity(identityId, "admin@example.com", "hash");
+    Membership membership = membership(identityId, tenantId, userId, true);
+    User userEntity = userEntity(tenantId, userId, "admin@example.com");
+    UserDto userDto = userDto(tenantId, userId);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(resolutionService.validate(identity)).thenReturn(AuthValidationResult.valid());
+    when(passwordEncoder.matches("secret", "hash")).thenReturn(true);
+    when(membershipRepository.findByLoginIdentityIdAndStatus(identityId, MembershipStatus.ACTIVE))
+        .thenReturn(List.of(membership));
+    when(userFacade.findById(tenantId, userId)).thenReturn(Optional.of(userDto));
+    when(userRepository.findByTenantIdAndId(tenantId, userId)).thenReturn(Optional.of(userEntity));
+    when(jwtService.generateAccessToken(userEntity)).thenReturn("access-token");
+    when(jwtService.generateRefreshToken(userEntity)).thenReturn("refresh-token");
+
+    LoginResponse response =
+        loginService.login(loginRequest("ADMIN@EXAMPLE.COM", "secret"), "127.0.0.1", "agent");
+
+    assertThat(response.getAccessToken()).isEqualTo("access-token");
+    assertThat(response.getRefreshToken()).isEqualTo("refresh-token");
+    assertThat(response.getUser()).isSameAs(userDto);
+    verify(loginIdentityRepository).findByEmail("admin@example.com");
+    verify(resolutionService).resetFailedAttempts(identity);
+    verify(refreshTokenRepository).save(any(RefreshToken.class));
+    verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+  }
+
+  @Test
+  void shouldRecordFailedAttemptAndLockIdentityOnWrongPassword() {
+    UUID identityId = UUID.randomUUID();
+    LoginIdentity identity = identity(identityId, "admin@example.com", "hash");
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(resolutionService.validate(identity)).thenReturn(AuthValidationResult.valid());
+    when(passwordEncoder.matches("bad-password", "hash")).thenReturn(false);
+    doAnswer(
+            invocation -> {
+              LoginIdentity failedIdentity = invocation.getArgument(0);
+              failedIdentity.recordFailedLogin(1, 60);
+              return null;
+            })
+        .when(resolutionService)
+        .recordFailedAttempt(identity);
+
+    assertThatThrownBy(
+            () ->
+                loginService.login(
+                    loginRequest("admin@example.com", "bad-password"), "127.0.0.1", "agent"))
+        .isInstanceOf(PlatformDomainException.class)
+        .satisfies(
+            exception ->
+                assertThat(((PlatformDomainException) exception).getErrorCode())
+                    .isEqualTo("AUTH_INVALID_CREDENTIALS"));
+
+    assertThat(identity.isLocked()).isTrue();
+    verify(resolutionService).recordFailedAttempt(identity);
+  }
+
+  @Test
+  void shouldDenyLoginWhenIdentityRequiresPasswordReset() {
+    LoginIdentity identity = identity(UUID.randomUUID(), "admin@example.com", "hash");
+    identity.setRequiresPasswordReset(true);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(resolutionService.validate(identity))
+        .thenReturn(AuthValidationResult.passwordResetRequired());
+
+    assertThatThrownBy(
+            () ->
+                loginService.login(
+                    loginRequest("admin@example.com", "secret"), "127.0.0.1", "agent"))
+        .isInstanceOf(PlatformDomainException.class)
+        .satisfies(
+            exception ->
+                assertThat(((PlatformDomainException) exception).getErrorCode())
+                    .isEqualTo("AUTH_PASSWORD_RESET_REQUIRED"));
+  }
+
+  @Test
+  void shouldUseDefaultMembershipWhenIdentityHasMultipleActiveMemberships() {
+    UUID identityId = UUID.randomUUID();
+    UUID firstTenantId = UUID.randomUUID();
+    UUID firstUserId = UUID.randomUUID();
+    UUID defaultTenantId = UUID.randomUUID();
+    UUID defaultUserId = UUID.randomUUID();
+    LoginIdentity identity = identity(identityId, "admin@example.com", "hash");
+    Membership firstMembership = membership(identityId, firstTenantId, firstUserId, false);
+    Membership defaultMembership = membership(identityId, defaultTenantId, defaultUserId, true);
+    User userEntity = userEntity(defaultTenantId, defaultUserId, "admin@example.com");
+    UserDto userDto = userDto(defaultTenantId, defaultUserId);
+
+    when(loginIdentityRepository.findByEmail("admin@example.com"))
+        .thenReturn(Optional.of(identity));
+    when(resolutionService.validate(identity)).thenReturn(AuthValidationResult.valid());
+    when(passwordEncoder.matches("secret", "hash")).thenReturn(true);
+    when(membershipRepository.findByLoginIdentityIdAndStatus(identityId, MembershipStatus.ACTIVE))
+        .thenReturn(List.of(firstMembership, defaultMembership));
+    when(userFacade.findById(defaultTenantId, defaultUserId)).thenReturn(Optional.of(userDto));
+    when(userRepository.findByTenantIdAndId(defaultTenantId, defaultUserId))
+        .thenReturn(Optional.of(userEntity));
+    when(jwtService.generateAccessToken(userEntity)).thenReturn("access-token");
+    when(jwtService.generateRefreshToken(userEntity)).thenReturn("refresh-token");
+
+    LoginResponse response =
+        loginService.login(loginRequest("admin@example.com", "secret"), "127.0.0.1", "agent");
+
+    assertThat(response.getUser()).isSameAs(userDto);
+    verify(userFacade).findById(defaultTenantId, defaultUserId);
+    verify(tenantSessionBinder).bindToCurrentSession(defaultTenantId);
+  }
+
+  private LoginRequest loginRequest(String email, String password) {
+    return LoginRequest.builder().contactValue(email).password(password).build();
+  }
+
+  private LoginIdentity identity(UUID identityId, String email, String passwordHash) {
+    return LoginIdentity.builder()
+        .id(identityId)
+        .email(email)
+        .passwordHash(passwordHash)
+        .isMfaEnabled(false)
+        .primaryMfaType(MfaType.NONE)
+        .isActive(true)
+        .emailVerified(true)
+        .failedLoginAttempts(0)
+        .requiresPasswordReset(false)
+        .build();
+  }
+
+  private Membership membership(UUID identityId, UUID tenantId, UUID userId, boolean isDefault) {
+    return Membership.builder()
+        .id(UUID.randomUUID())
+        .loginIdentityId(identityId)
+        .tenantId(tenantId)
+        .userId(userId)
+        .status(MembershipStatus.ACTIVE)
+        .isDefault(isDefault)
+        .build();
+  }
+
+  private UserDto userDto(UUID tenantId, UUID userId) {
+    return UserDto.builder()
+        .id(userId)
+        .tenantId(tenantId)
+        .uid("ACME-001-USER-00001")
+        .organizationId(UUID.randomUUID())
+        .isActive(true)
+        .hasCompletedOnboarding(true)
+        .build();
+  }
+
+  private User userEntity(UUID tenantId, UUID userId, String email) {
+    Contact contact =
+        Contact.builder()
+            .contactType(ContactType.EMAIL)
+            .contactValue(email)
+            .isVerified(true)
+            .build();
+    User user = User.create("Admin", "User", UUID.randomUUID());
+    user.setId(userId);
+    user.setTenantId(tenantId);
+    user.setUid("ACME-001-USER-00001");
+    user.getUserContacts().add(UserContact.builder().contact(contact).isDefault(true).build());
+    user.completeOnboarding();
+    return user;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/PasswordSetupServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/PasswordSetupServiceTest.java
@@ -62,6 +62,7 @@ class PasswordSetupServiceTest {
   @Mock private EmployeeProjectionPort employeeProjectionPort;
   @Mock private TrialLifecyclePort trialLifecyclePort;
   @Mock private TenantSessionBinder tenantSessionBinder;
+  @Mock private IdentityProvisioningService identityProvisioningService;
 
   private PasswordSetupService service;
 
@@ -85,7 +86,8 @@ class PasswordSetupServiceTest {
             tenantQueryPort,
             employeeProjectionPort,
             trialLifecyclePort,
-            tenantSessionBinder);
+            tenantSessionBinder,
+            identityProvisioningService);
     ReflectionTestUtils.setField(service, "refreshTokenExpiration", 604_800_000L);
     ReflectionTestUtils.setField(service, "accessTokenExpiration", 900_000L);
   }
@@ -113,6 +115,25 @@ class PasswordSetupServiceTest {
     service.setupPassword(fixture.request(), "127.0.0.1");
 
     verify(trialLifecyclePort, never()).startSelfServiceTrialIfNeeded(any());
+  }
+
+  @Test
+  @DisplayName("password setup provisions platform identity and membership")
+  void shouldProvisionIdentityAndMembershipOnPasswordSetup() {
+    PasswordSetupFixture fixture = arrangePasswordSetup(RegistrationTokenType.SALES_LED);
+
+    service.setupPassword(fixture.request(), "127.0.0.1");
+
+    verify(identityProvisioningService)
+        .provisionCredential(
+            "admin@example.com",
+            "hash",
+            false,
+            com.fabricmanagement.platform.auth.domain.MfaType.NONE,
+            null,
+            true,
+            fixture.tenantId(),
+            fixture.userId());
   }
 
   private PasswordSetupFixture arrangePasswordSetup(RegistrationTokenType tokenType) {
@@ -146,7 +167,7 @@ class PasswordSetupServiceTest {
     when(jwtService.generateRefreshToken(user)).thenReturn("refresh-token");
     when(employeeProjectionPort.findByUserId(tenantId, userId)).thenReturn(Optional.empty());
 
-    return new PasswordSetupFixture(request, tenantId);
+    return new PasswordSetupFixture(request, tenantId, userId);
   }
 
   private static User buildVerifiedUser(
@@ -166,5 +187,5 @@ class PasswordSetupServiceTest {
     return user;
   }
 
-  private record PasswordSetupFixture(PasswordSetupRequest request, UUID tenantId) {}
+  private record PasswordSetupFixture(PasswordSetupRequest request, UUID tenantId, UUID userId) {}
 }

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
@@ -134,6 +134,11 @@ class PurgeSchemaCoverageIT extends AbstractIntegrationTest {
         "common_auth.common_registration_token",
         "Registration/setup tokens are retained for account lifecycle.");
     tables.put(
+        "common_auth.membership",
+        "Platform identity membership rows are RLS-free auth data; tenant_id is a plain FK used "
+            + "before TenantContext exists. Demo purge retains them; tenant hard-delete removes "
+            + "them via fk_membership_tenant ON DELETE CASCADE.");
+    tables.put(
         "common_auth.common_trusted_device",
         "Seed-user trusted devices are deleted by demo_seed CTE.");
     tables.put(


### PR DESCRIPTION
Add RLS-exempt common_auth.login_identity and common_auth.membership tables with comments documenting the pre-auth cross-tenant exemption.

Add plain JPA entities and repositories for the new identity layer without extending tenant-scoped BaseEntity.

Backfill existing AuthUser credentials into global login identities and memberships via SystemTransactionExecutor, including idempotency, lowercase email normalization, collision merge handling, and missing-email skips.

Cover the backfill happy path, idempotency, collision merge, and missing-email skip behavior with unit tests.