### PR TITLE
fix(auth): resolve refresh tokens before rls reads

### DIFF
--- a/docs/platform/tickets/IDENTITY-3.md
+++ b/docs/platform/tickets/IDENTITY-3.md
@@ -1,0 +1,89 @@
+# IDENTITY-3 (BE) — Phase 3: fix refresh + logout-by-refresh (RLS pre-auth)
+
+> Epic: **Platform Identity & Memberships** (`../../architecture/ADR-0002-...`). Follows IDENTITY-1 (tables +
+> backfill, 6cc3add7) and IDENTITY-2 (login on identity, 2bc55afb). **Implementer:** Codex. **Reviewer:** Claude.
+> **Side:** BE only.
+> Goal: make **token refresh** work again (RLS-blinded → 401 today) using the same bypass-resolve-then-bind
+> pattern as setup-password. This also fixes the FE "Return to my account" button (it calls refresh) and the
+> ~15-min silent logout. MFA already moved to the identity in IDENTITY-2 — no MFA work here.
+
+## Why (code-confirmed root cause)
+`RefreshTokenService.refreshAccessToken` and `LogoutService.logoutByRefreshToken` are **anonymous / pre-auth**
+(no tenant context), but they look up the refresh token via the RLS-bound JPA repo:
+`refreshTokenRepository.findByToken(refreshToken)` on `common_auth.common_refresh_token` (RLS + FORCE). Under
+the SYSTEM binding the row is invisible → "Invalid refresh token" (401). `refreshAccessToken` additionally calls
+`TenantContext.requireTenantId()`, which has no tenant pre-auth. Net effect: refresh always 401s → the app
+treats it as session-expired and redirects to login; and `useReturnToOwner` (FE, calls refresh) dumps the user
+to login instead of returning them to the owner session.
+
+## Pattern to reuse (same as setup-password, IDENTITY-2)
+Resolve the token's tenant via the BYPASSRLS `TenantQueryPort`, then `TenantContext.setCurrentTenantId(tenantId)`
++ `tenantSessionBinder.bindToCurrentSession(tenantId)`, then run the existing RLS-bound flow (which now sees the
+row under the correct tenant). Keep the privileged executor behind the whitelisted adapter (ArchUnit Rule 14.1).
+
+## Changes
+
+### 1. Port: cross-tenant refresh-token → tenant resolution
+- `TenantQueryPort`: add `Optional<UUID> findTenantIdByRefreshToken(String token);` (javadoc: pre-auth refresh
+  is cross-tenant; resolved via BYPASSRLS, mirrors `findTenantIdByRegistrationToken`).
+- `TenantQueryAdapter`: implement via `SystemTransactionExecutor`:
+  `SELECT tenant_id FROM common_auth.common_refresh_token WHERE token = ?` → `Optional.ofNullable(uuid)`.
+  (Add a SQL constant next to the registration-token one.)
+
+### 2. `RefreshTokenService.refreshAccessToken(refreshToken)`
+- At the very start (before any RLS-bound read): `UUID tenantId = tenantQueryPort.findTenantIdByRefreshToken(refreshToken).orElseThrow(() -> new IllegalArgumentException("Invalid refresh token"));`
+- `TenantContext.setCurrentTenantId(tenantId)` + `tenantSessionBinder.bindToCurrentSession(tenantId)`.
+- Then keep the existing flow: `refreshTokenRepository.findByToken(...)` (now visible), validate (expired /
+  `isRevoked`), load the user (`findByTenantIdAndId(tenantId, userId)`), rotate (revoke old + issue new
+  refresh), issue new access token. **Remove the `TenantContext.requireTenantId()` reliance** — use the resolved
+  `tenantId` (context is already set).
+- Inject `TenantQueryPort` + `TenantSessionBinder`.
+
+### 3. `LogoutService.logoutByRefreshToken(refreshToken)`
+- Same bypass-resolve → `setCurrentTenantId` + `bindToCurrentSession` before `findByToken`, so anonymous
+  logout-by-cookie can find + revoke the token. (`logout(refreshToken, userId)` — the authenticated path using
+  `requireTenantId()` — is unchanged.)
+
+### 4. JWT `identity_id` claim (additive, defensive)
+- In `JwtService.buildCommonClaims(user)`, add `identity_id` resolved from the user's membership:
+  `membershipRepository.findByUserId(user.getId()).map(Membership::getLoginIdentityId)` → put `identity_id`
+  when present. If absent (legacy/edge), **skip the claim** (do not fail token generation). This sets up P4
+  switch-org; do not otherwise change token claims.
+
+## Acceptance
+- A valid refresh token (anonymous call, no tenant context) refreshes successfully: tenant resolved via bypass,
+  token rotated, new access + refresh returned. No more 401 on a valid token.
+- Session survives past the access-token lifetime (silent refresh works); FE "Return to my account" returns to
+  the owner and stays in the app (no login redirect).
+- Invalid / expired / revoked refresh token → the same clear error as before (no RLS false-negative).
+- `logoutByRefreshToken` finds + revokes the token from an anonymous (cookie-only) call.
+- JWT carries `identity_id` for users that have a membership; token generation still works when they don't.
+- New unit tests: refresh happy path (bypass-resolve + rotate), invalid/expired/revoked, logout-by-refresh
+  resolve, identity_id present/absent. Existing auth tests stay green.
+
+## Testing note
+Integration tests run as a Postgres **superuser** (Testcontainers) → RLS bypassed, so they won't prove the
+RLS-free win. Cover logic with unit tests; Fatih validates on the real (non-superuser) DB: log in, wait for the
+access token to expire (or force a refresh), confirm the session stays alive; in playground, use "View as…" then
+"Return to my account" and confirm it returns to the owner without a login redirect.
+
+## Out of scope (later)
+- P4: org-picker on multi-membership login + switch-organization UX (uses the new `identity_id`).
+- Removing `AuthUser` (still dual-written); moving refresh tokens onto the identity layer (kept per-tenant here).
+- System-worker RLS gap (email outbox + schedulers) — separate track.
+
+## Codex runs nothing
+Codex writes code + tests, hands Fatih `./mvnw -q fmt:format` + build/test commands + a conventional-commit
+message in `COMMIT_MSG_IDENTITY3.txt` (subject lowercase). Fatih runs everything, pastes output back; escalate to
+Claude if unsolved. Read canon/epic only if not already read this session.
+
+---
+### Türkçe özet (Fatih için)
+P3 = **refresh'i düzeltmek.** Bugün refresh anonim ama RLS'li tablodan token'ı arıyor → göremiyor → 401 → app
+"session bitti" deyip login'e atıyor; "Return to my account" da (refresh çağırdığı için) login'e düşüyor.
+Çözüm setup-password'un aynısı: refresh token'ın tenant'ını **BYPASSRLS** ile çöz → `TenantContext.set` +
+`TenantSessionBinder.bind` → sonra normal akış (bul/doğrula/rotate) RLS altında çalışır. `TenantQueryPort`'a
+`findTenantIdByRefreshToken` ekliyoruz; `RefreshTokenService` ve `LogoutService.logoutByRefreshToken` bunu
+kullanıyor. Ek olarak JWT'ye küçük, güvenli bir `identity_id` claim'i (P4 switch-org için). MFA zaten P2'de
+identity'ye geçmişti, ona dokunmuyoruz. Bu tek fix hem **session yenilemeyi** hem **"Return to my account"u**
+düzeltir.

--- a/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TenantQueryPort.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/tenant/TenantQueryPort.java
@@ -26,4 +26,11 @@ public interface TenantQueryPort {
    * RLS-bound reads. Runs via the BYPASSRLS system executor in the adapter.
    */
   Optional<UUID> findTenantIdByRegistrationToken(String token);
+
+  /**
+   * Pre-auth tenant resolution from a refresh token. Refresh is anonymous (no tenant context yet)
+   * so the tenant-scoped refresh-token table is invisible to RLS-bound reads. Runs via the
+   * BYPASSRLS system executor in the adapter.
+   */
+  Optional<UUID> findTenantIdByRefreshToken(String token);
 }

--- a/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/JwtService.java
@@ -2,6 +2,8 @@ package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
 import com.fabricmanagement.platform.common.exception.PlatformDomainException;
 import com.fabricmanagement.platform.organization.domain.Organization;
 import com.fabricmanagement.platform.organization.infra.repository.OrganizationRepository;
@@ -57,6 +59,7 @@ public class JwtService {
 
   private final TenantQueryPort tenantQueryPort;
   private final OrganizationRepository organizationRepository;
+  private final MembershipRepository membershipRepository;
   private final SecretKey secretKey;
   private final long accessTokenExpiration;
   private final long playgroundTokenExpiration;
@@ -64,12 +67,14 @@ public class JwtService {
   public JwtService(
       TenantQueryPort tenantQueryPort,
       OrganizationRepository organizationRepository,
+      MembershipRepository membershipRepository,
       @Value("${application.jwt.secret}") String secret,
       @Value("${application.jwt.expiration:900000}") long accessTokenExpiration,
       @Value("${application.jwt.playground-expiration:1209600000}")
           long playgroundTokenExpiration) {
     this.tenantQueryPort = tenantQueryPort;
     this.organizationRepository = organizationRepository;
+    this.membershipRepository = membershipRepository;
     this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     this.accessTokenExpiration = accessTokenExpiration;
     this.playgroundTokenExpiration = playgroundTokenExpiration;
@@ -176,6 +181,14 @@ public class JwtService {
     claims.put("organization_id", user.getOrganizationId().toString());
     claims.put("firstName", user.getFirstName());
     claims.put("lastName", user.getLastName());
+    try {
+      membershipRepository
+          .findByUserId(user.getId())
+          .map(Membership::getLoginIdentityId)
+          .ifPresent(identityId -> claims.put("identity_id", identityId.toString()));
+    } catch (RuntimeException ex) {
+      log.debug("Skipping identity_id claim: {}", ex.getMessage());
+    }
 
     List<String> departmentCodes = new ArrayList<>();
     String primaryDepartmentCode = null;

--- a/src/main/java/com/fabricmanagement/platform/auth/app/LogoutService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/LogoutService.java
@@ -2,6 +2,8 @@ package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.platform.auth.domain.RefreshToken;
 import com.fabricmanagement.platform.auth.domain.event.UserLogoutEvent;
 import com.fabricmanagement.platform.auth.dto.ActiveSessionDto;
@@ -26,6 +28,8 @@ public class LogoutService {
 
   private final RefreshTokenRepository refreshTokenRepository;
   private final DomainEventPublisher eventPublisher;
+  private final TenantQueryPort tenantQueryPort;
+  private final TenantSessionBinder tenantSessionBinder;
 
   /**
    * Logout user by revoking refresh token (requires authenticated context for userId).
@@ -78,26 +82,40 @@ public class LogoutService {
   @Transactional
   public void logoutByRefreshToken(String refreshToken) {
     log.info("Logout by refresh token (cookie)");
-    refreshTokenRepository
-        .findByToken(refreshToken)
+    tenantQueryPort
+        .findTenantIdByRefreshToken(refreshToken)
         .ifPresentOrElse(
-            token -> {
-              UUID tenantId = token.getTenantId();
-              UUID userId = token.getUserId();
-              token.revoke();
-              refreshTokenRepository.save(token);
-              eventPublisher.publish(new UserLogoutEvent(tenantId, userId));
-              log.info(
-                  "✅ Refresh token revoked (cookie logout): tokenId={}, userId={}",
-                  token.getId(),
-                  userId);
+            tenantId -> {
+              TenantContext.setCurrentTenantId(tenantId);
+              tenantSessionBinder.bindToCurrentSession(tenantId);
+              try {
+                refreshTokenRepository
+                    .findByToken(refreshToken)
+                    .ifPresentOrElse(
+                        token -> {
+                          UUID userId = token.getUserId();
+                          token.revoke();
+                          refreshTokenRepository.save(token);
+                          eventPublisher.publish(new UserLogoutEvent(tenantId, userId));
+                          log.info(
+                              "✅ Refresh token revoked (cookie logout): tokenId={}, userId={}",
+                              token.getId(),
+                              userId);
+                        },
+                        () -> logRefreshTokenNotFound(refreshToken));
+              } finally {
+                TenantContext.clear();
+              }
             },
-            () ->
-                log.warn(
-                    "Refresh token not found on logout: token={}***",
-                    refreshToken != null && !refreshToken.isEmpty()
-                        ? refreshToken.substring(0, Math.min(8, refreshToken.length()))
-                        : ""));
+            () -> logRefreshTokenNotFound(refreshToken));
+  }
+
+  private void logRefreshTokenNotFound(String refreshToken) {
+    log.warn(
+        "Refresh token not found on logout: token={}***",
+        refreshToken != null && !refreshToken.isEmpty()
+            ? refreshToken.substring(0, Math.min(8, refreshToken.length()))
+            : "");
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/platform/auth/app/RefreshTokenService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/RefreshTokenService.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.platform.auth.domain.RefreshToken;
 import com.fabricmanagement.platform.auth.dto.LoginResponse;
 import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
@@ -36,6 +38,8 @@ public class RefreshTokenService {
   private final UserRepository userRepository;
   private final UserFacade userFacade;
   private final JwtService jwtService;
+  private final TenantQueryPort tenantQueryPort;
+  private final TenantSessionBinder tenantSessionBinder;
 
   @Value("${application.jwt.expiration:900000}")
   private long accessTokenExpiration;
@@ -53,72 +57,86 @@ public class RefreshTokenService {
   public LoginResponse refreshAccessToken(String refreshToken) {
     log.info("Refresh token request");
 
-    // Find refresh token
-    RefreshToken token =
-        refreshTokenRepository
-            .findByToken(refreshToken)
+    UUID tenantId =
+        tenantQueryPort
+            .findTenantIdByRefreshToken(refreshToken)
             .orElseThrow(
                 () -> {
                   log.warn("Invalid refresh token");
                   return new IllegalArgumentException("Invalid refresh token");
                 });
+    TenantContext.setCurrentTenantId(tenantId);
+    tenantSessionBinder.bindToCurrentSession(tenantId);
 
-    // Validate token
-    if (!token.isValid()) {
-      log.warn("Refresh token expired or revoked: tokenId={}", token.getId());
-      throw new PlatformDomainException(
-          "Refresh token expired or revoked", "AUTH_REFRESH_TOKEN_INVALID", 401);
+    try {
+      // Find refresh token
+      RefreshToken token =
+          refreshTokenRepository
+              .findByToken(refreshToken)
+              .orElseThrow(
+                  () -> {
+                    log.warn("Invalid refresh token");
+                    return new IllegalArgumentException("Invalid refresh token");
+                  });
+
+      // Validate token
+      if (!token.isValid()) {
+        log.warn("Refresh token expired or revoked: tokenId={}", token.getId());
+        throw new PlatformDomainException(
+            "Refresh token expired or revoked", "AUTH_REFRESH_TOKEN_INVALID", 401);
+      }
+
+      UUID userId = token.getUserId();
+
+      // Get user
+      com.fabricmanagement.platform.user.domain.User user =
+          userRepository
+              .findByTenantIdAndId(tenantId, userId)
+              .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+      // Check user status
+      if (!user.getIsActive()) {
+        throw new PlatformDomainException(
+            "User account is deactivated", "AUTH_USER_DEACTIVATED", 403);
+      }
+
+      // Revoke old refresh token (token rotation)
+      token.revoke();
+      refreshTokenRepository.save(token);
+      log.debug("Old refresh token revoked: tokenId={}", token.getId());
+
+      // Generate new tokens
+      String newAccessToken = jwtService.generateAccessToken(user);
+      String newRefreshToken = jwtService.generateRefreshToken(user);
+
+      // Carry over device info from old token (same session, same device)
+      RefreshToken newRefreshTokenEntity =
+          RefreshToken.create(
+              user.getId(),
+              newRefreshToken,
+              Instant.now().plusMillis(refreshTokenExpiration),
+              token.getIpAddress(),
+              token.getUserAgent(),
+              token.getDeviceName());
+      refreshTokenRepository.save(newRefreshTokenEntity);
+
+      // Get UserDto for response
+      UserDto userDto =
+          userFacade
+              .findById(tenantId, userId)
+              .orElseThrow(() -> new IllegalArgumentException("User DTO not found"));
+
+      log.info("✅ Access token refreshed: userId={}, uid={}", userId, userDto.getUid());
+
+      return LoginResponse.builder()
+          .accessToken(newAccessToken)
+          .refreshToken(newRefreshToken)
+          .expiresIn(accessTokenExpiration / 1000)
+          .user(userDto)
+          .needsOnboarding(!user.hasCompletedOnboarding())
+          .build();
+    } finally {
+      TenantContext.clear();
     }
-
-    UUID tenantId = TenantContext.requireTenantId();
-    UUID userId = token.getUserId();
-
-    // Get user
-    com.fabricmanagement.platform.user.domain.User user =
-        userRepository
-            .findByTenantIdAndId(tenantId, userId)
-            .orElseThrow(() -> new IllegalArgumentException("User not found"));
-
-    // Check user status
-    if (!user.getIsActive()) {
-      throw new PlatformDomainException(
-          "User account is deactivated", "AUTH_USER_DEACTIVATED", 403);
-    }
-
-    // Revoke old refresh token (token rotation)
-    token.revoke();
-    refreshTokenRepository.save(token);
-    log.debug("Old refresh token revoked: tokenId={}", token.getId());
-
-    // Generate new tokens
-    String newAccessToken = jwtService.generateAccessToken(user);
-    String newRefreshToken = jwtService.generateRefreshToken(user);
-
-    // Carry over device info from old token (same session, same device)
-    RefreshToken newRefreshTokenEntity =
-        RefreshToken.create(
-            user.getId(),
-            newRefreshToken,
-            Instant.now().plusMillis(refreshTokenExpiration),
-            token.getIpAddress(),
-            token.getUserAgent(),
-            token.getDeviceName());
-    refreshTokenRepository.save(newRefreshTokenEntity);
-
-    // Get UserDto for response
-    UserDto userDto =
-        userFacade
-            .findById(tenantId, userId)
-            .orElseThrow(() -> new IllegalArgumentException("User DTO not found"));
-
-    log.info("✅ Access token refreshed: userId={}, uid={}", userId, userDto.getUid());
-
-    return LoginResponse.builder()
-        .accessToken(newAccessToken)
-        .refreshToken(newRefreshToken)
-        .expiresIn(accessTokenExpiration / 1000)
-        .user(userDto)
-        .needsOnboarding(!user.hasCompletedOnboarding())
-        .build();
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/adapter/TenantQueryAdapter.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/adapter/TenantQueryAdapter.java
@@ -39,6 +39,9 @@ public class TenantQueryAdapter implements TenantQueryPort {
   private static final String SELECT_TENANT_ID_BY_REG_TOKEN =
       "SELECT tenant_id FROM common_auth.common_registration_token WHERE token = ?";
 
+  private static final String SELECT_TENANT_ID_BY_REFRESH_TOKEN =
+      "SELECT tenant_id FROM common_auth.common_refresh_token WHERE token = ?";
+
   @Override
   public List<TenantReference> findAllActiveTenants() {
     return systemExecutor.executeQuery(
@@ -88,6 +91,16 @@ public class TenantQueryAdapter implements TenantQueryPort {
     UUID tenantId =
         systemExecutor.executeQueryForObject(
             SELECT_TENANT_ID_BY_REG_TOKEN, (rs, i) -> rs.getObject("tenant_id", UUID.class), token);
+    return Optional.ofNullable(tenantId);
+  }
+
+  @Override
+  public Optional<UUID> findTenantIdByRefreshToken(String token) {
+    UUID tenantId =
+        systemExecutor.executeQueryForObject(
+            SELECT_TENANT_ID_BY_REFRESH_TOKEN,
+            (rs, i) -> rs.getObject("tenant_id", UUID.class),
+            token);
     return Optional.ofNullable(tenantId);
   }
 }

--- a/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/JwtServiceTest.java
@@ -1,10 +1,14 @@
 package com.fabricmanagement.platform.auth.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.platform.auth.domain.Membership;
+import com.fabricmanagement.platform.auth.infra.repository.MembershipRepository;
 import com.fabricmanagement.platform.communication.domain.Contact;
 import com.fabricmanagement.platform.communication.domain.ContactType;
 import com.fabricmanagement.platform.organization.domain.Department;
@@ -22,6 +26,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 import javax.crypto.SecretKey;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -35,13 +40,21 @@ class JwtServiceTest {
   private final TenantQueryPort tenantQueryPort = org.mockito.Mockito.mock(TenantQueryPort.class);
   private final OrganizationRepository organizationRepository =
       org.mockito.Mockito.mock(OrganizationRepository.class);
+  private final MembershipRepository membershipRepository =
+      org.mockito.Mockito.mock(MembershipRepository.class);
   private final JwtService jwtService =
       new JwtService(
           tenantQueryPort,
           organizationRepository,
+          membershipRepository,
           SECRET,
           ACCESS_TOKEN_EXPIRATION,
           PLAYGROUND_TOKEN_EXPIRATION);
+
+  @BeforeEach
+  void setUp() {
+    lenient().when(membershipRepository.findByUserId(any(UUID.class))).thenReturn(Optional.empty());
+  }
 
   @Test
   @DisplayName("regular access token uses application.jwt.expiration")
@@ -151,6 +164,46 @@ class JwtServiceTest {
             jwtService.generatePlaygroundAccessToken(user, "guest-123", "guest@example.com"));
 
     assertThat(secondsUntilExpiry).isBetween(1_209_595L, 1_209_600L);
+  }
+
+  @Test
+  @DisplayName("access token includes identity_id when membership exists")
+  void generateAccessToken_includesIdentityIdWhenMembershipExists() {
+    User user = buildUser();
+    UUID identityId = UUID.randomUUID();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+    when(organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId()))
+        .thenReturn(Optional.empty());
+    when(membershipRepository.findByUserId(user.getId()))
+        .thenReturn(
+            Optional.of(
+                Membership.builder()
+                    .loginIdentityId(identityId)
+                    .tenantId(user.getTenantId())
+                    .userId(user.getId())
+                    .build()));
+
+    Claims claims = parse(jwtService.generateAccessToken(user));
+
+    assertThat(claims.get("identity_id", String.class)).isEqualTo(identityId.toString());
+  }
+
+  @Test
+  @DisplayName("access token omits identity_id when membership is absent")
+  void generateAccessToken_omitsIdentityIdWhenMembershipAbsent() {
+    User user = buildUser();
+    when(tenantQueryPort.findById(user.getTenantId()))
+        .thenReturn(
+            Optional.of(new TenantReference(user.getTenantId(), "TEST-001", "Test", "TENANT")));
+    when(organizationRepository.findByTenantIdAndId(user.getTenantId(), user.getOrganizationId()))
+        .thenReturn(Optional.empty());
+    when(membershipRepository.findByUserId(user.getId())).thenReturn(Optional.empty());
+
+    Claims claims = parse(jwtService.generateAccessToken(user));
+
+    assertThat(claims.get("identity_id", String.class)).isNull();
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/platform/auth/app/LogoutServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/LogoutServiceTest.java
@@ -1,0 +1,93 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.platform.auth.domain.RefreshToken;
+import com.fabricmanagement.platform.auth.domain.event.UserLogoutEvent;
+import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LogoutServiceTest {
+
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private DomainEventPublisher eventPublisher;
+  @Mock private TenantQueryPort tenantQueryPort;
+  @Mock private TenantSessionBinder tenantSessionBinder;
+
+  @InjectMocks private LogoutService logoutService;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void shouldResolveTenantThenLogoutByRefreshToken() {
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    String refreshTokenValue = "refresh-token";
+    RefreshToken refreshToken =
+        RefreshToken.create(
+            userId,
+            refreshTokenValue,
+            Instant.now().plusSeconds(60),
+            "127.0.0.1",
+            "agent",
+            "browser");
+    refreshToken.setId(UUID.randomUUID());
+    refreshToken.setTenantId(tenantId);
+
+    when(tenantQueryPort.findTenantIdByRefreshToken(refreshTokenValue))
+        .thenReturn(Optional.of(tenantId));
+    when(refreshTokenRepository.findByToken(refreshTokenValue))
+        .thenReturn(Optional.of(refreshToken));
+
+    logoutService.logoutByRefreshToken(refreshTokenValue);
+
+    assertThat(refreshToken.getIsRevoked()).isTrue();
+    verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+    verify(refreshTokenRepository).save(refreshToken);
+
+    ArgumentCaptor<UserLogoutEvent> eventCaptor = ArgumentCaptor.forClass(UserLogoutEvent.class);
+    verify(eventPublisher).publish(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getTenantId()).isEqualTo(tenantId);
+    assertThat(eventCaptor.getValue().getUserId()).isEqualTo(userId);
+
+    InOrder inOrder = inOrder(tenantQueryPort, tenantSessionBinder, refreshTokenRepository);
+    inOrder.verify(tenantQueryPort).findTenantIdByRefreshToken(refreshTokenValue);
+    inOrder.verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+    inOrder.verify(refreshTokenRepository).findByToken(refreshTokenValue);
+  }
+
+  @Test
+  void shouldSkipRepositoryLookupWhenRefreshTokenTenantCannotBeResolved() {
+    when(tenantQueryPort.findTenantIdByRefreshToken("missing-refresh-token"))
+        .thenReturn(Optional.empty());
+
+    logoutService.logoutByRefreshToken("missing-refresh-token");
+
+    verify(refreshTokenRepository, never()).findByToken(any());
+    verify(refreshTokenRepository, never()).save(any());
+    verify(eventPublisher, never()).publish(any());
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/auth/app/RefreshTokenServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/RefreshTokenServiceTest.java
@@ -1,0 +1,171 @@
+package com.fabricmanagement.platform.auth.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.platform.auth.domain.RefreshToken;
+import com.fabricmanagement.platform.auth.dto.LoginResponse;
+import com.fabricmanagement.platform.auth.infra.repository.RefreshTokenRepository;
+import com.fabricmanagement.platform.common.exception.PlatformDomainException;
+import com.fabricmanagement.platform.communication.domain.Contact;
+import com.fabricmanagement.platform.communication.domain.ContactType;
+import com.fabricmanagement.platform.user.api.facade.UserFacade;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.domain.UserContact;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+  @Mock private RefreshTokenRepository refreshTokenRepository;
+  @Mock private UserRepository userRepository;
+  @Mock private UserFacade userFacade;
+  @Mock private JwtService jwtService;
+  @Mock private TenantQueryPort tenantQueryPort;
+  @Mock private TenantSessionBinder tenantSessionBinder;
+
+  @InjectMocks private RefreshTokenService refreshTokenService;
+
+  @BeforeEach
+  void setUp() {
+    ReflectionTestUtils.setField(refreshTokenService, "accessTokenExpiration", 900_000L);
+    ReflectionTestUtils.setField(refreshTokenService, "refreshTokenExpiration", 604_800_000L);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void shouldResolveTenantThenRotateRefreshToken() {
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    String oldTokenValue = "old-refresh-token";
+    String newTokenValue = "new-refresh-token";
+    RefreshToken oldToken =
+        refreshToken(userId, tenantId, oldTokenValue, Instant.now().plusSeconds(60));
+    User user = user(tenantId, userId);
+    UserDto userDto = UserDto.builder().id(userId).tenantId(tenantId).uid("TEN-001-USER-1").build();
+
+    when(tenantQueryPort.findTenantIdByRefreshToken(oldTokenValue))
+        .thenReturn(Optional.of(tenantId));
+    when(refreshTokenRepository.findByToken(oldTokenValue)).thenReturn(Optional.of(oldToken));
+    when(userRepository.findByTenantIdAndId(tenantId, userId)).thenReturn(Optional.of(user));
+    when(jwtService.generateAccessToken(user)).thenReturn("new-access-token");
+    when(jwtService.generateRefreshToken(user)).thenReturn(newTokenValue);
+    when(userFacade.findById(tenantId, userId)).thenReturn(Optional.of(userDto));
+
+    LoginResponse response = refreshTokenService.refreshAccessToken(oldTokenValue);
+
+    assertThat(response.getAccessToken()).isEqualTo("new-access-token");
+    assertThat(response.getRefreshToken()).isEqualTo(newTokenValue);
+    assertThat(oldToken.getIsRevoked()).isTrue();
+    verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+
+    InOrder inOrder = inOrder(tenantQueryPort, tenantSessionBinder, refreshTokenRepository);
+    inOrder.verify(tenantQueryPort).findTenantIdByRefreshToken(oldTokenValue);
+    inOrder.verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+    inOrder.verify(refreshTokenRepository).findByToken(oldTokenValue);
+
+    ArgumentCaptor<RefreshToken> tokenCaptor = ArgumentCaptor.forClass(RefreshToken.class);
+    verify(refreshTokenRepository, org.mockito.Mockito.times(2)).save(tokenCaptor.capture());
+    assertThat(tokenCaptor.getAllValues().get(1).getToken()).isEqualTo(newTokenValue);
+    assertThat(tokenCaptor.getAllValues().get(1).getUserId()).isEqualTo(userId);
+  }
+
+  @Test
+  void shouldRejectInvalidRefreshTokenBeforeRlsBoundLookup() {
+    when(tenantQueryPort.findTenantIdByRefreshToken("missing-token")).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> refreshTokenService.refreshAccessToken("missing-token"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid refresh token");
+
+    verify(refreshTokenRepository, never()).findByToken(any());
+  }
+
+  @Test
+  void shouldRejectExpiredRefreshToken() {
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    RefreshToken token =
+        refreshToken(userId, tenantId, "expired-token", Instant.now().minusSeconds(1));
+
+    when(tenantQueryPort.findTenantIdByRefreshToken("expired-token"))
+        .thenReturn(Optional.of(tenantId));
+    when(refreshTokenRepository.findByToken("expired-token")).thenReturn(Optional.of(token));
+
+    assertThatThrownBy(() -> refreshTokenService.refreshAccessToken("expired-token"))
+        .isInstanceOf(PlatformDomainException.class)
+        .satisfies(
+            exception ->
+                assertThat(((PlatformDomainException) exception).getErrorCode())
+                    .isEqualTo("AUTH_REFRESH_TOKEN_INVALID"));
+  }
+
+  @Test
+  void shouldRejectRevokedRefreshToken() {
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    RefreshToken token =
+        refreshToken(userId, tenantId, "revoked-token", Instant.now().plusSeconds(60));
+    token.revoke();
+
+    when(tenantQueryPort.findTenantIdByRefreshToken("revoked-token"))
+        .thenReturn(Optional.of(tenantId));
+    when(refreshTokenRepository.findByToken("revoked-token")).thenReturn(Optional.of(token));
+
+    assertThatThrownBy(() -> refreshTokenService.refreshAccessToken("revoked-token"))
+        .isInstanceOf(PlatformDomainException.class)
+        .satisfies(
+            exception ->
+                assertThat(((PlatformDomainException) exception).getErrorCode())
+                    .isEqualTo("AUTH_REFRESH_TOKEN_INVALID"));
+  }
+
+  private RefreshToken refreshToken(UUID userId, UUID tenantId, String token, Instant expiresAt) {
+    RefreshToken refreshToken =
+        RefreshToken.create(userId, token, expiresAt, "127.0.0.1", "agent", "browser");
+    refreshToken.setId(UUID.randomUUID());
+    refreshToken.setTenantId(tenantId);
+    return refreshToken;
+  }
+
+  private User user(UUID tenantId, UUID userId) {
+    Contact contact =
+        Contact.builder()
+            .contactType(ContactType.EMAIL)
+            .contactValue("refresh@example.com")
+            .isVerified(true)
+            .build();
+    User user = User.create("Refresh", "User", UUID.randomUUID());
+    user.setId(userId);
+    user.setTenantId(tenantId);
+    user.setUid("TEN-001-USER-1");
+    user.getUserContacts().add(UserContact.builder().contact(contact).isDefault(true).build());
+    return user;
+  }
+}


### PR DESCRIPTION
Resolve refresh-token tenant ids through TenantQueryPort with the system executor before refresh and cookie logout read the RLS-scoped refresh token table.

Bind TenantContext and the current DB session from the resolved tenant, then keep the existing refresh validation, rotation, and logout behavior unchanged.

Add identity_id to access-token claims when a membership exists, while keeping token generation tolerant of absent membership data.

Cover refresh rotation, invalid/expired/revoked refresh tokens, cookie logout resolution, and identity_id claim presence/absence.