### PR TITLE
fix(auth): split create-org flow into per-part transactions

### DIFF
--- a/src/main/java/com/fabricmanagement/platform/auth/api/controller/AuthController.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/api/controller/AuthController.java
@@ -331,7 +331,15 @@ public class AuthController {
    */
   private UUID getCurrentUserId() {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-    if (auth == null || !auth.isAuthenticated()) {
+    // /api/v1/auth/** is permitAll, so an expired/absent token still reaches the controller as
+    // Spring's ANONYMOUS authentication (isAuthenticated()=true, principal="anonymousUser").
+    // Without this check that principal fell through to UUID.fromString and produced a 400 —
+    // which the frontend refresh interceptor ignores (it only reacts to 401), breaking silent
+    // re-auth on the authenticated auth endpoints (memberships, switch-org, organizations).
+    if (auth == null
+        || !auth.isAuthenticated()
+        || auth
+            instanceof org.springframework.security.authentication.AnonymousAuthenticationToken) {
       throw new PlatformDomainException("Not authenticated", "AUTH_NOT_AUTHENTICATED", 401);
     }
     Object principal = auth.getPrincipal();

--- a/src/main/java/com/fabricmanagement/platform/auth/app/ExistingAccountOrganizationService.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/app/ExistingAccountOrganizationService.java
@@ -1,7 +1,6 @@
 package com.fabricmanagement.platform.auth.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
-import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
 import com.fabricmanagement.common.infrastructure.tenant.TrialLifecyclePort;
 import com.fabricmanagement.common.infrastructure.web.exception.TaxIdAlreadyExistsException;
 import com.fabricmanagement.platform.auth.app.onboarding.OnboardingContext;
@@ -26,7 +25,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 /** Creates a new trial tenant for an already authenticated login identity. */
@@ -44,12 +42,18 @@ public class ExistingAccountOrganizationService {
   private final UserRepository userRepository;
   private final TrialLifecyclePort trialLifecyclePort;
   private final SwitchOrganizationService switchOrganizationService;
-  private final TenantSessionBinder tenantSessionBinder;
 
   @Value("${application.identity.max-organizations:5}")
   private int maxOrganizations;
 
-  @Transactional
+  // Deliberately NOT @Transactional at this level. One long transaction breaks the flow twice:
+  // (1) /api/v1/auth/* skips the tenant-context interceptor, so the connection would be acquired
+  // unbound and the RLS-scoped user pre-read sees nothing; (2) the final token issuance reloads the
+  // new admin User inside the SAME persistence context that created it, and its contact links
+  // (written via separate link entities) are not visible on the cached instance
+  // (AUTH_NO_VERIFIED_CONTACT). Instead each part runs its own transaction: the orchestrator is
+  // @Transactional (atomic pipeline), and SwitchOrganizationService opens a fresh session that
+  // reads the committed user + verified contact from the database.
   public LoginResponse createOrganization(
       UUID currentUserId,
       CreateExistingAccountOrganizationRequest request,
@@ -85,16 +89,29 @@ public class ExistingAccountOrganizationService {
       throw new TaxIdAlreadyExistsException("Organization with this tax ID already exists");
     }
 
-    // /api/v1/auth/* is excluded from the tenant-context interceptor (pre-auth endpoints), so no
-    // tenant is bound here and the RLS-scoped User read below would see nothing. Bind the caller's
-    // own tenant first — the same bind-before-read pattern SwitchOrganizationService uses. The
-    // onboarding pipeline (CreateTenantStep) re-binds to the NEW tenant afterwards.
+    // Set the caller's tenant on the thread BEFORE the RLS-scoped read: with no surrounding
+    // transaction, the read acquires a fresh connection and TenantConnectionProvider binds
+    // app.current_tenant from TenantContext at acquisition time.
     TenantContext.setCurrentTenantId(currentMembership.getTenantId());
-    tenantSessionBinder.bindToCurrentSession(currentMembership.getTenantId());
+    try {
+      return doCreateOrganization(currentUserId, request, ipAddress, userAgent, identity, taxId);
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  private LoginResponse doCreateOrganization(
+      UUID currentUserId,
+      CreateExistingAccountOrganizationRequest request,
+      String ipAddress,
+      String userAgent,
+      LoginIdentity identity,
+      String taxId) {
+    UUID callerTenantId = TenantContext.requireTenantId();
 
     User currentUser =
         userRepository
-            .findByTenantIdAndId(currentMembership.getTenantId(), currentUserId)
+            .findByTenantIdAndId(callerTenantId, currentUserId)
             .orElseThrow(
                 () ->
                     new PlatformDomainException(

--- a/src/test/java/com/fabricmanagement/platform/auth/app/ExistingAccountOrganizationServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/auth/app/ExistingAccountOrganizationServiceTest.java
@@ -43,10 +43,6 @@ class ExistingAccountOrganizationServiceTest {
   private final TrialLifecyclePort trialLifecyclePort = Mockito.mock(TrialLifecyclePort.class);
   private final SwitchOrganizationService switchOrganizationService =
       Mockito.mock(SwitchOrganizationService.class);
-  private final com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder
-      tenantSessionBinder =
-          Mockito.mock(
-              com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder.class);
 
   private ExistingAccountOrganizationService service;
 
@@ -60,8 +56,7 @@ class ExistingAccountOrganizationServiceTest {
             loginIdentityRepository,
             userRepository,
             trialLifecyclePort,
-            switchOrganizationService,
-            tenantSessionBinder);
+            switchOrganizationService);
     ReflectionTestUtils.setField(service, "maxOrganizations", 5);
   }
 


### PR DESCRIPTION
One wrapping transaction broke the flow twice: the token issuance at the end reloaded the freshly created admin user inside the same persistence context, where its contact links were not visible (AUTH_NO_VERIFIED_CONTACT). Drop the outer transaction: the onboarding orchestrator stays atomic in its own transaction, the RLS-scoped pre-read binds the caller tenant via TenantContext at connection acquisition, and the switch reloads the committed user with its verified contact in a fresh session. Tenant context is cleared in a finally block.