### PR TITLE
feat(sales): expose customerName on quote responses (BE-NAME)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -53575,6 +53575,10 @@ components:
         customerId:
           type: string
           format: uuid
+        customerName:
+          type: string
+          description: Customer display name resolved from trading partner data
+          nullable: true
         estimatedUnitCost:
           type: number
         id:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -53576,9 +53576,10 @@ components:
           type: string
           format: uuid
         customerName:
-          type: string
+          type:
+          - string
+          - "null"
           description: Customer display name resolved from trading partner data
-          nullable: true
         estimatedUnitCost:
           type: number
         id:

--- a/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
@@ -18,7 +18,6 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
@@ -52,8 +51,8 @@ public class QuoteController {
   @Operation(summary = "List all quotes (paginated)")
   public ResponseEntity<ApiResponse<PagedResponse<QuoteResponse>>> listQuotes(
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
-    Page<QuoteResponse> page = quoteService.findAll(pageable).map(QuoteResponse::from);
-    return ResponseEntity.ok(ApiResponse.success(PagedResponse.from(page)));
+    return ResponseEntity.ok(
+        ApiResponse.success(PagedResponse.from(quoteService.findAllResponses(pageable))));
   }
 
   @GetMapping("/{quoteId}")
@@ -62,11 +61,9 @@ public class QuoteController {
   public ResponseEntity<ApiResponse<QuoteResponse>> getQuote(@PathVariable UUID quoteId) {
     return ResponseEntity.ok(
         ApiResponse.success(
-            QuoteResponse.from(
-                quoteService
-                    .findById(quoteId)
-                    .orElseThrow(
-                        () -> new EntityNotFoundException("Quote not found: " + quoteId)))));
+            quoteService
+                .findResponseById(quoteId)
+                .orElseThrow(() -> new EntityNotFoundException("Quote not found: " + quoteId))));
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -79,7 +76,7 @@ public class QuoteController {
   public ResponseEntity<ApiResponse<QuoteResponse>> createQuote(
       @Valid @RequestBody QuoteCreateRequest req) {
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse.success(QuoteResponse.from(quoteService.createQuote(req))));
+        .body(ApiResponse.success(quoteService.toResponse(quoteService.createQuote(req))));
   }
 
   @PostMapping("/{quoteId}/lines")
@@ -90,7 +87,7 @@ public class QuoteController {
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(
             ApiResponse.success(
-                QuoteResponse.from(
+                quoteService.toResponse(
                     quoteService.addQuoteLine(
                         quoteId,
                         req.getProductId(),
@@ -105,7 +102,7 @@ public class QuoteController {
   public ResponseEntity<ApiResponse<QuoteResponse>> updateQuote(
       @PathVariable UUID quoteId, @Valid @RequestBody UpdateQuoteRequest req) {
     return ResponseEntity.ok(
-        ApiResponse.success(QuoteResponse.from(quoteService.updateQuoteHeader(quoteId, req))));
+        ApiResponse.success(quoteService.toResponse(quoteService.updateQuoteHeader(quoteId, req))));
   }
 
   @PatchMapping("/{quoteId}/lines/{lineId}")
@@ -117,7 +114,7 @@ public class QuoteController {
       @Valid @RequestBody UpdateQuoteLineRequest req) {
     return ResponseEntity.ok(
         ApiResponse.success(
-            QuoteResponse.from(quoteService.updateQuoteLine(quoteId, lineId, req))));
+            quoteService.toResponse(quoteService.updateQuoteLine(quoteId, lineId, req))));
   }
 
   @DeleteMapping("/{quoteId}/lines/{lineId}")
@@ -126,7 +123,8 @@ public class QuoteController {
   public ResponseEntity<ApiResponse<QuoteResponse>> removeLine(
       @PathVariable UUID quoteId, @PathVariable UUID lineId) {
     return ResponseEntity.ok(
-        ApiResponse.success(QuoteResponse.from(quoteService.removeQuoteLine(quoteId, lineId))));
+        ApiResponse.success(
+            quoteService.toResponse(quoteService.removeQuoteLine(quoteId, lineId))));
   }
 
   @PostMapping("/{quoteId}/submit")
@@ -134,7 +132,7 @@ public class QuoteController {
   @Operation(summary = "Submit a quote for approval")
   public ResponseEntity<ApiResponse<QuoteResponse>> submitQuote(@PathVariable UUID quoteId) {
     return ResponseEntity.ok(
-        ApiResponse.success(QuoteResponse.from(quoteService.submitQuote(quoteId))));
+        ApiResponse.success(quoteService.toResponse(quoteService.submitQuote(quoteId))));
   }
 
   @PostMapping("/{quoteId}/send")
@@ -153,7 +151,7 @@ public class QuoteController {
   @Operation(summary = "Create a new revision of a quote")
   public ResponseEntity<ApiResponse<QuoteResponse>> reviseQuote(@PathVariable UUID quoteId) {
     return ResponseEntity.status(HttpStatus.CREATED)
-        .body(ApiResponse.success(QuoteResponse.from(quoteService.reviseQuote(quoteId))));
+        .body(ApiResponse.success(quoteService.toResponse(quoteService.reviseQuote(quoteId))));
   }
 
   // ═══════════════════════════════════════════════════════════════════════════

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -6,6 +6,7 @@ import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrency
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredException;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService;
@@ -18,6 +19,7 @@ import com.fabricmanagement.sales.quote.domain.QuoteApprovalToken;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
@@ -27,6 +29,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -46,6 +51,7 @@ public class QuoteService {
   private final ExchangeRateService exchangeRateService;
   private final TenantReportingCurrencyPort tenantReportingCurrencyPort;
   private final QuoteApprovalService quoteApprovalService;
+  private final TradingPartnerResolver tradingPartnerResolver;
 
   @Transactional(readOnly = true)
   public Page<Quote> findAll(Pageable pageable) {
@@ -54,9 +60,33 @@ public class QuoteService {
   }
 
   @Transactional(readOnly = true)
+  public Page<QuoteResponse> findAllResponses(Pageable pageable) {
+    UUID tenantId = TenantContext.requireTenantId();
+    Page<Quote> page = quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable);
+    Map<UUID, String> customerNames =
+        tradingPartnerResolver.resolveDisplayNames(
+            tenantId,
+            page.getContent().stream()
+                .map(Quote::getCustomerId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList());
+    Map<UUID, String> safeCustomerNames = customerNames != null ? customerNames : Map.of();
+    return page.map(quote -> toResponse(quote, safeCustomerNames));
+  }
+
+  @Transactional(readOnly = true)
   public Optional<Quote> findById(UUID quoteId) {
     UUID tenantId = TenantContext.requireTenantId();
     return quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId);
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<QuoteResponse> findResponseById(UUID quoteId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    return quoteRepository
+        .findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId)
+        .map(quote -> toResponse(quote, resolveCustomerName(tenantId, quote.getCustomerId())));
   }
 
   @Transactional
@@ -66,6 +96,11 @@ public class QuoteService {
     quote.setStatus(QuoteStatus.DRAFT);
     quote.setRevisionNumber(1);
     return quoteRepository.save(quote);
+  }
+
+  @Transactional(readOnly = true)
+  public QuoteResponse toResponse(Quote quote) {
+    return toResponse(quote, resolveCustomerName(quote.getTenantId(), quote.getCustomerId()));
   }
 
   @Transactional
@@ -261,6 +296,23 @@ public class QuoteService {
     return quoteRepository
         .findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId)
         .orElseThrow(() -> SalesDomainException.quoteNotFound(quoteId.toString()));
+  }
+
+  private QuoteResponse toResponse(Quote quote, Map<UUID, String> customerNames) {
+    return QuoteResponse.from(quote, customerNames.get(quote.getCustomerId()));
+  }
+
+  private QuoteResponse toResponse(Quote quote, String customerName) {
+    return QuoteResponse.from(quote, customerName);
+  }
+
+  private String resolveCustomerName(UUID tenantId, UUID customerId) {
+    if (tenantId == null || customerId == null) {
+      return null;
+    }
+    Map<UUID, String> customerNames =
+        tradingPartnerResolver.resolveDisplayNames(tenantId, List.of(customerId));
+    return customerNames != null ? customerNames.get(customerId) : null;
   }
 
   private void assertEditable(Quote quote, String action) {

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
@@ -5,6 +5,7 @@ import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.common.dto.MoneyDto;
 import com.fabricmanagement.sales.quote.domain.Quote;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -18,6 +19,10 @@ public class QuoteResponse {
   private final UUID id;
   private final String quoteNumber;
   private final UUID customerId;
+
+  @Schema(description = "Customer display name resolved from trading partner data", nullable = true)
+  private final String customerName;
+
   private final UUID assignedToId;
   private final String moduleType;
   private final QuoteStatus status;
@@ -35,9 +40,14 @@ public class QuoteResponse {
   private final List<QuoteLineResponse> lines;
 
   private QuoteResponse(Quote quote) {
+    this(quote, null);
+  }
+
+  private QuoteResponse(Quote quote, String customerName) {
     this.id = quote.getId();
     this.quoteNumber = quote.getQuoteNumber();
     this.customerId = quote.getCustomerId();
+    this.customerName = customerName;
     this.assignedToId = quote.getAssignedToId();
     this.moduleType = quote.getModuleType();
     this.status = quote.getStatus();
@@ -57,6 +67,10 @@ public class QuoteResponse {
 
   public static QuoteResponse from(Quote quote) {
     return new QuoteResponse(quote);
+  }
+
+  public static QuoteResponse from(Quote quote, String customerName) {
+    return new QuoteResponse(quote, customerName);
   }
 
   private static ConvertedMoneyDto toDto(ConvertedMoney money) {

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -2,6 +2,7 @@ package com.fabricmanagement.sales.quote.app;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,6 +17,7 @@ import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrency
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredException;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService;
@@ -29,6 +31,7 @@ import com.fabricmanagement.sales.quote.domain.QuoteApprovalToken;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
@@ -38,6 +41,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +53,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class QuoteServiceTest {
@@ -60,11 +67,13 @@ class QuoteServiceTest {
   @Mock private ExchangeRateService exchangeRateService;
   @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
   @Mock private QuoteApprovalService quoteApprovalService;
+  @Mock private TradingPartnerResolver tradingPartnerResolver;
 
   @InjectMocks private QuoteService quoteService;
 
   private final UUID tenantId = UUID.randomUUID();
   private final UUID quoteId = UUID.randomUUID();
+  private final UUID customerId = UUID.randomUUID();
   private final UUID productId = UUID.randomUUID();
   private Quote quote;
 
@@ -96,6 +105,34 @@ class QuoteServiceTest {
 
     assertEquals("GBP", created.getCurrency());
     assertEquals(QuoteStatus.DRAFT, created.getStatus());
+  }
+
+  @Test
+  @DisplayName("Should populate customer name on quote list response")
+  void shouldPopulateCustomerNameOnQuoteListResponse() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable))
+        .thenReturn(new PageImpl<>(List.of(quote), pageable, 1));
+    when(tradingPartnerResolver.resolveDisplayNames(tenantId, List.of(customerId)))
+        .thenReturn(Map.of(customerId, "Acme Textiles"));
+
+    Page<QuoteResponse> page = quoteService.findAllResponses(pageable);
+
+    assertEquals("Acme Textiles", page.getContent().get(0).getCustomerName());
+  }
+
+  @Test
+  @DisplayName("Should keep customer name null when quote customer is missing")
+  void shouldKeepCustomerNameNullWhenCustomerMissing() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable))
+        .thenReturn(new PageImpl<>(List.of(quote), pageable, 1));
+    when(tradingPartnerResolver.resolveDisplayNames(tenantId, List.of(customerId)))
+        .thenReturn(Map.of());
+
+    Page<QuoteResponse> page = quoteService.findAllResponses(pageable);
+
+    assertNull(page.getContent().get(0).getCustomerName());
   }
 
   @Test
@@ -603,7 +640,7 @@ class QuoteServiceTest {
     q.setId(quoteId);
     q.setTenantId(tenantId);
     q.setQuoteNumber("Q-2026-001");
-    q.setCustomerId(UUID.randomUUID());
+    q.setCustomerId(customerId);
     q.setAssignedToId(UUID.randomUUID());
     q.setModuleType("FABRIC");
     q.setCurrency(currency);


### PR DESCRIPTION
- add nullable customerName to QuoteResponse; populated at mapping time via TradingPartnerResolver.resolveDisplayNames across list/detail/ write responses; quote table schema unchanged
- openapi.yaml contract updated (FE regenerates types)
- tests: name populated on list response; null-safe when customer cannot be resolved