### PR TITLE
feat(sales): role-gated quote send via send-requests (APPROVAL-1 BE)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -38276,7 +38276,7 @@ paths:
           content:
             '*/*':
               schema:
-                $ref: "#/components/schemas/ApiResponseQuoteApprovalTokenDto"
+                $ref: "#/components/schemas/ApiResponseSendQuoteResponse"
           description: OK
         "400":
           content:
@@ -38329,7 +38329,167 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
-      summary: Send a quote approval email to the customer
+      summary: Send a quote to a customer or request internal send approval
+      tags:
+      - Quotes
+  /api/v1/sales/quotes/{quoteId}/send-requests/{requestId}/approve:
+    post:
+      operationId: approveSendRequest
+      parameters:
+      - in: path
+        name: quoteId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        name: requestId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseSendQuoteResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Approve a quote send request and send the quote to the customer
+      tags:
+      - Quotes
+  /api/v1/sales/quotes/{quoteId}/send-requests/{requestId}/reject:
+    post:
+      operationId: rejectSendRequest
+      parameters:
+      - in: path
+        name: quoteId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        name: requestId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectQuoteSendRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseQuoteSendRequestDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Reject a quote send request
       tags:
       - Quotes
   /api/v1/sales/quotes/{quoteId}/submit:
@@ -45357,6 +45517,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponseQuoteSendRequestDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/QuoteSendRequestDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseReceivablesSummaryDto:
       type: object
       properties:
@@ -45488,6 +45666,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/SampleRequestDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseSendQuoteResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/SendQuoteResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -54040,6 +54236,53 @@ components:
         validUntil:
           type: string
           format: date
+    QuoteSendRequestDto:
+      type: object
+      description: Internal approval request for sending a quote to a customer contact
+      properties:
+        channel:
+          type: string
+          enum:
+          - EMAIL
+          - WHATSAPP
+          - IN_PERSON
+        contactId:
+          type: string
+          format: uuid
+        decidedAt:
+          type: string
+          format: date-time
+        decidedBy:
+          type: string
+          format: uuid
+        decisionNote:
+          type: string
+        id:
+          type: string
+          format: uuid
+        quoteId:
+          type: string
+          format: uuid
+        requestedAt:
+          type: string
+          format: date-time
+        requestedBy:
+          type: string
+          format: uuid
+        status:
+          type: string
+          enum:
+          - PENDING
+          - APPROVED
+          - REJECTED
+      required:
+      - channel
+      - contactId
+      - id
+      - quoteId
+      - requestedAt
+      - requestedBy
+      - status
     RealizedFxCurrencyDto:
       type: object
       properties:
@@ -54436,6 +54679,16 @@ components:
           minLength: 10
       required:
       - reviewNote
+    RejectQuoteSendRequest:
+      type: object
+      description: Decision note for rejecting a quote send request
+      properties:
+        decisionNote:
+          type: string
+          maxLength: 1000
+          minLength: 0
+      required:
+      - decisionNote
     RejectRequestDto:
       type: object
       properties:
@@ -55047,6 +55300,21 @@ components:
           format: uuid
       required:
       - contactId
+    SendQuoteResponse:
+      type: object
+      description: Result of a quote send attempt
+      properties:
+        approvalToken:
+          $ref: "#/components/schemas/QuoteApprovalTokenDto"
+        result:
+          type: string
+          enum:
+          - SENT
+          - AWAITING_APPROVAL
+        sendRequest:
+          $ref: "#/components/schemas/QuoteSendRequestDto"
+      required:
+      - result
     ShipmentDto:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/flowboard/generator/app/SmartTaskGeneratorListener.java
+++ b/src/main/java/com/fabricmanagement/flowboard/generator/app/SmartTaskGeneratorListener.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.common.domain.event.production.WorkOrderRecipeAssign
 import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
 import com.fabricmanagement.production.execution.workorder.domain.event.WorkOrderApprovedEvent;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
 import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderConfirmedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -65,6 +66,17 @@ public class SmartTaskGeneratorListener {
         event.getEventId(),
         this.getClass(),
         "onRecipeAssignmentNeeded",
+        () -> {
+          eventRouterService.route(event);
+        });
+  }
+
+  @ApplicationModuleListener
+  public void onQuoteSendRequested(QuoteSendRequestedEvent event) {
+    idempotentHandler.executeOnce(
+        event.getEventId(),
+        this.getClass(),
+        "onQuoteSendRequested",
         () -> {
           eventRouterService.route(event);
         });

--- a/src/main/java/com/fabricmanagement/flowboard/generator/app/adapter/QuoteSendRequestedEventAdapter.java
+++ b/src/main/java/com/fabricmanagement/flowboard/generator/app/adapter/QuoteSendRequestedEventAdapter.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.flowboard.generator.app.adapter;
+
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuoteSendRequestedEventAdapter implements DomainEventAdapter<QuoteSendRequestedEvent> {
+
+  @Override
+  public Class<QuoteSendRequestedEvent> getSupportedEventType() {
+    return QuoteSendRequestedEvent.class;
+  }
+
+  @Override
+  public String getEventTypeName() {
+    return "QuoteSendRequested";
+  }
+
+  @Override
+  public TaskTemplateContext buildContext(QuoteSendRequestedEvent event) {
+    return new TaskTemplateContext(
+        event.getTenantId(),
+        event.getQuoteSendRequestId(),
+        "QUOTE_SEND_REQUEST",
+        event.getQuoteNumber(),
+        null,
+        Map.of("quote.quoteNumber", event.getQuoteNumber()));
+  }
+}

--- a/src/main/java/com/fabricmanagement/notification/hub/app/listener/QuoteNotificationListener.java
+++ b/src/main/java/com/fabricmanagement/notification/hub/app/listener/QuoteNotificationListener.java
@@ -1,0 +1,51 @@
+package com.fabricmanagement.notification.hub.app.listener;
+
+import com.fabricmanagement.notification.hub.app.NotificationContext;
+import com.fabricmanagement.notification.hub.app.NotificationHubService;
+import com.fabricmanagement.notification.hub.domain.NotificationEventType;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestRejectedEvent;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class QuoteNotificationListener {
+
+  private final NotificationHubService notificationHubService;
+
+  @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+  @Async
+  public void onQuoteSendRequestRejected(QuoteSendRequestRejectedEvent event) {
+    if (event.getRequesterId() == null || SystemUser.ID.equals(event.getRequesterId())) {
+      log.debug(
+          "QuoteSendRequestRejected: requester not a DB user (id={}) - skipping notification",
+          event.getRequesterId());
+      return;
+    }
+
+    notificationHubService.notify(
+        NotificationContext.of(
+            event.getTenantId(),
+            event.getRequesterId(),
+            NotificationEventType.APPROVAL_REJECTED,
+            Map.of(
+                "entityType", "QUOTE",
+                "entityCode", nonNull(event.getQuoteNumber()),
+                "rejectionReason", nonNull(event.getDecisionNote()),
+                "referenceId", event.getQuoteId().toString(),
+                "referenceType", "QUOTE"),
+            event.getQuoteId(),
+            "QUOTE"));
+  }
+
+  private static String nonNull(String value) {
+    return value != null ? value : "";
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -130,6 +130,7 @@ public class TenantTransactionalPurgeService {
           "sales_ord.sales_order",
           "sales.sample_delivery",
           "sales.sample_request",
+          "sales.quote_send_request",
           "sales.quote_approval_token",
           "sales.quote_line",
           "sales.quote",

--- a/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
+++ b/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
@@ -71,4 +71,21 @@ public class SalesDomainException extends DomainException {
     return new SalesDomainException(
         message, "SALES_006_QUOTE_NEEDS_INTERNAL_APPROVAL", HttpStatus.CONFLICT);
   }
+
+  public static SalesDomainException quoteSendRequestAlreadyPending(String message) {
+    return new SalesDomainException(
+        message, "SALES_012_QUOTE_SEND_REQUEST_ALREADY_PENDING", HttpStatus.CONFLICT);
+  }
+
+  public static SalesDomainException quoteSendRequestNotFound(String requestId) {
+    return new SalesDomainException(
+        "Quote send request not found: " + requestId,
+        "SALES_013_QUOTE_SEND_REQUEST_NOT_FOUND",
+        HttpStatus.NOT_FOUND);
+  }
+
+  public static SalesDomainException invalidQuoteSendRequestDecision(String message) {
+    return new SalesDomainException(
+        message, "SALES_014_INVALID_QUOTE_SEND_REQUEST_DECISION", HttpStatus.BAD_REQUEST);
+  }
 }

--- a/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
@@ -1,14 +1,19 @@
 package com.fabricmanagement.sales.quote.api;
 
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
 import com.fabricmanagement.common.infrastructure.web.ApiResponse;
 import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.sales.quote.app.QuoteApprovalService;
 import com.fabricmanagement.sales.quote.app.QuoteService;
+import com.fabricmanagement.sales.quote.app.SendQuoteResult;
 import com.fabricmanagement.sales.quote.dto.AddQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.GenerateQuoteTokenRequest;
 import com.fabricmanagement.sales.quote.dto.QuoteApprovalTokenDto;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
+import com.fabricmanagement.sales.quote.dto.QuoteSendRequestDto;
+import com.fabricmanagement.sales.quote.dto.RejectQuoteSendRequest;
 import com.fabricmanagement.sales.quote.dto.SendQuoteRequest;
+import com.fabricmanagement.sales.quote.dto.SendQuoteResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.mapper.QuoteMapper;
@@ -23,6 +28,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -41,6 +47,7 @@ public class QuoteController {
   private final QuoteService quoteService;
   private final QuoteApprovalService quoteApprovalService;
   private final QuoteMapper mapper;
+  private final SpELPermissionEvaluator auth;
 
   // ═══════════════════════════════════════════════════════════════════════════
   // READ
@@ -137,12 +144,40 @@ public class QuoteController {
 
   @PostMapping("/{quoteId}/send")
   @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
-  @Operation(summary = "Send a quote approval email to the customer")
-  public ResponseEntity<ApiResponse<QuoteApprovalTokenDto>> sendQuote(
-      @PathVariable UUID quoteId, @Valid @RequestBody SendQuoteRequest req) {
+  @Operation(summary = "Send a quote to a customer or request internal send approval")
+  public ResponseEntity<ApiResponse<SendQuoteResponse>> sendQuote(
+      @PathVariable UUID quoteId,
+      @Valid @RequestBody SendQuoteRequest req,
+      Authentication authentication) {
+    boolean callerCanApprove = auth.can(authentication, "sales", "approve");
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(
-            ApiResponse.success(mapper.toDto(quoteService.sendQuote(quoteId, req.getContactId()))));
+            ApiResponse.success(
+                toSendQuoteResponse(
+                    quoteService.sendQuote(quoteId, req.getContactId(), callerCanApprove))));
+  }
+
+  @PostMapping("/{quoteId}/send-requests/{requestId}/approve")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'approve')")
+  @Operation(summary = "Approve a quote send request and send the quote to the customer")
+  public ResponseEntity<ApiResponse<SendQuoteResponse>> approveSendRequest(
+      @PathVariable UUID quoteId, @PathVariable UUID requestId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            toSendQuoteResponse(quoteService.approveSendRequest(quoteId, requestId))));
+  }
+
+  @PostMapping("/{quoteId}/send-requests/{requestId}/reject")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'approve')")
+  @Operation(summary = "Reject a quote send request")
+  public ResponseEntity<ApiResponse<QuoteSendRequestDto>> rejectSendRequest(
+      @PathVariable UUID quoteId,
+      @PathVariable UUID requestId,
+      @Valid @RequestBody RejectQuoteSendRequest req) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            QuoteSendRequestDto.from(
+                quoteService.rejectSendRequest(quoteId, requestId, req.decisionNote()))));
   }
 
   @PostMapping("/{quoteId}/revise")
@@ -168,5 +203,16 @@ public class QuoteController {
                 mapper.toDto(
                     quoteApprovalService.generateTokenForQuote(
                         quoteId, req.getChannel(), req.getSentTo()))));
+  }
+
+  private SendQuoteResponse toSendQuoteResponse(SendQuoteResult result) {
+    QuoteApprovalTokenDto token =
+        result.approvalToken() != null ? mapper.toDto(result.approvalToken()) : null;
+    QuoteSendRequestDto request =
+        result.sendRequest() != null ? QuoteSendRequestDto.from(result.sendRequest()) : null;
+    if (result.awaitingApproval()) {
+      return SendQuoteResponse.awaitingApproval(request);
+    }
+    return request != null ? SendQuoteResponse.sent(token, request) : SendQuoteResponse.sent(token);
   }
 }

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -20,11 +20,15 @@ import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalToken;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequest;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestRejectedEvent;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
+import com.fabricmanagement.sales.quote.infra.repository.QuoteSendRequestRepository;
 import com.fabricmanagement.sales.salesproduct.app.SalesProductService;
 import com.fabricmanagement.sales.salesproduct.dto.SalesProductDto;
 import java.math.BigDecimal;
@@ -37,6 +41,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -55,6 +61,8 @@ public class QuoteService {
   private final QuoteApprovalService quoteApprovalService;
   private final TradingPartnerResolver tradingPartnerResolver;
   private final PartnerContactService partnerContactService;
+  private final QuoteSendRequestRepository quoteSendRequestRepository;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
   public Page<Quote> findAll(Pageable pageable) {
@@ -211,27 +219,80 @@ public class QuoteService {
   }
 
   @Transactional
-  public QuoteApprovalToken sendQuote(UUID quoteId, UUID contactId) {
+  public SendQuoteResult sendQuote(UUID quoteId, UUID contactId, boolean callerCanApprove) {
     Quote quote = getActiveQuote(quoteId);
+    PartnerContact contact = requireQuoteCustomerContact(quote, contactId);
 
     if (quote.getStatus() == QuoteStatus.DRAFT || quote.getStatus() == QuoteStatus.EVALUATION) {
       rejectBlockedQuoteForCustomerSend(quote);
       quote = submitQuote(quoteId);
     }
 
+    if (callerCanApprove && quote.getStatus() == QuoteStatus.PENDING_APPROVAL) {
+      quote.setStatus(QuoteStatus.APPROVED);
+      quote = quoteRepository.save(quote);
+    }
+
     if (quote.getStatus() == QuoteStatus.APPROVED) {
-      PartnerContact contact = requireQuoteCustomerContact(quote, contactId);
-      return quoteApprovalService.generateTokenForQuote(
-          quoteId, QuoteApprovalChannel.EMAIL, contact.getEmail(), contact.getId());
+      if (callerCanApprove) {
+        return SendQuoteResult.sent(
+            quoteApprovalService.generateTokenForQuote(
+                quoteId, QuoteApprovalChannel.EMAIL, contact.getEmail(), contact.getId()));
+      }
+      return SendQuoteResult.awaitingApproval(createPendingSendRequest(quote, contact));
     }
 
     if (quote.getStatus() == QuoteStatus.PENDING_APPROVAL) {
-      throw SalesDomainException.needsInternalApproval(
-          "Quote needs internal approval before it can be sent to the customer.");
+      return SendQuoteResult.awaitingApproval(createPendingSendRequest(quote, contact));
     }
 
     throw SalesDomainException.invalidQuoteStatus(
         "Cannot send a quote in " + quote.getStatus() + " status");
+  }
+
+  @Transactional
+  public SendQuoteResult approveSendRequest(UUID quoteId, UUID requestId) {
+    Quote quote = getActiveQuote(quoteId);
+    QuoteSendRequest request = getActiveSendRequest(quoteId, requestId);
+
+    if (quote.getStatus() == QuoteStatus.PENDING_APPROVAL) {
+      quote.setStatus(QuoteStatus.APPROVED);
+      quote = quoteRepository.save(quote);
+    }
+    if (quote.getStatus() != QuoteStatus.APPROVED) {
+      throw SalesDomainException.invalidQuoteStatus(
+          "Cannot approve a send request for a quote in " + quote.getStatus() + " status");
+    }
+
+    PartnerContact contact = requireQuoteCustomerContact(quote, request.getContactId());
+    request.approve(requireCurrentUserId(), Instant.now());
+    QuoteSendRequest savedRequest = quoteSendRequestRepository.save(request);
+
+    QuoteApprovalToken token =
+        quoteApprovalService.generateTokenForQuote(
+            quoteId, request.getChannel(), contact.getEmail(), contact.getId());
+    return SendQuoteResult.sent(token, savedRequest);
+  }
+
+  @Transactional
+  public QuoteSendRequest rejectSendRequest(UUID quoteId, UUID requestId, String decisionNote) {
+    Quote quote = getActiveQuote(quoteId);
+    QuoteSendRequest request = getActiveSendRequest(quoteId, requestId);
+
+    request.reject(requireCurrentUserId(), Instant.now(), decisionNote);
+    quote.setStatus(QuoteStatus.EVALUATION);
+
+    Quote savedQuote = quoteRepository.save(quote);
+    QuoteSendRequest savedRequest = quoteSendRequestRepository.save(request);
+    eventPublisher.publishEvent(
+        new QuoteSendRequestRejectedEvent(
+            savedRequest.getTenantId(),
+            savedRequest.getId(),
+            savedQuote.getId(),
+            savedQuote.getQuoteNumber(),
+            savedRequest.getRequestedBy(),
+            savedRequest.getDecisionNote()));
+    return savedRequest;
   }
 
   @Transactional
@@ -305,6 +366,52 @@ public class QuoteService {
         .orElseThrow(() -> SalesDomainException.quoteNotFound(quoteId.toString()));
   }
 
+  private QuoteSendRequest getActiveSendRequest(UUID quoteId, UUID requestId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    QuoteSendRequest request =
+        quoteSendRequestRepository
+            .findByTenantIdAndIdAndIsActiveTrue(tenantId, requestId)
+            .orElseThrow(() -> SalesDomainException.quoteSendRequestNotFound(requestId.toString()));
+    if (!quoteId.equals(request.getQuoteId())) {
+      throw SalesDomainException.quoteSendRequestNotFound(requestId.toString());
+    }
+    return request;
+  }
+
+  private QuoteSendRequest createPendingSendRequest(Quote quote, PartnerContact contact) {
+    UUID tenantId = quote.getTenantId();
+    quoteSendRequestRepository
+        .findPendingByTenantIdAndQuoteId(tenantId, quote.getId())
+        .ifPresent(
+            existing -> {
+              throw SalesDomainException.quoteSendRequestAlreadyPending(
+                  "Quote already has a pending send request.");
+            });
+
+    QuoteSendRequest request =
+        QuoteSendRequest.create(
+            tenantId,
+            quote.getId(),
+            contact.getId(),
+            QuoteApprovalChannel.EMAIL,
+            requireCurrentUserId(),
+            Instant.now());
+    try {
+      QuoteSendRequest saved = quoteSendRequestRepository.save(request);
+      eventPublisher.publishEvent(
+          new QuoteSendRequestedEvent(
+              saved.getTenantId(),
+              saved.getId(),
+              quote.getId(),
+              quote.getQuoteNumber(),
+              saved.getRequestedBy()));
+      return saved;
+    } catch (DataIntegrityViolationException ex) {
+      throw SalesDomainException.quoteSendRequestAlreadyPending(
+          "Quote already has a pending send request.");
+    }
+  }
+
   private QuoteResponse toResponse(Quote quote, Map<UUID, String> customerNames) {
     return QuoteResponse.from(quote, customerNames.get(quote.getCustomerId()));
   }
@@ -364,6 +471,15 @@ public class QuoteService {
       throw SalesDomainException.needsInternalApproval(
           "Quote needs internal approval before it can be sent to the customer.");
     }
+  }
+
+  private UUID requireCurrentUserId() {
+    UUID userId = TenantContext.getCurrentUserId();
+    if (userId == null) {
+      throw SalesDomainException.invalidQuoteSendRequestDecision(
+          "Authenticated user context is required for quote send approval workflow.");
+    }
+    return userId;
   }
 
   private QuoteLine getQuoteLine(Quote quote, UUID lineId) {

--- a/src/main/java/com/fabricmanagement/sales/quote/app/SendQuoteResult.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/SendQuoteResult.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.sales.quote.app;
+
+import com.fabricmanagement.sales.quote.domain.QuoteApprovalToken;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequest;
+
+public record SendQuoteResult(QuoteApprovalToken approvalToken, QuoteSendRequest sendRequest) {
+
+  public boolean awaitingApproval() {
+    return sendRequest != null && approvalToken == null;
+  }
+
+  public static SendQuoteResult sent(QuoteApprovalToken approvalToken) {
+    return new SendQuoteResult(approvalToken, null);
+  }
+
+  public static SendQuoteResult sent(QuoteApprovalToken approvalToken, QuoteSendRequest request) {
+    return new SendQuoteResult(approvalToken, request);
+  }
+
+  public static SendQuoteResult awaitingApproval(QuoteSendRequest request) {
+    return new SendQuoteResult(null, request);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteSendRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteSendRequest.java
@@ -1,0 +1,100 @@
+package com.fabricmanagement.sales.quote.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "quote_send_request", schema = "sales")
+@Getter
+@Setter
+@NoArgsConstructor
+public class QuoteSendRequest extends BaseEntity {
+
+  @Column(name = "quote_id", nullable = false)
+  private UUID quoteId;
+
+  @Column(name = "contact_id", nullable = false)
+  private UUID contactId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "channel", nullable = false, length = 20)
+  private QuoteApprovalChannel channel = QuoteApprovalChannel.EMAIL;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  private QuoteSendRequestStatus status = QuoteSendRequestStatus.PENDING;
+
+  @Column(name = "requested_by", nullable = false)
+  private UUID requestedBy;
+
+  @Column(name = "requested_at", nullable = false)
+  private Instant requestedAt;
+
+  @Column(name = "decided_by")
+  private UUID decidedBy;
+
+  @Column(name = "decided_at")
+  private Instant decidedAt;
+
+  @Column(name = "decision_note", columnDefinition = "TEXT")
+  private String decisionNote;
+
+  public static QuoteSendRequest create(
+      UUID tenantId,
+      UUID quoteId,
+      UUID contactId,
+      QuoteApprovalChannel channel,
+      UUID requestedBy,
+      Instant requestedAt) {
+    QuoteSendRequest request = new QuoteSendRequest();
+    request.setTenantId(tenantId);
+    request.quoteId = quoteId;
+    request.contactId = contactId;
+    request.channel = channel;
+    request.requestedBy = requestedBy;
+    request.requestedAt = requestedAt;
+    request.status = QuoteSendRequestStatus.PENDING;
+    return request;
+  }
+
+  public void approve(UUID approverId, Instant decidedAt) {
+    requirePending();
+    this.status = QuoteSendRequestStatus.APPROVED;
+    this.decidedBy = approverId;
+    this.decidedAt = decidedAt;
+  }
+
+  public void reject(UUID approverId, Instant decidedAt, String decisionNote) {
+    requirePending();
+    if (decisionNote == null || decisionNote.isBlank()) {
+      throw SalesDomainException.invalidQuoteSendRequestDecision(
+          "decisionNote is required when rejecting a quote send request.");
+    }
+    this.status = QuoteSendRequestStatus.REJECTED;
+    this.decidedBy = approverId;
+    this.decidedAt = decidedAt;
+    this.decisionNote = decisionNote.strip();
+  }
+
+  private void requirePending() {
+    if (this.status != QuoteSendRequestStatus.PENDING) {
+      throw SalesDomainException.invalidQuoteSendRequestDecision(
+          "Quote send request is already " + this.status + ".");
+    }
+  }
+
+  @Override
+  protected String getModuleCode() {
+    return "QSR";
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteSendRequestStatus.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteSendRequestStatus.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.sales.quote.domain;
+
+public enum QuoteSendRequestStatus {
+  PENDING,
+  APPROVED,
+  REJECTED
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestRejectedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestRejectedEvent.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.sales.quote.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class QuoteSendRequestRejectedEvent extends DomainEvent {
+
+  private final UUID quoteSendRequestId;
+  private final UUID quoteId;
+  private final String quoteNumber;
+  private final UUID requesterId;
+  private final String decisionNote;
+
+  public QuoteSendRequestRejectedEvent(
+      UUID tenantId,
+      UUID quoteSendRequestId,
+      UUID quoteId,
+      String quoteNumber,
+      UUID requesterId,
+      String decisionNote) {
+    super(tenantId, "QUOTE_SEND_REQUEST_REJECTED");
+    this.quoteSendRequestId = quoteSendRequestId;
+    this.quoteId = quoteId;
+    this.quoteNumber = quoteNumber;
+    this.requesterId = requesterId;
+    this.decisionNote = decisionNote;
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestedEvent.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.sales.quote.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class QuoteSendRequestedEvent extends DomainEvent {
+
+  private final UUID quoteSendRequestId;
+  private final UUID quoteId;
+  private final String quoteNumber;
+  private final UUID requestedBy;
+
+  public QuoteSendRequestedEvent(
+      UUID tenantId, UUID quoteSendRequestId, UUID quoteId, String quoteNumber, UUID requestedBy) {
+    super(tenantId, "QUOTE_SEND_REQUESTED");
+    this.quoteSendRequestId = quoteSendRequestId;
+    this.quoteId = quoteId;
+    this.quoteNumber = quoteNumber;
+    this.requestedBy = requestedBy;
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteSendRequestDto.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteSendRequestDto.java
@@ -1,0 +1,36 @@
+package com.fabricmanagement.sales.quote.dto;
+
+import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequest;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequestStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(description = "Internal approval request for sending a quote to a customer contact")
+public record QuoteSendRequestDto(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID id,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID quoteId,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID contactId,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) QuoteApprovalChannel channel,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) QuoteSendRequestStatus status,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID requestedBy,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Instant requestedAt,
+    UUID decidedBy,
+    Instant decidedAt,
+    String decisionNote) {
+
+  public static QuoteSendRequestDto from(QuoteSendRequest request) {
+    return new QuoteSendRequestDto(
+        request.getId(),
+        request.getQuoteId(),
+        request.getContactId(),
+        request.getChannel(),
+        request.getStatus(),
+        request.getRequestedBy(),
+        request.getRequestedAt(),
+        request.getDecidedBy(),
+        request.getDecidedAt(),
+        request.getDecisionNote());
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/RejectQuoteSendRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/RejectQuoteSendRequest.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.sales.quote.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "Decision note for rejecting a quote send request")
+public record RejectQuoteSendRequest(
+    @NotBlank
+        @Size(max = 1000)
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, maxLength = 1000)
+        String decisionNote) {}

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/SendQuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/SendQuoteResponse.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.sales.quote.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Result of a quote send attempt")
+public record SendQuoteResponse(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) SendQuoteResult result,
+    QuoteApprovalTokenDto approvalToken,
+    QuoteSendRequestDto sendRequest) {
+
+  public static SendQuoteResponse sent(QuoteApprovalTokenDto approvalToken) {
+    return new SendQuoteResponse(SendQuoteResult.SENT, approvalToken, null);
+  }
+
+  public static SendQuoteResponse sent(
+      QuoteApprovalTokenDto approvalToken, QuoteSendRequestDto sendRequest) {
+    return new SendQuoteResponse(SendQuoteResult.SENT, approvalToken, sendRequest);
+  }
+
+  public static SendQuoteResponse awaitingApproval(QuoteSendRequestDto sendRequest) {
+    return new SendQuoteResponse(SendQuoteResult.AWAITING_APPROVAL, null, sendRequest);
+  }
+
+  public enum SendQuoteResult {
+    SENT,
+    AWAITING_APPROVAL
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteSendRequestRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteSendRequestRepository.java
@@ -1,0 +1,20 @@
+package com.fabricmanagement.sales.quote.infra.repository;
+
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequest;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequestStatus;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuoteSendRequestRepository extends JpaRepository<QuoteSendRequest, UUID> {
+
+  Optional<QuoteSendRequest> findByTenantIdAndIdAndIsActiveTrue(UUID tenantId, UUID id);
+
+  Optional<QuoteSendRequest> findByTenantIdAndQuoteIdAndStatusAndIsActiveTrue(
+      UUID tenantId, UUID quoteId, QuoteSendRequestStatus status);
+
+  default Optional<QuoteSendRequest> findPendingByTenantIdAndQuoteId(UUID tenantId, UUID quoteId) {
+    return findByTenantIdAndQuoteIdAndStatusAndIsActiveTrue(
+        tenantId, quoteId, QuoteSendRequestStatus.PENDING);
+  }
+}

--- a/src/main/resources/db/migration/V20260706120000__quote_send_requests.sql
+++ b/src/main/resources/db/migration/V20260706120000__quote_send_requests.sql
@@ -1,0 +1,127 @@
+CREATE TABLE IF NOT EXISTS sales.quote_send_request (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    uid VARCHAR(100) UNIQUE,
+    quote_id UUID NOT NULL,
+    contact_id UUID NOT NULL,
+    channel VARCHAR(20) NOT NULL,
+    status VARCHAR(20) NOT NULL,
+    requested_by UUID NOT NULL,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    decided_by UUID,
+    decided_at TIMESTAMPTZ,
+    decision_note TEXT,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    deleted_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID,
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT fk_quote_send_request_tenant
+        FOREIGN KEY (tenant_id) REFERENCES common_tenant.common_tenant(id) ON DELETE RESTRICT,
+    CONSTRAINT fk_quote_send_request_quote
+        FOREIGN KEY (quote_id) REFERENCES sales.quote(id) ON DELETE CASCADE,
+    CONSTRAINT fk_quote_send_request_contact
+        FOREIGN KEY (contact_id) REFERENCES common_company.partner_contact(id) ON DELETE RESTRICT,
+    CONSTRAINT ck_quote_send_request_channel
+        CHECK (channel IN ('EMAIL', 'WHATSAPP', 'IN_PERSON')),
+    CONSTRAINT ck_quote_send_request_status
+        CHECK (status IN ('PENDING', 'APPROVED', 'REJECTED')),
+    CONSTRAINT ck_quote_send_request_reject_note
+        CHECK (status <> 'REJECTED' OR decision_note IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS idx_quote_send_request_tenant
+    ON sales.quote_send_request(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_quote_send_request_quote
+    ON sales.quote_send_request(quote_id);
+CREATE INDEX IF NOT EXISTS idx_quote_send_request_contact
+    ON sales.quote_send_request(contact_id);
+CREATE INDEX IF NOT EXISTS idx_quote_send_request_requested_by
+    ON sales.quote_send_request(requested_by);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_quote_send_request_open_quote
+    ON sales.quote_send_request(tenant_id, quote_id)
+    WHERE status = 'PENDING' AND is_active = TRUE;
+
+ALTER TABLE sales.quote_send_request ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales.quote_send_request FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rls_tenant_isolation ON sales.quote_send_request;
+CREATE POLICY rls_tenant_isolation ON sales.quote_send_request
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+INSERT INTO flowboard.task_template (
+    id, tenant_id, uid, name, event_type, title_template, task_type,
+    module_type, default_priority, default_assignee_role, estimated_hours,
+    is_active, created_at, updated_at, version
+)
+SELECT
+    gen_random_uuid(),
+    tenant_ids.tenant_id,
+    gen_random_uuid()::varchar,
+    'Quote send approval',
+    'QuoteSendRequested',
+    'Quote send approval - {quote.quoteNumber}',
+    'APPROVAL',
+    'GENERAL',
+    'HIGH',
+    'ANY',
+    0.25,
+    TRUE,
+    NOW(),
+    NOW(),
+    0
+FROM (
+    SELECT DISTINCT tenant_id FROM flowboard.task_template
+    UNION
+    SELECT '00000000-0000-0000-ffff-000000000001'::uuid
+) tenant_ids
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM flowboard.task_template existing
+    WHERE existing.tenant_id = tenant_ids.tenant_id
+      AND existing.event_type = 'QuoteSendRequested'
+      AND existing.task_type = 'APPROVAL'
+      AND existing.is_active = TRUE
+);
+
+INSERT INTO common_user.permission_template (
+    id, tenant_id, uid, role_code, department_code, resource, action,
+    data_scope, is_active, created_at, updated_at, version
+)
+SELECT
+    gen_random_uuid(),
+    src.tenant_id,
+    gen_random_uuid()::varchar,
+    src.role_code,
+    src.department_code,
+    'sales',
+    'approve',
+    CASE WHEN src.role_code IN ('ADMIN', 'PLATFORM_ADMIN') THEN 'GLOBAL' ELSE 'ORGANIZATION' END,
+    TRUE,
+    NOW(),
+    NOW(),
+    0
+FROM (
+    SELECT DISTINCT tenant_id, role_code, department_code
+    FROM common_user.permission_template
+    WHERE role_code IN ('ADMIN', 'PLATFORM_ADMIN', 'MANAGER', 'SUPERVISOR')
+      AND tenant_id IS NOT NULL
+    UNION
+    SELECT '00000000-0000-0000-ffff-000000000001'::uuid, 'ADMIN', NULL
+    UNION
+    SELECT '00000000-0000-0000-ffff-000000000001'::uuid, 'MANAGER', NULL
+    UNION
+    SELECT '00000000-0000-0000-ffff-000000000001'::uuid, 'SUPERVISOR', NULL
+) src
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM common_user.permission_template existing
+    WHERE existing.tenant_id = src.tenant_id
+      AND existing.role_code = src.role_code
+      AND COALESCE(existing.department_code, '__ALL__') = COALESCE(src.department_code, '__ALL__')
+      AND existing.resource = 'sales'
+      AND existing.action = 'approve'
+);

--- a/src/test/java/com/fabricmanagement/flowboard/generator/app/adapter/QuoteSendRequestedEventAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/flowboard/generator/app/adapter/QuoteSendRequestedEventAdapterTest.java
@@ -1,0 +1,35 @@
+package com.fabricmanagement.flowboard.generator.app.adapter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class QuoteSendRequestedEventAdapterTest {
+
+  private final QuoteSendRequestedEventAdapter adapter = new QuoteSendRequestedEventAdapter();
+
+  @Test
+  void shouldBuildApprovalTaskContextFromQuoteSendRequest() {
+    UUID tenantId = UUID.randomUUID();
+    UUID requestId = UUID.randomUUID();
+    UUID quoteId = UUID.randomUUID();
+    UUID requestedBy = UUID.randomUUID();
+
+    QuoteSendRequestedEvent event =
+        new QuoteSendRequestedEvent(tenantId, requestId, quoteId, "Q-2026-001", requestedBy);
+
+    TaskTemplateContext context = adapter.buildContext(event);
+
+    assertEquals(QuoteSendRequestedEvent.class, adapter.getSupportedEventType());
+    assertEquals("QuoteSendRequested", adapter.getEventTypeName());
+    assertEquals(tenantId, context.tenantId());
+    assertEquals(requestId, context.entityId());
+    assertEquals("QUOTE_SEND_REQUEST", context.entityType());
+    assertEquals("Q-2026-001", context.entityRef());
+    assertNull(context.deadline());
+    assertEquals("Q-2026-001", context.templateVariables().get("quote.quoteNumber"));
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -78,6 +78,7 @@ class TenantTransactionalPurgeServiceTest {
     assertThat(result.trialEndsAt()).isEqualTo(Instant.parse("2026-09-25T12:00:00Z"));
     assertThat(result.deletedRows())
         .containsKeys(
+            "sales.quote_send_request",
             "sales.quote",
             "procurement.purchase_order",
             "production.prod_product",
@@ -93,6 +94,9 @@ class TenantTransactionalPurgeServiceTest {
             "human.human_employee_number_sequence",
             "common_user.common_user(seed-demo-users)");
     verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM sales.quote_send_request WHERE tenant_id = ?"), eq(TENANT_ID));
     verify(jdbc)
         .update(
             contains("DELETE FROM procurement.purchase_order WHERE tenant_id = ?"), eq(TENANT_ID));
@@ -163,6 +167,7 @@ class TenantTransactionalPurgeServiceTest {
     assertThat(result.tenantId()).isEqualTo(TENANT_ID);
     assertThat(result.deletedRows())
         .containsKeys(
+            "sales.quote_send_request",
             "sales.quote",
             "procurement.purchase_order",
             "production.prod_product",
@@ -170,6 +175,9 @@ class TenantTransactionalPurgeServiceTest {
             "sales_ord.sales_order_line_processed_shipments",
             "common_user.common_user(seed-demo-users)");
     verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM sales.quote_send_request WHERE tenant_id = ?"), eq(TENANT_ID));
     verify(jdbc)
         .update(
             contains("DELETE FROM production.production_execution_batch_override_log log"),

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -36,11 +36,16 @@ import com.fabricmanagement.sales.quote.domain.QuoteApprovalStatus;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalToken;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequest;
+import com.fabricmanagement.sales.quote.domain.QuoteSendRequestStatus;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestRejectedEvent;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
+import com.fabricmanagement.sales.quote.infra.repository.QuoteSendRequestRepository;
 import com.fabricmanagement.sales.salesproduct.app.SalesProductService;
 import com.fabricmanagement.sales.salesproduct.dto.SalesProductDto;
 import java.math.BigDecimal;
@@ -59,6 +64,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -75,6 +81,8 @@ class QuoteServiceTest {
   @Mock private QuoteApprovalService quoteApprovalService;
   @Mock private TradingPartnerResolver tradingPartnerResolver;
   @Mock private PartnerContactService partnerContactService;
+  @Mock private QuoteSendRequestRepository quoteSendRequestRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
 
   @InjectMocks private QuoteService quoteService;
 
@@ -83,11 +91,13 @@ class QuoteServiceTest {
   private final UUID customerId = UUID.randomUUID();
   private final UUID contactId = UUID.randomUUID();
   private final UUID productId = UUID.randomUUID();
+  private final UUID userId = UUID.randomUUID();
   private Quote quote;
 
   @BeforeEach
   void setUp() {
     TenantContext.setCurrentTenantId(tenantId);
+    TenantContext.setCurrentUserId(userId);
     quote = quote("GBP");
   }
 
@@ -691,7 +701,8 @@ class QuoteServiceTest {
     assertThrows(
         SalesDomainException.class, () -> quoteService.updateQuoteLine(quoteId, lineId, lineReq));
     assertThrows(SalesDomainException.class, () -> quoteService.removeQuoteLine(quoteId, lineId));
-    assertThrows(SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId));
+    assertThrows(
+        SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId, false));
 
     verify(quoteRepository, times(4)).findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId);
     verify(quoteRepository, never()).save(any(Quote.class));
@@ -700,8 +711,8 @@ class QuoteServiceTest {
   }
 
   @Test
-  @DisplayName("Should submit clean draft quote and mint email token when sending")
-  void shouldSubmitCleanDraftQuoteAndMintEmailTokenWhenSending() {
+  @DisplayName("Approver send should submit clean draft quote and mint email token")
+  void approverSendShouldSubmitCleanDraftQuoteAndMintEmailToken() {
     quote.addLine(quoteLine("GBP", "10.00", "2.000"));
     QuoteApprovalToken approvalToken = quoteApprovalToken("buyer@example.com");
 
@@ -714,12 +725,41 @@ class QuoteServiceTest {
             quoteId, QuoteApprovalChannel.EMAIL, "buyer@example.com", contactId))
         .thenReturn(approvalToken);
 
-    QuoteApprovalToken result = quoteService.sendQuote(quoteId, contactId);
+    SendQuoteResult result = quoteService.sendQuote(quoteId, contactId, true);
 
-    assertEquals(approvalToken, result);
+    assertEquals(approvalToken, result.approvalToken());
+    assertNull(result.sendRequest());
     assertEquals(QuoteStatus.APPROVED, quote.getStatus());
     verify(quoteApprovalService)
         .generateTokenForQuote(quoteId, QuoteApprovalChannel.EMAIL, "buyer@example.com", contactId);
+  }
+
+  @Test
+  @DisplayName("Non-approver send should create pending send request and not mint token")
+  void nonApproverSendShouldCreatePendingSendRequestAndNotMintToken() {
+    quote.addLine(quoteLine("GBP", "10.00", "2.000"));
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteSendRequestRepository.findPendingByTenantIdAndQuoteId(tenantId, quoteId))
+        .thenReturn(Optional.empty());
+    when(quoteSendRequestRepository.save(any(QuoteSendRequest.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    SendQuoteResult result = quoteService.sendQuote(quoteId, contactId, false);
+
+    assertNull(result.approvalToken());
+    assertNotNull(result.sendRequest());
+    assertEquals(QuoteSendRequestStatus.PENDING, result.sendRequest().getStatus());
+    assertEquals(contactId, result.sendRequest().getContactId());
+    assertEquals(userId, result.sendRequest().getRequestedBy());
+    assertEquals(QuoteStatus.APPROVED, quote.getStatus());
+    verify(quoteApprovalService, never())
+        .generateTokenForQuote(any(), any(QuoteApprovalChannel.class), any(), any());
+    verify(eventPublisher).publishEvent(any(QuoteSendRequestedEvent.class));
   }
 
   @Test
@@ -733,7 +773,8 @@ class QuoteServiceTest {
         .thenReturn(partnerContact(contactId, otherCustomerId, "buyer@example.com"));
 
     SalesDomainException ex =
-        assertThrows(SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId));
+        assertThrows(
+            SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId, true));
 
     assertEquals("SALES_010_INVALID_QUOTE_RECIPIENT_CONTACT", ex.getErrorCode());
     assertEquals(400, ex.getHttpStatus());
@@ -742,23 +783,128 @@ class QuoteServiceTest {
   }
 
   @Test
-  @DisplayName("Should move manager approval quote to pending approval and not mint token")
-  void shouldMoveManagerApprovalQuoteToPendingApprovalAndNotMintToken() {
+  @DisplayName("Non-approver manager approval quote should create pending send request")
+  void nonApproverManagerApprovalQuoteShouldCreatePendingSendRequest() {
     QuoteLine line = quoteLine("GBP", "10.00", "2.000");
     line.setPriceZone(QuotePriceZone.MANAGER_APPROVAL);
     quote.addLine(line);
 
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(quote));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
     when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteSendRequestRepository.findPendingByTenantIdAndQuoteId(tenantId, quoteId))
+        .thenReturn(Optional.empty());
+    when(quoteSendRequestRepository.save(any(QuoteSendRequest.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
 
-    SalesDomainException ex =
-        assertThrows(SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId));
+    SendQuoteResult result = quoteService.sendQuote(quoteId, contactId, false);
 
-    assertEquals("SALES_006_QUOTE_NEEDS_INTERNAL_APPROVAL", ex.getErrorCode());
+    assertNull(result.approvalToken());
+    assertNotNull(result.sendRequest());
     assertEquals(QuoteStatus.PENDING_APPROVAL, quote.getStatus());
     verify(quoteApprovalService, never())
         .generateTokenForQuote(any(), any(QuoteApprovalChannel.class), any(), any());
+  }
+
+  @Test
+  @DisplayName("Approver send should approve manager-zone quote and mint email token")
+  void approverSendShouldApproveManagerZoneQuoteAndMintToken() {
+    QuoteLine line = quoteLine("GBP", "10.00", "2.000");
+    line.setPriceZone(QuotePriceZone.MANAGER_APPROVAL);
+    quote.addLine(line);
+    QuoteApprovalToken approvalToken = quoteApprovalToken("buyer@example.com");
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteApprovalService.generateTokenForQuote(
+            quoteId, QuoteApprovalChannel.EMAIL, "buyer@example.com", contactId))
+        .thenReturn(approvalToken);
+
+    SendQuoteResult result = quoteService.sendQuote(quoteId, contactId, true);
+
+    assertEquals(approvalToken, result.approvalToken());
+    assertEquals(QuoteStatus.APPROVED, quote.getStatus());
+    verify(quoteApprovalService)
+        .generateTokenForQuote(quoteId, QuoteApprovalChannel.EMAIL, "buyer@example.com", contactId);
+  }
+
+  @Test
+  @DisplayName("Second open send request should return conflict")
+  void secondOpenSendRequestShouldReturnConflict() {
+    quote.setStatus(QuoteStatus.APPROVED);
+    QuoteSendRequest existing = quoteSendRequest();
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
+    when(quoteSendRequestRepository.findPendingByTenantIdAndQuoteId(tenantId, quoteId))
+        .thenReturn(Optional.of(existing));
+
+    SalesDomainException ex =
+        assertThrows(
+            SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId, false));
+
+    assertEquals("SALES_012_QUOTE_SEND_REQUEST_ALREADY_PENDING", ex.getErrorCode());
+    verify(quoteApprovalService, never())
+        .generateTokenForQuote(any(), any(QuoteApprovalChannel.class), any(), any());
+    verify(quoteSendRequestRepository, never()).save(any(QuoteSendRequest.class));
+  }
+
+  @Test
+  @DisplayName("Approve send request should approve pending quote and mint email token")
+  void approveSendRequestShouldApprovePendingQuoteAndMintEmailToken() {
+    quote.setStatus(QuoteStatus.PENDING_APPROVAL);
+    QuoteSendRequest request = quoteSendRequest();
+    QuoteApprovalToken approvalToken = quoteApprovalToken("buyer@example.com");
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(quoteSendRequestRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, request.getId()))
+        .thenReturn(Optional.of(request));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteSendRequestRepository.save(any(QuoteSendRequest.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+    when(quoteApprovalService.generateTokenForQuote(
+            quoteId, QuoteApprovalChannel.EMAIL, "buyer@example.com", contactId))
+        .thenReturn(approvalToken);
+
+    SendQuoteResult result = quoteService.approveSendRequest(quoteId, request.getId());
+
+    assertEquals(approvalToken, result.approvalToken());
+    assertEquals(QuoteSendRequestStatus.APPROVED, result.sendRequest().getStatus());
+    assertEquals(userId, result.sendRequest().getDecidedBy());
+    assertEquals(QuoteStatus.APPROVED, quote.getStatus());
+  }
+
+  @Test
+  @DisplayName("Reject send request should return quote to evaluation and notify requester")
+  void rejectSendRequestShouldReturnQuoteToEvaluationAndNotifyRequester() {
+    quote.setStatus(QuoteStatus.PENDING_APPROVAL);
+    QuoteSendRequest request = quoteSendRequest();
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(quoteSendRequestRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, request.getId()))
+        .thenReturn(Optional.of(request));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteSendRequestRepository.save(any(QuoteSendRequest.class)))
+        .thenAnswer(inv -> inv.getArgument(0));
+
+    QuoteSendRequest rejected =
+        quoteService.rejectSendRequest(quoteId, request.getId(), "Margin too low");
+
+    assertEquals(QuoteStatus.EVALUATION, quote.getStatus());
+    assertEquals(QuoteSendRequestStatus.REJECTED, rejected.getStatus());
+    assertEquals("Margin too low", rejected.getDecisionNote());
+    verify(eventPublisher).publishEvent(any(QuoteSendRequestRejectedEvent.class));
   }
 
   @Test
@@ -770,9 +916,12 @@ class QuoteServiceTest {
 
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(quote));
+    when(partnerContactService.requireActiveContact(tenantId, contactId))
+        .thenReturn(partnerContact(contactId, customerId, "buyer@example.com"));
 
     SalesDomainException ex =
-        assertThrows(SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId));
+        assertThrows(
+            SalesDomainException.class, () -> quoteService.sendQuote(quoteId, contactId, false));
 
     assertEquals("SALES_006_QUOTE_NEEDS_INTERNAL_APPROVAL", ex.getErrorCode());
     assertEquals(QuoteStatus.DRAFT, quote.getStatus());
@@ -846,6 +995,14 @@ class QuoteServiceTest {
     token.setExpiresAt(Instant.now().plusSeconds(3600));
     token.setStatus(QuoteApprovalStatus.PENDING);
     return token;
+  }
+
+  private QuoteSendRequest quoteSendRequest() {
+    QuoteSendRequest request =
+        QuoteSendRequest.create(
+            tenantId, quoteId, contactId, QuoteApprovalChannel.EMAIL, userId, Instant.now());
+    request.setId(UUID.randomUUID());
+    return request;
   }
 
   private PartnerContact partnerContact(UUID contactId, UUID partnerId, String email) {


### PR DESCRIPTION
- new sales.quote_send_request (RLS, one PENDING per quote via partial unique index): requested_by/decided_by/decision_note audit trail
- POST /send branches on effective sales:approve — approvers send directly (and clear zone PENDING_APPROVAL in the same act); non-approvers create a pending send request: no token, no email
- approve endpoint (sales:approve): clears zone approval if needed, mints token + emails the requested contact at approval time; reject requires a note, returns quote to EVALUATION, notifies the requester
- QuoteSendRequested event wired to SmartTaskGenerator → pool task for approvers; rejection notification listener
- fixes the pre-existing dead end: zone PENDING_APPROVAL quotes had no approve path at all
- quote_send_request added to tenant purge; openapi exported; tests