### PR TITLE
fix(production): stop WorkOrderApprovedEvent retry storm from poisoni…

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
@@ -231,6 +231,9 @@ public class DemoTransactionSeeder {
   }
 
   private void seedSalesQuoteDemo(UUID tenantId) {
+    // Runs in its own transaction (REQUIRES_NEW, same pattern as SalesDemoSeeder): a DB-level
+    // failure inside the seeder aborts only ITS transaction, so catching here keeps signup /
+    // onboarding / reset flows (which call this from within their own transaction) healthy.
     try {
       salesQuoteDemoSeeder.seedFor(tenantId);
     } catch (Exception salesQuoteEx) {

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
@@ -45,6 +45,7 @@ public class DemoTransactionSeeder {
   private final FinanceDemoSeeder financeDemoSeeder;
   private final SalesDemoSeeder salesDemoSeeder;
   private final ProcurementDemoSeeder procurementDemoSeeder;
+  private final SalesQuoteDemoSeeder salesQuoteDemoSeeder;
 
   @Value("${application.seed.demo-transactions.enabled:false}")
   private boolean enabled;
@@ -87,6 +88,7 @@ public class DemoTransactionSeeder {
       if (!existing.isEmpty()) {
         log.info("Demo transactions already exist for tenant: {}. Skipping.", tenantId);
         seedProcurementDemo(tenantId);
+        seedSalesQuoteDemo(tenantId);
         return;
       }
 
@@ -120,6 +122,7 @@ public class DemoTransactionSeeder {
       }
 
       seedProcurementDemo(tenantId);
+      seedSalesQuoteDemo(tenantId);
 
       // 3. Production demo (best-effort, isolated): sales order → work order → batch.
       // Pre-existing demo data. Wrapped in its own try/catch so a failure here can never roll back
@@ -224,6 +227,17 @@ public class DemoTransactionSeeder {
           "Procurement demo seeding failed for tenant {} - continuing; other demos unaffected.",
           tenantId,
           procurementEx);
+    }
+  }
+
+  private void seedSalesQuoteDemo(UUID tenantId) {
+    try {
+      salesQuoteDemoSeeder.seedFor(tenantId);
+    } catch (Exception salesQuoteEx) {
+      log.warn(
+          "Sales quote demo seeding failed for tenant {} - continuing; other demos unaffected.",
+          tenantId,
+          salesQuoteEx);
     }
   }
 }

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
@@ -22,14 +22,11 @@ import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
 import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
 import com.fabricmanagement.production.execution.batch.app.BatchService;
-import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
-import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.dto.AddBatchAttributeRequest;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
 import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
 import com.fabricmanagement.production.execution.batch.dto.ReserveRequest;
-import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
@@ -38,10 +35,9 @@ import com.fabricmanagement.production.masterdata.color.app.ColorService;
 import com.fabricmanagement.production.masterdata.color.domain.Color;
 import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
-import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
 import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
+import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
-import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
@@ -62,6 +58,8 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Seeds the playground sales/ATP demo dataset (DEMO-SALES-1) for the "Pennine Mills Ltd" scenario:
@@ -71,9 +69,15 @@ import org.springframework.stereotype.Component;
  * behaviour (shade warning, remnant nudge, three-number stock, forced delivery status) on realistic
  * British data.
  *
- * <p>Mirrors {@link ProcurementDemoSeeder}: runs post-clone inside the cloned tenant's context,
- * writes via application services so real invariants apply, is idempotent (skips when the demo
- * customer already exists), and is best-effort — it must never break playground initialisation.
+ * <p>Runs post-clone inside the cloned tenant's context, writes via application services so real
+ * invariants apply, and is idempotent (skips when the demo customer already exists).
+ *
+ * <p>Runs in its OWN transaction ({@link Propagation#REQUIRES_NEW}) and is invoked from {@link
+ * DemoTransactionSeeder} inside a try/catch — the exact {@link SalesDemoSeeder} pattern. Signup and
+ * onboarding call the seeding chain from inside their own transaction; without this boundary a
+ * single failed INSERT here aborts the shared Postgres transaction ("current transaction is
+ * aborted") and turns the whole signup into a 500 even though the exception itself is caught. With
+ * it, a failure rolls back only the demo dataset and can never break playground initialisation.
  */
 @Component
 @RequiredArgsConstructor
@@ -95,6 +99,13 @@ public class SalesQuoteDemoSeeder {
   static final String MARKETER_LAST_NAME = "Whitfield";
   static final String MARKETER_EMAIL = "emma.whitfield@nexusfabrics.com";
 
+  /**
+   * Batch-header unit for fabric length lots. {@code chk_batch_unit} only admits KG / MT / PIECE
+   * (see V001 + {@code BatchUnit}); metre granularity is carried by the rolls' {@code
+   * StockUnit.lengthUnit = "M"}.
+   */
+  static final String BATCH_UNIT_METRES = "MT";
+
   private static final String CURRENCY = "GBP";
   private static final String QUOTE_MODULE_TYPE = "FABRIC";
   private static final String COLOUR_ATTRIBUTE_CODE = "COLOR";
@@ -107,10 +118,8 @@ public class SalesQuoteDemoSeeder {
   private final QualityGradeService qualityGradeService;
   private final ColorService colorService;
   private final BatchService batchService;
-  private final BatchRepository batchRepository;
   private final StockUnitService stockUnitService;
   private final BatchAttributeService batchAttributeService;
-  private final ProductAttributeRepository productAttributeRepository;
   private final SalesProductService salesProductService;
   private final DiscountPolicyService discountPolicyService;
   private final ExchangeRateService exchangeRateService;
@@ -122,6 +131,7 @@ public class SalesQuoteDemoSeeder {
   private final OrganizationService organizationService;
   private final Clock clock;
 
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void seedFor(UUID tenantId) {
     TenantContext.TenantSnapshot previous = TenantContext.capture();
     try {
@@ -147,7 +157,7 @@ public class SalesQuoteDemoSeeder {
       // Rust deliberately gets NO stock — the picker's passive-but-selectable colour case.
       ensureColour("RUST-04", "Rust", "#B7410E");
 
-      ProductAttribute colourAxis = ensureColourAxisAttribute(tenantId);
+      ProductAttributeDto colourAxis = ensureColourAxisAttribute();
 
       ProductDto gabardine = productFacade.createProduct(product(ProductType.FABRIC, "M"));
       ProductDto combedYarn = productFacade.createProduct(product(ProductType.YARN, "KG"));
@@ -163,19 +173,29 @@ public class SalesQuoteDemoSeeder {
           "USD", CURRENCY, new BigDecimal("0.79"), today, ExchangeRateSource.MANUAL);
 
       // ── Lots and pieces (per the DEMO-SALES-1 table) ──
+      // Fabric lot headers use BATCH_UNIT_METRES ("MT"): production_execution_batch carries
+      // chk_batch_unit CHECK (unit IN ('KG','MT','PIECE')) — "M" is rejected at INSERT. Metre
+      // detail lives on the rolls (StockUnit.lengthUnit = "M"), which is also what the lot picker
+      // surfaces for piece-backed length lots.
       BatchDto lot24011 =
-          saleableBatch(gabardine, "LOT-24011", "2000", "M", "Main Navy dye lot, spring run");
+          saleableBatch(
+              gabardine, "LOT-24011", "2000", BATCH_UNIT_METRES, "Main Navy dye lot, spring run");
       addRolls(lot24011.getId(), "24011", 16, "125", "36.800", fabricGrades.first().getId());
       attachColour(lot24011.getId(), colourAxis, navy);
 
       BatchDto lot24012 =
           saleableBatch(
-              gabardine, "LOT-24012", "3000", "M", "Second Navy dye lot — shade may vary");
+              gabardine,
+              "LOT-24012",
+              "3000",
+              BATCH_UNIT_METRES,
+              "Second Navy dye lot — shade may vary");
       addRolls(lot24012.getId(), "24012", 24, "125", "36.800", fabricGrades.first().getId());
       attachColour(lot24012.getId(), colourAxis, navy);
 
       BatchDto lot23087 =
-          saleableBatch(gabardine, "LOT-23087", "290", "M", "Remnant lot — close it out");
+          saleableBatch(
+              gabardine, "LOT-23087", "290", BATCH_UNIT_METRES, "Remnant lot — close it out");
       addRoll(lot23087.getId(), "23087", 1, "100", "29.500", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 2, "95", "28.000", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 3, "95", "28.000", fabricGrades.first().getId());
@@ -183,7 +203,11 @@ public class SalesQuoteDemoSeeder {
 
       BatchDto lot24020 =
           saleableBatch(
-              gabardine, "LOT-24020", "450", "M", "Second Quality Ecru — bulk, no pieces");
+              gabardine,
+              "LOT-24020",
+              "450",
+              BATCH_UNIT_METRES,
+              "Second Quality Ecru — bulk, no pieces");
       attachColour(lot24020.getId(), colourAxis, ecru);
 
       BatchDto lot24031 =
@@ -196,7 +220,8 @@ public class SalesQuoteDemoSeeder {
 
       // Waste-grade stock exists but must stay invisible to the picker (negative test).
       BatchDto lot23050 =
-          saleableBatch(gabardine, "LOT-23050", "120", "M", "Waste grade — not saleable");
+          saleableBatch(
+              gabardine, "LOT-23050", "120", BATCH_UNIT_METRES, "Waste grade — not saleable");
       addRoll(lot23050.getId(), "23050", 1, "60", "17.700", fabricGrades.waste().getId());
       addRoll(lot23050.getId(), "23050", 2, "60", "17.700", fabricGrades.waste().getId());
       attachColour(lot23050.getId(), colourAxis, navy);
@@ -253,9 +278,9 @@ public class SalesQuoteDemoSeeder {
           draftQuote.getId(), gabardine.getId(), fabricGrades.first().getId(), navy.getId());
 
       log.info("Successfully provisioned sales quote demo data for tenant: {}", tenantId);
-    } catch (Exception e) {
-      log.warn("Sales quote demo seeding failed for tenant {} - continuing.", tenantId, e);
     } finally {
+      // Failures propagate to DemoTransactionSeeder's try/catch so THIS transaction (REQUIRES_NEW)
+      // rolls back cleanly. Swallowing here would commit a rollback-only transaction instead.
       TenantContext.restore(previous);
     }
   }
@@ -310,27 +335,18 @@ public class SalesQuoteDemoSeeder {
   /**
    * The lot picker resolves a lot's colour from a {@code BatchAttribute} whose {@code
    * ProductAttribute} code is COLOR (see ProductionSalesLotQueryService). ProductAttribute is
-   * read-only reference data with no create service, so the seeder registers the colour axis
-   * directly through the repository — the one narrow repository write in this seeder.
+   * read-only reference data with no create endpoint, so the seeder registers the colour axis
+   * through {@link ProductFacade#ensureAttribute}, whose lookup is tenant-scoped and
+   * create-if-missing.
    */
-  private ProductAttribute ensureColourAxisAttribute(UUID tenantId) {
-    return productAttributeRepository
-        .findByAttributeCode(COLOUR_ATTRIBUTE_CODE)
-        .filter(attribute -> tenantId.equals(attribute.getTenantId()))
-        .orElseGet(
-            () -> {
-              ProductAttribute attribute =
-                  ProductAttribute.builder()
-                      .attributeCode(COLOUR_ATTRIBUTE_CODE)
-                      .attributeName("Colour")
-                      .attributeGroup("VARIANT")
-                      .productScope("ALL")
-                      .description("Colour card reference for dyed lots")
-                      .displayOrder(100)
-                      .build();
-              attribute.setTenantId(tenantId);
-              return productAttributeRepository.save(attribute);
-            });
+  private ProductAttributeDto ensureColourAxisAttribute() {
+    return productFacade.ensureAttribute(
+        COLOUR_ATTRIBUTE_CODE,
+        "Colour",
+        "VARIANT",
+        "ALL",
+        "Colour card reference for dyed lots",
+        100);
   }
 
   private CreateProductRequest product(ProductType productType, String unit) {
@@ -380,24 +396,9 @@ public class SalesQuoteDemoSeeder {
                 .sourceType(BatchSourceType.INITIAL_STOCK)
                 .remarks(remarks)
                 .build());
-    releaseFromQc(batch.getId());
+    // New batches start in PENDING_QC; the picker only lists AVAILABLE/RESERVED lots.
+    batchService.releaseFromQc(batch.getId());
     return batch;
-  }
-
-  /**
-   * New batches start in PENDING_QC; the picker only lists AVAILABLE/RESERVED lots. There is no
-   * QC-approval service API (the only production path is the async {@code FiberTestResultApproved}
-   * listener), so the seeder applies the same APPROVED→AVAILABLE transition through the aggregate —
-   * mirroring {@code BatchQcEventListener}.
-   */
-  private void releaseFromQc(UUID batchId) {
-    UUID tenantId = TenantContext.requireTenantId();
-    Batch batch =
-        batchRepository
-            .findByIdAndTenantId(batchId, tenantId)
-            .orElseThrow(() -> new IllegalStateException("Seeded batch not found: " + batchId));
-    batch.transitionStatus(BatchStatus.AVAILABLE, SystemUser.ID);
-    batchRepository.save(batch);
   }
 
   private void addRolls(
@@ -463,9 +464,9 @@ public class SalesQuoteDemoSeeder {
     return String.format("PM-%s-%02d", lotDigits, index);
   }
 
-  private void attachColour(UUID batchId, ProductAttribute colourAxis, Color colour) {
+  private void attachColour(UUID batchId, ProductAttributeDto colourAxis, Color colour) {
     batchAttributeService.add(
-        batchId, new AddBatchAttributeRequest(colourAxis.getId(), colour.getId().toString()));
+        batchId, new AddBatchAttributeRequest(colourAxis.id(), colour.getId().toString()));
   }
 
   // ── Actor helpers ───────────────────────────────────────────────────────────

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
@@ -1,0 +1,600 @@
+package com.fabricmanagement.common.infrastructure.bootstrap;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.costing.domain.exchange.ExchangeRateSource;
+import com.fabricmanagement.platform.organization.app.OrganizationService;
+import com.fabricmanagement.platform.organization.domain.Department;
+import com.fabricmanagement.platform.organization.dto.OrganizationDto;
+import com.fabricmanagement.platform.organization.infra.repository.DepartmentRepository;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerService;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
+import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
+import com.fabricmanagement.platform.user.app.RoleService;
+import com.fabricmanagement.platform.user.app.UserCreationService;
+import com.fabricmanagement.platform.user.domain.ContactType;
+import com.fabricmanagement.platform.user.domain.Role;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.dto.CreateInternalUserRequest;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
+import com.fabricmanagement.production.execution.batch.app.BatchService;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.dto.AddBatchAttributeRequest;
+import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
+import com.fabricmanagement.production.execution.batch.dto.ReserveRequest;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.masterdata.color.app.ColorService;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
+import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
+import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
+import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
+import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
+import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
+import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
+import com.fabricmanagement.sales.pricing.domain.DiscountPolicy;
+import com.fabricmanagement.sales.quote.api.QuoteCreateRequest;
+import com.fabricmanagement.sales.quote.app.QuoteService;
+import com.fabricmanagement.sales.quote.domain.Quote;
+import com.fabricmanagement.sales.quote.dto.AddQuoteLineRequest;
+import com.fabricmanagement.sales.quote.dto.QuoteLineLotSelectionRequest;
+import com.fabricmanagement.sales.salesproduct.app.SalesProductService;
+import com.fabricmanagement.sales.salesproduct.dto.CreateSalesProductRequest;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * Seeds the playground sales/ATP demo dataset (DEMO-SALES-1) for the "Pennine Mills Ltd" scenario:
+ * quality grades, colour cards, products with GBP catalogue entries, dye lots with rolls/cartons, a
+ * competing marketer quote whose soft lot-quantity intents shrink Navy free stock, one hard {@code
+ * BatchReservation}, and a pre-filled draft quote — so the quote picker exercises every QLINE+ATP
+ * behaviour (shade warning, remnant nudge, three-number stock, forced delivery status) on realistic
+ * British data.
+ *
+ * <p>Mirrors {@link ProcurementDemoSeeder}: runs post-clone inside the cloned tenant's context,
+ * writes via application services so real invariants apply, is idempotent (skips when the demo
+ * customer already exists), and is best-effort — it must never break playground initialisation.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SalesQuoteDemoSeeder {
+
+  static final String CUSTOMER_ALBION = "Albion Apparel Ltd";
+
+  /**
+   * Quote-number stems per the DEMO-SALES-1 ticket. {@code sales.quote.quote_number} carries a
+   * GLOBAL unique constraint (not tenant-scoped — see V001 + the tenant-scoped-uniques migration,
+   * which does not cover it), so each playground tenant appends its own short suffix to avoid
+   * cross-tenant collisions.
+   */
+  static final String COMPETING_QUOTE_NUMBER_STEM = "Q-2026-1041";
+
+  static final String DRAFT_QUOTE_NUMBER_STEM = "Q-2026-1042";
+  static final String MARKETER_FIRST_NAME = "Emma";
+  static final String MARKETER_LAST_NAME = "Whitfield";
+  static final String MARKETER_EMAIL = "emma.whitfield@nexusfabrics.com";
+
+  private static final String CURRENCY = "GBP";
+  private static final String QUOTE_MODULE_TYPE = "FABRIC";
+  private static final String COLOUR_ATTRIBUTE_CODE = "COLOR";
+  private static final String GRADING_REASON = "Initial grading (demo seed)";
+  private static final String GABARDINE_LIST_PRICE = "6.80";
+  private static final String GABARDINE_OFFERED_PRICE = "6.50";
+
+  private final TradingPartnerService tradingPartnerService;
+  private final ProductFacade productFacade;
+  private final QualityGradeService qualityGradeService;
+  private final ColorService colorService;
+  private final BatchService batchService;
+  private final BatchRepository batchRepository;
+  private final StockUnitService stockUnitService;
+  private final BatchAttributeService batchAttributeService;
+  private final ProductAttributeRepository productAttributeRepository;
+  private final SalesProductService salesProductService;
+  private final DiscountPolicyService discountPolicyService;
+  private final ExchangeRateService exchangeRateService;
+  private final QuoteService quoteService;
+  private final UserRepository userRepository;
+  private final UserCreationService userCreationService;
+  private final RoleService roleService;
+  private final DepartmentRepository departmentRepository;
+  private final OrganizationService organizationService;
+  private final Clock clock;
+
+  public void seedFor(UUID tenantId) {
+    TenantContext.TenantSnapshot previous = TenantContext.capture();
+    try {
+      TenantContext.setCurrentTenantId(tenantId);
+      TenantContext.setCurrentUserId(SystemUser.ID);
+
+      if (!tradingPartnerService.searchByName(tenantId, CUSTOMER_ALBION).isEmpty()) {
+        log.info("Sales quote demo data already exists for tenant: {}. Skipping.", tenantId);
+        return;
+      }
+
+      LocalDate today = LocalDate.now(clock);
+
+      // ── Master data ──
+      GradeTrio fabricGrades = seedGradeTrio(ProductType.FABRIC);
+      GradeTrio yarnGrades = seedGradeTrio(ProductType.YARN);
+      seedGradeTrio(ProductType.FIBER);
+
+      Color navy = ensureColour("NAVY-01", "Navy", "#1F2A44");
+      Color ecru = ensureColour("ECRU-02", "Ecru", "#F0EAD6");
+      ensureColour("CHAR-03", "Charcoal", "#36454F");
+      Color pfd = ensureColour("PFD-00", "Prepared For Dyeing", null);
+      // Rust deliberately gets NO stock — the picker's passive-but-selectable colour case.
+      ensureColour("RUST-04", "Rust", "#B7410E");
+
+      ProductAttribute colourAxis = ensureColourAxisAttribute(tenantId);
+
+      ProductDto gabardine = productFacade.createProduct(product(ProductType.FABRIC, "M"));
+      ProductDto combedYarn = productFacade.createProduct(product(ProductType.YARN, "KG"));
+      ProductDto rawCotton = productFacade.createProduct(product(ProductType.FIBER, "KG"));
+
+      catalogueEntry(gabardine, "PM-1453 Gabardine 155cm 190gsm", GABARDINE_LIST_PRICE);
+      catalogueEntry(combedYarn, "PM-3001 Combed Yarn Ne 30/1", "4.20");
+      catalogueEntry(rawCotton, "PM-9001 Raw Cotton", "1.85");
+
+      ensureDiscountPolicy();
+      // Reporting currency for demo tenants is USD (FinanceDemoSeeder); GBP quotes need this rate.
+      exchangeRateService.saveRate(
+          "USD", CURRENCY, new BigDecimal("0.79"), today, ExchangeRateSource.MANUAL);
+
+      // ── Lots and pieces (per the DEMO-SALES-1 table) ──
+      BatchDto lot24011 =
+          saleableBatch(gabardine, "LOT-24011", "2000", "M", "Main Navy dye lot, spring run");
+      addRolls(lot24011.getId(), "24011", 16, "125", "36.800", fabricGrades.first().getId());
+      attachColour(lot24011.getId(), colourAxis, navy);
+
+      BatchDto lot24012 =
+          saleableBatch(
+              gabardine, "LOT-24012", "3000", "M", "Second Navy dye lot — shade may vary");
+      addRolls(lot24012.getId(), "24012", 24, "125", "36.800", fabricGrades.first().getId());
+      attachColour(lot24012.getId(), colourAxis, navy);
+
+      BatchDto lot23087 =
+          saleableBatch(gabardine, "LOT-23087", "290", "M", "Remnant lot — close it out");
+      addRoll(lot23087.getId(), "23087", 1, "100", "29.500", fabricGrades.first().getId());
+      addRoll(lot23087.getId(), "23087", 2, "95", "28.000", fabricGrades.first().getId());
+      addRoll(lot23087.getId(), "23087", 3, "95", "28.000", fabricGrades.first().getId());
+      attachColour(lot23087.getId(), colourAxis, navy);
+
+      BatchDto lot24020 =
+          saleableBatch(
+              gabardine, "LOT-24020", "450", "M", "Second Quality Ecru — bulk, no pieces");
+      attachColour(lot24020.getId(), colourAxis, ecru);
+
+      BatchDto lot24031 =
+          saleableBatch(combedYarn, "LOT-24031", "1200", "KG", "Combed yarn, prepared for dyeing");
+      addCartons(lot24031.getId(), "24031", 48, "25.000", yarnGrades.first().getId());
+      attachColour(lot24031.getId(), colourAxis, pfd);
+
+      // Raw cotton skips the colour axis entirely — fibre cascade has no Colour step.
+      saleableBatch(rawCotton, "LOT-24040", "5000", "KG", "Raw cotton, bulk store");
+
+      // Waste-grade stock exists but must stay invisible to the picker (negative test).
+      BatchDto lot23050 =
+          saleableBatch(gabardine, "LOT-23050", "120", "M", "Waste grade — not saleable");
+      addRoll(lot23050.getId(), "23050", 1, "60", "17.700", fabricGrades.waste().getId());
+      addRoll(lot23050.getId(), "23050", 2, "60", "17.700", fabricGrades.waste().getId());
+      attachColour(lot23050.getId(), colourAxis, navy);
+
+      // ── Actors ──
+      TradingPartnerDto albion = createAlbionCustomer(tenantId);
+      UUID emmaId = ensureMarketer(tenantId);
+      UUID draftOwnerId = resolveDraftOwner(tenantId, emmaId);
+
+      // ── Emma's competing open quote: soft intents shrink Navy free stock ──
+      Quote emmaQuote =
+          createQuote(
+              albion.getId(),
+              emmaId,
+              quoteNumber(COMPETING_QUOTE_NUMBER_STEM, tenantId),
+              today.plusDays(14),
+              "Navy gabardine for the spring collection — awaiting customer confirmation");
+      // Each line's selected-lot quantity equals the line requested quantity, so the seed passes
+      // the same invariant real users hit; QuoteService writes the intents through
+      // BatchLotQuantityIntentPort.replaceIntents with Emma's quote/line ids.
+      addLotBackedLine(
+          emmaQuote.getId(),
+          gabardine.getId(),
+          fabricGrades.first().getId(),
+          navy.getId(),
+          lot24011.getId(),
+          "1500");
+      addLotBackedLine(
+          emmaQuote.getId(),
+          gabardine.getId(),
+          fabricGrades.first().getId(),
+          navy.getId(),
+          lot24012.getId(),
+          "2000");
+
+      // ── Hard reservation: an order in progress holds 200 m of the Ecru bulk lot ──
+      batchService.reserve(
+          lot24020.getId(),
+          ReserveRequest.builder()
+              .quantity(new BigDecimal("200"))
+              .referenceType("SALES_ORDER")
+              .remarks("Order in progress — hard reservation (demo)")
+              .build());
+
+      // ── Draft quote for the demo user, one line pre-filled, no lots yet ──
+      Quote draftQuote =
+          createQuote(
+              albion.getId(),
+              draftOwnerId,
+              quoteNumber(DRAFT_QUOTE_NUMBER_STEM, tenantId),
+              today.plusDays(30),
+              "Draft — open the lot picker on the Gabardine line to continue");
+      addFreeEntryLine(
+          draftQuote.getId(), gabardine.getId(), fabricGrades.first().getId(), navy.getId());
+
+      log.info("Successfully provisioned sales quote demo data for tenant: {}", tenantId);
+    } catch (Exception e) {
+      log.warn("Sales quote demo seeding failed for tenant {} - continuing.", tenantId, e);
+    } finally {
+      TenantContext.restore(previous);
+    }
+  }
+
+  // ── Master data helpers ─────────────────────────────────────────────────────
+
+  private GradeTrio seedGradeTrio(ProductType productType) {
+    QualityGrade first =
+        ensureGrade(productType, "1ST", "First Quality", 1, "1.000", true, false, "#22C55E", true);
+    QualityGrade second =
+        ensureGrade(
+            productType, "2ND", "Second Quality", 2, "0.550", true, false, "#EAB308", false);
+    QualityGrade waste =
+        ensureGrade(productType, "WASTE", "Waste", 3, "0.100", false, true, "#EF4444", false);
+    return new GradeTrio(first, second, waste);
+  }
+
+  private QualityGrade ensureGrade(
+      ProductType productType,
+      String code,
+      String name,
+      int rank,
+      String priceFactor,
+      boolean saleable,
+      boolean requiresApproval,
+      String colorHex,
+      boolean isDefault) {
+    return qualityGradeService.findByProductType(productType).stream()
+        .filter(grade -> code.equalsIgnoreCase(grade.getCode()))
+        .findFirst()
+        .orElseGet(
+            () ->
+                qualityGradeService.create(
+                    productType,
+                    code,
+                    name,
+                    rank,
+                    new BigDecimal(priceFactor),
+                    saleable,
+                    requiresApproval,
+                    colorHex,
+                    isDefault));
+  }
+
+  private Color ensureColour(String code, String name, String colorHex) {
+    return colorService.list(true).stream()
+        .filter(colour -> code.equalsIgnoreCase(colour.getCode()))
+        .findFirst()
+        .orElseGet(() -> colorService.create(code, name, colorHex));
+  }
+
+  /**
+   * The lot picker resolves a lot's colour from a {@code BatchAttribute} whose {@code
+   * ProductAttribute} code is COLOR (see ProductionSalesLotQueryService). ProductAttribute is
+   * read-only reference data with no create service, so the seeder registers the colour axis
+   * directly through the repository — the one narrow repository write in this seeder.
+   */
+  private ProductAttribute ensureColourAxisAttribute(UUID tenantId) {
+    return productAttributeRepository
+        .findByAttributeCode(COLOUR_ATTRIBUTE_CODE)
+        .filter(attribute -> tenantId.equals(attribute.getTenantId()))
+        .orElseGet(
+            () -> {
+              ProductAttribute attribute =
+                  ProductAttribute.builder()
+                      .attributeCode(COLOUR_ATTRIBUTE_CODE)
+                      .attributeName("Colour")
+                      .attributeGroup("VARIANT")
+                      .productScope("ALL")
+                      .description("Colour card reference for dyed lots")
+                      .displayOrder(100)
+                      .build();
+              attribute.setTenantId(tenantId);
+              return productAttributeRepository.save(attribute);
+            });
+  }
+
+  private CreateProductRequest product(ProductType productType, String unit) {
+    return CreateProductRequest.builder().productType(productType).unit(unit).build();
+  }
+
+  private void catalogueEntry(ProductDto product, String productName, String listPrice) {
+    salesProductService.createEntry(
+        new CreateSalesProductRequest(
+            product.getId(),
+            productName,
+            QUOTE_MODULE_TYPE,
+            new BigDecimal(listPrice),
+            CURRENCY,
+            null,
+            null,
+            null,
+            null,
+            null));
+  }
+
+  private void ensureDiscountPolicy() {
+    try {
+      discountPolicyService.getActivePolicy(QUOTE_MODULE_TYPE);
+    } catch (IllegalArgumentException missingPolicy) {
+      DiscountPolicy policy = new DiscountPolicy();
+      policy.setModuleType(QUOTE_MODULE_TYPE);
+      policy.setBaseDiscountLimit(new BigDecimal("0.1000"));
+      policy.setMinProfitMargin(new BigDecimal("0.0500"));
+      policy.setRequireManagerAbove(new BigDecimal("0.1500"));
+      discountPolicyService.savePolicy(policy);
+    }
+  }
+
+  // ── Lot helpers ─────────────────────────────────────────────────────────────
+
+  private BatchDto saleableBatch(
+      ProductDto product, String batchCode, String quantity, String unit, String remarks) {
+    BatchDto batch =
+        batchService.create(
+            CreateBatchRequest.builder()
+                .productId(product.getId())
+                .productType(product.getProductType())
+                .batchCode(batchCode)
+                .quantity(new BigDecimal(quantity))
+                .unit(unit)
+                .sourceType(BatchSourceType.INITIAL_STOCK)
+                .remarks(remarks)
+                .build());
+    releaseFromQc(batch.getId());
+    return batch;
+  }
+
+  /**
+   * New batches start in PENDING_QC; the picker only lists AVAILABLE/RESERVED lots. There is no
+   * QC-approval service API (the only production path is the async {@code FiberTestResultApproved}
+   * listener), so the seeder applies the same APPROVED→AVAILABLE transition through the aggregate —
+   * mirroring {@code BatchQcEventListener}.
+   */
+  private void releaseFromQc(UUID batchId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    Batch batch =
+        batchRepository
+            .findByIdAndTenantId(batchId, tenantId)
+            .orElseThrow(() -> new IllegalStateException("Seeded batch not found: " + batchId));
+    batch.transitionStatus(BatchStatus.AVAILABLE, SystemUser.ID);
+    batchRepository.save(batch);
+  }
+
+  private void addRolls(
+      UUID batchId,
+      String lotDigits,
+      int count,
+      String lengthMetres,
+      String weightKg,
+      UUID gradeId) {
+    for (int index = 1; index <= count; index++) {
+      addRoll(batchId, lotDigits, index, lengthMetres, weightKg, gradeId);
+    }
+  }
+
+  private void addRoll(
+      UUID batchId,
+      String lotDigits,
+      int index,
+      String lengthMetres,
+      String weightKg,
+      UUID gradeId) {
+    StockUnit unit =
+        stockUnitService.create(
+            batchId,
+            ProductType.FABRIC,
+            barcode(lotDigits, index),
+            null,
+            PackageType.ROLL,
+            new BigDecimal(weightKg),
+            null,
+            "KG",
+            new BigDecimal(lengthMetres),
+            "M",
+            null,
+            StockUnitSourceType.PRODUCTION,
+            batchId);
+    stockUnitService.changeGrade(unit.getId(), gradeId, GRADING_REASON, null);
+  }
+
+  private void addCartons(
+      UUID batchId, String lotDigits, int count, String weightKg, UUID gradeId) {
+    for (int index = 1; index <= count; index++) {
+      StockUnit unit =
+          stockUnitService.create(
+              batchId,
+              ProductType.YARN,
+              barcode(lotDigits, index),
+              null,
+              PackageType.CARTON,
+              new BigDecimal(weightKg),
+              null,
+              "KG",
+              null,
+              null,
+              null,
+              StockUnitSourceType.PRODUCTION,
+              batchId);
+      stockUnitService.changeGrade(unit.getId(), gradeId, GRADING_REASON, null);
+    }
+  }
+
+  private String barcode(String lotDigits, int index) {
+    return String.format("PM-%s-%02d", lotDigits, index);
+  }
+
+  private void attachColour(UUID batchId, ProductAttribute colourAxis, Color colour) {
+    batchAttributeService.add(
+        batchId, new AddBatchAttributeRequest(colourAxis.getId(), colour.getId().toString()));
+  }
+
+  // ── Actor helpers ───────────────────────────────────────────────────────────
+
+  private TradingPartnerDto createAlbionCustomer(UUID tenantId) {
+    CreateTradingPartnerRequest req = new CreateTradingPartnerRequest();
+    req.setCompanyName(CUSTOMER_ALBION);
+    req.setCustomName(CUSTOMER_ALBION);
+    req.setTaxId("GB-ALB-" + tenantSuffix(tenantId));
+    req.setCountry("GBR");
+    req.setPartnerType(PartnerType.CUSTOMER);
+    req.setRelationshipMeta(
+        Map.of(
+            "payment_terms", "NET30",
+            "contact_email", "buying@albionapparel.co.uk",
+            "notes", "Demo customer for sales quotes"));
+    return tradingPartnerService.createPartner(req);
+  }
+
+  private UUID ensureMarketer(UUID tenantId) {
+    return userRepository
+        .findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(
+            tenantId, MARKETER_FIRST_NAME, MARKETER_LAST_NAME)
+        .map(User::getId)
+        .orElseGet(() -> createMarketer(tenantId));
+  }
+
+  /**
+   * Creates the competing-marketer persona through the same services {@link UserSeeder} uses. No
+   * credential is provisioned — playground access works via impersonation, matching how cloned
+   * persona users behave (TenantClonerService intentionally skips auth users).
+   */
+  private UUID createMarketer(UUID tenantId) {
+    OrganizationDto rootOrg =
+        organizationService
+            .getRootOrganization()
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Root organisation missing — cannot seed demo marketer"));
+    Role role =
+        roleService
+            .findByCode("WORKER")
+            .orElseThrow(() -> new IllegalStateException("WORKER role missing for demo marketer"));
+    UUID departmentId =
+        departmentRepository
+            .findByTenantIdAndOrganizationIdAndDepartmentCode(tenantId, rootOrg.getId(), "SALES")
+            .map(Department::getId)
+            .orElse(null);
+
+    UserDto created =
+        userCreationService.createInternalUser(
+            CreateInternalUserRequest.builder()
+                .firstName(MARKETER_FIRST_NAME)
+                .lastName(MARKETER_LAST_NAME)
+                .contactValue(MARKETER_EMAIL)
+                .contactType(ContactType.EMAIL)
+                .organizationId(rootOrg.getId())
+                .departmentId(departmentId)
+                .roleId(role.getId())
+                .jobTitleCode("SALES_REP")
+                .build());
+
+    userRepository
+        .findByTenantIdAndId(tenantId, created.getId())
+        .ifPresent(
+            user -> {
+              user.setDemoSeed(true);
+              userRepository.save(user);
+            });
+    return created.getId();
+  }
+
+  private UUID resolveDraftOwner(UUID tenantId, UUID fallbackUserId) {
+    // Sandra Deal is the seeded sales-rep persona a playground visitor enters the sales views as.
+    return userRepository
+        .findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(tenantId, "Sandra", "Deal")
+        .map(User::getId)
+        .orElse(fallbackUserId);
+  }
+
+  // ── Quote helpers ───────────────────────────────────────────────────────────
+
+  private Quote createQuote(
+      UUID customerId, UUID assignedToId, String quoteNumber, LocalDate validUntil, String notes) {
+    QuoteCreateRequest req = new QuoteCreateRequest();
+    req.setCustomerId(customerId);
+    req.setAssignedToId(assignedToId);
+    req.setModuleType(QUOTE_MODULE_TYPE);
+    req.setQuoteNumber(quoteNumber);
+    req.setCurrency(CURRENCY);
+    req.setValidUntil(validUntil);
+    req.setPaymentTerms("Net 30 days");
+    req.setNotes(notes);
+    return quoteService.createQuote(req);
+  }
+
+  private void addLotBackedLine(
+      UUID quoteId, UUID productId, UUID qualityGradeId, UUID colourId, UUID lotId, String qty) {
+    AddQuoteLineRequest req = new AddQuoteLineRequest();
+    req.setProductId(productId);
+    req.setQualityGradeId(qualityGradeId);
+    req.setColorId(colourId);
+    req.setSelectedLots(
+        List.of(new QuoteLineLotSelectionRequest(lotId, null, new BigDecimal(qty))));
+    req.setRequestedQty(new BigDecimal(qty));
+    req.setUnit("M");
+    req.setOfferedPrice(new BigDecimal(GABARDINE_OFFERED_PRICE));
+    quoteService.addQuoteLine(quoteId, req);
+  }
+
+  private void addFreeEntryLine(UUID quoteId, UUID productId, UUID qualityGradeId, UUID colourId) {
+    AddQuoteLineRequest req = new AddQuoteLineRequest();
+    req.setProductId(productId);
+    req.setQualityGradeId(qualityGradeId);
+    req.setColorId(colourId);
+    req.setRequestedQty(new BigDecimal("400"));
+    req.setUnit("M");
+    req.setOfferedPrice(new BigDecimal(GABARDINE_LIST_PRICE));
+    quoteService.addQuoteLine(quoteId, req);
+  }
+
+  private String quoteNumber(String stem, UUID tenantId) {
+    return stem + "-" + tenantSuffix(tenantId);
+  }
+
+  private String tenantSuffix(UUID tenantId) {
+    return tenantId.toString().substring(0, 8).toUpperCase();
+  }
+
+  private record GradeTrio(QualityGrade first, QualityGrade second, QualityGrade waste) {}
+}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
@@ -233,6 +233,31 @@ public class BatchService {
         .toList();
   }
 
+  // ── QC release ─────────────────────────────────────────────────────────────
+
+  /**
+   * Releases a batch from QC by applying the PENDING_QC → AVAILABLE transition.
+   *
+   * <p>Exists because there is no QC-approval service API yet: the only production path that
+   * releases a batch is the async {@link BatchQcEventListener} reacting to {@code
+   * FiberTestResultApproved}. This method mirrors that listener's APPROVED → AVAILABLE mapping so
+   * in-process callers (e.g. demo seeders) can make freshly created batches saleable without
+   * reaching into the batch infra layer.
+   */
+  @Transactional
+  public BatchDto releaseFromQc(UUID batchId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    log.debug("Releasing batch from QC: tenantId={}, batchId={}", tenantId, batchId);
+
+    Batch batch = loadBatchWithLock(batchId, tenantId);
+    batch.transitionStatus(BatchStatus.AVAILABLE, TenantContext.getCurrentUserId());
+    Batch saved = batchRepository.save(batch);
+
+    log.info("Batch released from QC: id={}, batchCode={}", saved.getId(), saved.getBatchCode());
+
+    return toBatchDto(saved);
+  }
+
   // ── Named Reservation ──────────────────────────────────────────────────────
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/app/WorkOrderPlannedCostTriggerService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/app/WorkOrderPlannedCostTriggerService.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -53,7 +54,14 @@ public class WorkOrderPlannedCostTriggerService {
    * @param workOrderId the WorkOrder to compute planned cost for
    * @return updated WorkOrderResponse with plannedCost and plannedCostCurrency
    */
-  @Transactional
+  // REQUIRES_NEW is deliberate: the WorkOrderApprovedEvent listener runs this inside
+  // IdempotentEventHandler.executeOnce's REQUIRES_NEW transaction. If this method joined that
+  // transaction (default REQUIRED) and threw, the outer transaction would be marked
+  // rollback-only even though the listener catches and swallows the exception — the
+  // idempotency INSERT would then roll back too, and Spring Modulith would retry the event
+  // forever (UnexpectedRollbackException on every commit). Running in its own transaction lets
+  // a cost-calculation failure roll back cleanly without poisoning the caller's transaction.
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public WorkOrderResponse triggerPlannedCost(UUID workOrderId) {
     UUID tenantId = TenantContext.requireTenantId();
 

--- a/src/main/java/com/fabricmanagement/production/masterdata/product/api/facade/ProductFacade.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/product/api/facade/ProductFacade.java
@@ -67,4 +67,28 @@ public interface ProductFacade {
    */
   List<com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto> getAttributes(
       String scope);
+
+  /**
+   * Ensure a product attribute exists for the current tenant, creating it if missing.
+   *
+   * <p>The lookup is tenant-scoped (TenantContext); attribute codes repeat across tenants.
+   * ProductAttribute is read-only reference data with no create endpoint, so this is the sanctioned
+   * write path for in-process callers (e.g. bootstrap seeders) that need a tenant-local attribute
+   * axis such as COLOR.
+   *
+   * @param attributeCode Attribute code (e.g., COLOR)
+   * @param attributeName Display name used when the attribute has to be created
+   * @param attributeGroup Attribute group (e.g., VARIANT)
+   * @param productScope Product scope (e.g., FIBER, YARN, FABRIC, ALL)
+   * @param description Description used when the attribute has to be created
+   * @param displayOrder Display order used when the attribute has to be created
+   * @return Existing or newly created attribute
+   */
+  com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto ensureAttribute(
+      String attributeCode,
+      String attributeName,
+      String attributeGroup,
+      String productScope,
+      String description,
+      Integer displayOrder);
 }

--- a/src/main/java/com/fabricmanagement/production/masterdata/product/app/ProductService.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/product/app/ProductService.java
@@ -9,6 +9,7 @@ import com.fabricmanagement.production.masterdata.product.api.facade.ProductFaca
 import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.domain.event.ProductCreatedEvent;
+import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
 import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
 import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
@@ -177,6 +178,47 @@ public class ProductService implements ProductFacade {
     return productAttributeRepository.findByIsActiveTrue().stream()
         .map(ProductAttributeDto::from)
         .toList();
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>The lookup is explicitly tenant-scoped: attribute codes repeat across tenants, and
+   * integration tests run as a superuser DB role that bypasses RLS, so an unscoped code lookup is
+   * not single-result-safe.
+   */
+  @Override
+  @Transactional
+  public ProductAttributeDto ensureAttribute(
+      String attributeCode,
+      String attributeName,
+      String attributeGroup,
+      String productScope,
+      String description,
+      Integer displayOrder) {
+    UUID tenantId = TenantContext.requireTenantId();
+
+    return productAttributeRepository
+        .findFirstByTenantIdAndAttributeCode(tenantId, attributeCode)
+        .map(ProductAttributeDto::from)
+        .orElseGet(
+            () -> {
+              ProductAttribute attribute =
+                  ProductAttribute.builder()
+                      .attributeCode(attributeCode)
+                      .attributeName(attributeName)
+                      .attributeGroup(attributeGroup)
+                      .productScope(productScope)
+                      .description(description)
+                      .displayOrder(displayOrder)
+                      .build();
+              attribute.setTenantId(tenantId);
+
+              ProductAttribute saved = productAttributeRepository.save(attribute);
+              log.info(
+                  "✅ Product attribute created: code={}, tenantId={}", attributeCode, tenantId);
+              return ProductAttributeDto.from(saved);
+            });
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/masterdata/product/infra/repository/ProductAttributeRepository.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/product/infra/repository/ProductAttributeRepository.java
@@ -14,5 +14,12 @@ public interface ProductAttributeRepository extends JpaRepository<ProductAttribu
 
   List<ProductAttribute> findByIsActiveTrueAndProductScopeIn(List<String> scopes);
 
-  Optional<ProductAttribute> findByAttributeCode(String attributeCode);
+  /**
+   * Tenant-scoped code lookup. Attribute codes repeat across tenants (each tenant carries its own
+   * copy of the reference rows), and integration tests run as a superuser DB role that bypasses RLS
+   * — so an unscoped code lookup is not single-result-safe. {@code findFirst} keeps the query safe
+   * even if a tenant ever ends up with duplicate rows for the same code.
+   */
+  Optional<ProductAttribute> findFirstByTenantIdAndAttributeCode(
+      UUID tenantId, String attributeCode);
 }

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
@@ -1,0 +1,392 @@
+package com.fabricmanagement.common.infrastructure.bootstrap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.platform.organization.app.OrganizationService;
+import com.fabricmanagement.platform.organization.infra.repository.DepartmentRepository;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerService;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
+import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
+import com.fabricmanagement.platform.user.app.RoleService;
+import com.fabricmanagement.platform.user.app.UserCreationService;
+import com.fabricmanagement.platform.user.domain.User;
+import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
+import com.fabricmanagement.production.execution.batch.app.BatchService;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
+import com.fabricmanagement.production.execution.batch.dto.ReserveRequest;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.masterdata.color.app.ColorService;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
+import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
+import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
+import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
+import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
+import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
+import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
+import com.fabricmanagement.sales.quote.api.QuoteCreateRequest;
+import com.fabricmanagement.sales.quote.app.QuoteService;
+import com.fabricmanagement.sales.quote.domain.Quote;
+import com.fabricmanagement.sales.quote.dto.AddQuoteLineRequest;
+import com.fabricmanagement.sales.quote.dto.QuoteLineLotSelectionRequest;
+import com.fabricmanagement.sales.salesproduct.app.SalesProductService;
+import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SalesQuoteDemoSeederTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID EMMA_ID = UUID.randomUUID();
+  private static final UUID SANDRA_ID = UUID.randomUUID();
+  private static final LocalDate TODAY = LocalDate.of(2026, 7, 8);
+
+  @Mock private TradingPartnerService tradingPartnerService;
+  @Mock private ProductFacade productFacade;
+  @Mock private QualityGradeService qualityGradeService;
+  @Mock private ColorService colorService;
+  @Mock private BatchService batchService;
+  @Mock private BatchRepository batchRepository;
+  @Mock private StockUnitService stockUnitService;
+  @Mock private BatchAttributeService batchAttributeService;
+  @Mock private ProductAttributeRepository productAttributeRepository;
+  @Mock private SalesProductService salesProductService;
+  @Mock private DiscountPolicyService discountPolicyService;
+  @Mock private ExchangeRateService exchangeRateService;
+  @Mock private QuoteService quoteService;
+  @Mock private UserRepository userRepository;
+  @Mock private UserCreationService userCreationService;
+  @Mock private RoleService roleService;
+  @Mock private DepartmentRepository departmentRepository;
+  @Mock private OrganizationService organizationService;
+
+  private final List<TradingPartnerDto> partners = new ArrayList<>();
+  private final Map<String, UUID> batchIdsByCode = new HashMap<>();
+
+  private SalesQuoteDemoSeeder seeder;
+
+  @BeforeEach
+  void setUp() {
+    Clock clock = Clock.fixed(Instant.parse("2026-07-08T10:00:00Z"), ZoneId.of("UTC"));
+    seeder =
+        new SalesQuoteDemoSeeder(
+            tradingPartnerService,
+            productFacade,
+            qualityGradeService,
+            colorService,
+            batchService,
+            batchRepository,
+            stockUnitService,
+            batchAttributeService,
+            productAttributeRepository,
+            salesProductService,
+            discountPolicyService,
+            exchangeRateService,
+            quoteService,
+            userRepository,
+            userCreationService,
+            roleService,
+            departmentRepository,
+            organizationService,
+            clock);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void seedFor_createsSalesAtpDatasetAndIsIdempotent() {
+    stubHappyPath();
+
+    seeder.seedFor(TENANT_ID);
+    seeder.seedFor(TENANT_ID);
+
+    // Idempotency: the second run must short-circuit on the demo-customer marker.
+    ArgumentCaptor<CreateTradingPartnerRequest> partnerCaptor =
+        ArgumentCaptor.forClass(CreateTradingPartnerRequest.class);
+    verify(tradingPartnerService, times(1)).createPartner(partnerCaptor.capture());
+    assertThat(partnerCaptor.getValue().getPartnerType()).isEqualTo(PartnerType.CUSTOMER);
+    assertThat(partnerCaptor.getValue().getCountry()).isEqualTo("GBR");
+
+    // 3 grades per product type (FABRIC, YARN, FIBER); Waste is never saleable.
+    ArgumentCaptor<Boolean> saleableCaptor = ArgumentCaptor.forClass(Boolean.class);
+    verify(qualityGradeService, times(9))
+        .create(
+            any(ProductType.class),
+            any(String.class),
+            any(String.class),
+            anyInt(),
+            any(BigDecimal.class),
+            saleableCaptor.capture(),
+            anyBoolean(),
+            any(),
+            anyBoolean());
+    assertThat(saleableCaptor.getAllValues()).containsSequence(true, true, false);
+
+    verify(colorService, times(5)).create(any(), any(), any());
+    verify(productFacade, times(3)).createProduct(any(CreateProductRequest.class));
+    verify(salesProductService, times(3)).createEntry(any());
+
+    // 6 scenario lots + 1 waste-grade negative-test lot; all released from QC.
+    verify(batchService, times(7)).create(any(CreateBatchRequest.class));
+    verify(batchRepository, times(7)).save(any(Batch.class));
+
+    // 16 + 24 + 3 rolls, 48 yarn cartons, 2 waste rolls — each graded through the service.
+    verify(stockUnitService, times(93))
+        .create(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            any());
+    verify(stockUnitService, times(93)).changeGrade(any(), any(), any(), any());
+
+    // Emma's open quote + the demo user's draft quote.
+    ArgumentCaptor<QuoteCreateRequest> quoteCaptor =
+        ArgumentCaptor.forClass(QuoteCreateRequest.class);
+    verify(quoteService, times(2)).createQuote(quoteCaptor.capture());
+    QuoteCreateRequest emmaQuote = quoteCaptor.getAllValues().get(0);
+    // Quote numbers carry a per-tenant suffix: quote_number is globally unique in the schema.
+    assertThat(emmaQuote.getQuoteNumber())
+        .startsWith(SalesQuoteDemoSeeder.COMPETING_QUOTE_NUMBER_STEM);
+    assertThat(emmaQuote.getCurrency()).isEqualTo("GBP");
+    assertThat(emmaQuote.getAssignedToId()).isEqualTo(EMMA_ID);
+    assertThat(emmaQuote.getValidUntil()).isEqualTo(TODAY.plusDays(14));
+    QuoteCreateRequest draftQuote = quoteCaptor.getAllValues().get(1);
+    assertThat(draftQuote.getQuoteNumber())
+        .startsWith(SalesQuoteDemoSeeder.DRAFT_QUOTE_NUMBER_STEM);
+    assertThat(draftQuote.getAssignedToId()).isEqualTo(SANDRA_ID);
+
+    // Intents ride through QuoteService.addQuoteLine: per line, the selected-lot quantity must
+    // equal the requested quantity so BatchLotQuantityIntentPort invariants hold.
+    ArgumentCaptor<AddQuoteLineRequest> lineCaptor =
+        ArgumentCaptor.forClass(AddQuoteLineRequest.class);
+    verify(quoteService, times(3)).addQuoteLine(any(UUID.class), lineCaptor.capture());
+    List<AddQuoteLineRequest> lines = lineCaptor.getAllValues();
+
+    List<AddQuoteLineRequest> lotBackedLines =
+        lines.stream().filter(line -> line.getSelectedLots() != null).toList();
+    assertThat(lotBackedLines).hasSize(2);
+    assertThat(lotBackedLines)
+        .allSatisfy(
+            line -> {
+              assertThat(line.getSelectedLots()).hasSize(1);
+              QuoteLineLotSelectionRequest selection = line.getSelectedLots().get(0);
+              assertThat(selection.quantity()).isEqualByComparingTo(line.getRequestedQty());
+            });
+    assertThat(lotBackedLines.get(0).getSelectedLots().get(0).lotId())
+        .isEqualTo(batchIdsByCode.get("LOT-24011"));
+    assertThat(lotBackedLines.get(0).getRequestedQty()).isEqualByComparingTo("1500");
+    assertThat(lotBackedLines.get(1).getSelectedLots().get(0).lotId())
+        .isEqualTo(batchIdsByCode.get("LOT-24012"));
+    assertThat(lotBackedLines.get(1).getRequestedQty()).isEqualByComparingTo("2000");
+
+    // The draft line stays free-entry: no lots selected.
+    assertThat(lines.stream().filter(line -> line.getSelectedLots() == null)).hasSize(1);
+
+    // Hard reservation: 200 m on the Ecru bulk lot, seeded through BatchService.reserve.
+    ArgumentCaptor<ReserveRequest> reserveCaptor = ArgumentCaptor.forClass(ReserveRequest.class);
+    verify(batchService, times(1))
+        .reserve(eq(batchIdsByCode.get("LOT-24020")), reserveCaptor.capture());
+    assertThat(reserveCaptor.getValue().getQuantity()).isEqualByComparingTo("200");
+    assertThat(reserveCaptor.getValue().getReferenceType()).isEqualTo("SALES_ORDER");
+  }
+
+  @Test
+  void seedFor_neverThrowsWhenDependencyFails() {
+    when(tradingPartnerService.searchByName(TENANT_ID, SalesQuoteDemoSeeder.CUSTOMER_ALBION))
+        .thenReturn(List.of());
+    when(qualityGradeService.findByProductType(any(ProductType.class)))
+        .thenThrow(new IllegalStateException("grades unavailable"));
+
+    assertThatCode(() -> seeder.seedFor(TENANT_ID)).doesNotThrowAnyException();
+    verify(tradingPartnerService, never()).createPartner(any());
+  }
+
+  private void stubHappyPath() {
+    when(tradingPartnerService.searchByName(TENANT_ID, SalesQuoteDemoSeeder.CUSTOMER_ALBION))
+        .thenAnswer(invocation -> List.copyOf(partners));
+    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              CreateTradingPartnerRequest req = invocation.getArgument(0);
+              TradingPartnerDto dto =
+                  TradingPartnerDto.builder()
+                      .id(UUID.randomUUID())
+                      .displayName(req.getCompanyName())
+                      .partnerType(req.getPartnerType())
+                      .build();
+              partners.add(dto);
+              return dto;
+            });
+
+    when(qualityGradeService.findByProductType(any(ProductType.class))).thenReturn(List.of());
+    when(qualityGradeService.create(
+            any(ProductType.class),
+            any(String.class),
+            any(String.class),
+            anyInt(),
+            any(BigDecimal.class),
+            anyBoolean(),
+            anyBoolean(),
+            any(),
+            anyBoolean()))
+        .thenAnswer(
+            invocation -> {
+              QualityGrade grade =
+                  QualityGrade.builder()
+                      .productType(invocation.getArgument(0))
+                      .code(invocation.getArgument(1))
+                      .name(invocation.getArgument(2))
+                      .rank(invocation.getArgument(3))
+                      .priceFactor(invocation.getArgument(4))
+                      .saleable(invocation.getArgument(5))
+                      .requiresApproval(invocation.getArgument(6))
+                      .colorHex(invocation.getArgument(7))
+                      .isDefault(invocation.getArgument(8))
+                      .build();
+              grade.setId(UUID.randomUUID());
+              grade.setTenantId(TENANT_ID);
+              return grade;
+            });
+
+    when(colorService.list(true)).thenReturn(List.of());
+    when(colorService.create(any(), any(), any()))
+        .thenAnswer(
+            invocation -> {
+              Color colour =
+                  Color.builder()
+                      .code(invocation.getArgument(0))
+                      .name(invocation.getArgument(1))
+                      .colorHex(invocation.getArgument(2))
+                      .build();
+              colour.setId(UUID.randomUUID());
+              colour.setTenantId(TENANT_ID);
+              return colour;
+            });
+
+    when(productAttributeRepository.findByAttributeCode("COLOR")).thenReturn(Optional.empty());
+    when(productAttributeRepository.save(any(ProductAttribute.class)))
+        .thenAnswer(
+            invocation -> {
+              ProductAttribute attribute = invocation.getArgument(0);
+              attribute.setId(UUID.randomUUID());
+              return attribute;
+            });
+
+    when(productFacade.createProduct(any(CreateProductRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              CreateProductRequest req = invocation.getArgument(0);
+              return ProductDto.builder()
+                  .id(UUID.randomUUID())
+                  .productType(req.getProductType())
+                  .unit(req.getUnit())
+                  .build();
+            });
+
+    when(discountPolicyService.getActivePolicy("FABRIC"))
+        .thenThrow(new IllegalArgumentException("No active discount policy"));
+
+    when(batchService.create(any(CreateBatchRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              CreateBatchRequest req = invocation.getArgument(0);
+              UUID id = UUID.randomUUID();
+              batchIdsByCode.put(req.getBatchCode(), id);
+              return BatchDto.builder()
+                  .id(id)
+                  .batchCode(req.getBatchCode())
+                  .productType(req.getProductType())
+                  .build();
+            });
+    when(batchRepository.findByIdAndTenantId(any(UUID.class), eq(TENANT_ID)))
+        .thenAnswer(
+            invocation -> {
+              Batch batch =
+                  Batch.builder()
+                      .productId(UUID.randomUUID())
+                      .productType(ProductType.FABRIC)
+                      .batchCode("LOT-TEST")
+                      .quantity(BigDecimal.ONE)
+                      .unit("M")
+                      .status(BatchStatus.PENDING_QC)
+                      .build();
+              batch.setId(invocation.getArgument(0));
+              batch.setTenantId(TENANT_ID);
+              return Optional.of(batch);
+            });
+    when(batchRepository.save(any(Batch.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    when(stockUnitService.create(
+            any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
+            any()))
+        .thenAnswer(
+            invocation -> {
+              StockUnit unit = StockUnit.builder().barcode(invocation.getArgument(2)).build();
+              unit.setId(UUID.randomUUID());
+              return unit;
+            });
+
+    when(userRepository.findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(
+            TENANT_ID,
+            SalesQuoteDemoSeeder.MARKETER_FIRST_NAME,
+            SalesQuoteDemoSeeder.MARKETER_LAST_NAME))
+        .thenReturn(Optional.of(user(EMMA_ID, "Emma", "Whitfield")));
+    when(userRepository.findFirstByTenantIdAndFirstNameAndLastNameAndIsActiveTrue(
+            TENANT_ID, "Sandra", "Deal"))
+        .thenReturn(Optional.of(user(SANDRA_ID, "Sandra", "Deal")));
+
+    when(quoteService.createQuote(any(QuoteCreateRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              QuoteCreateRequest req = invocation.getArgument(0);
+              Quote quote = req.toQuote();
+              quote.setId(UUID.randomUUID());
+              quote.setTenantId(TENANT_ID);
+              return quote;
+            });
+  }
+
+  private User user(UUID id, String firstName, String lastName) {
+    User user = User.builder().firstName(firstName).lastName(lastName).build();
+    user.setId(id);
+    return user;
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
@@ -1,7 +1,7 @@
 package com.fabricmanagement.common.infrastructure.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -25,22 +25,18 @@ import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
 import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
 import com.fabricmanagement.production.execution.batch.app.BatchService;
-import com.fabricmanagement.production.execution.batch.domain.Batch;
-import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
 import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
 import com.fabricmanagement.production.execution.batch.dto.ReserveRequest;
-import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.masterdata.color.app.ColorService;
 import com.fabricmanagement.production.masterdata.color.domain.Color;
 import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
-import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
 import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
+import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
-import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
@@ -68,6 +64,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @ExtendWith(MockitoExtension.class)
 class SalesQuoteDemoSeederTest {
@@ -82,10 +80,8 @@ class SalesQuoteDemoSeederTest {
   @Mock private QualityGradeService qualityGradeService;
   @Mock private ColorService colorService;
   @Mock private BatchService batchService;
-  @Mock private BatchRepository batchRepository;
   @Mock private StockUnitService stockUnitService;
   @Mock private BatchAttributeService batchAttributeService;
-  @Mock private ProductAttributeRepository productAttributeRepository;
   @Mock private SalesProductService salesProductService;
   @Mock private DiscountPolicyService discountPolicyService;
   @Mock private ExchangeRateService exchangeRateService;
@@ -111,10 +107,8 @@ class SalesQuoteDemoSeederTest {
             qualityGradeService,
             colorService,
             batchService,
-            batchRepository,
             stockUnitService,
             batchAttributeService,
-            productAttributeRepository,
             salesProductService,
             discountPolicyService,
             exchangeRateService,
@@ -165,9 +159,19 @@ class SalesQuoteDemoSeederTest {
     verify(productFacade, times(3)).createProduct(any(CreateProductRequest.class));
     verify(salesProductService, times(3)).createEntry(any());
 
-    // 6 scenario lots + 1 waste-grade negative-test lot; all released from QC.
-    verify(batchService, times(7)).create(any(CreateBatchRequest.class));
-    verify(batchRepository, times(7)).save(any(Batch.class));
+    // 6 scenario lots + 1 waste-grade negative-test lot; all released from QC via the service.
+    ArgumentCaptor<CreateBatchRequest> batchCaptor =
+        ArgumentCaptor.forClass(CreateBatchRequest.class);
+    verify(batchService, times(7)).create(batchCaptor.capture());
+    verify(batchService, times(7)).releaseFromQc(any(UUID.class));
+    // Regression guard: production_execution_batch.chk_batch_unit admits only KG/MT/PIECE — a
+    // batch header with unit "M" aborts the INSERT and poisoned real signup transactions.
+    assertThat(batchCaptor.getAllValues())
+        .extracting(CreateBatchRequest::getUnit)
+        .allMatch(List.of("KG", "MT", "PIECE")::contains);
+
+    // The colour axis rides through the tenant-scoped app-layer ensure, not a repository write.
+    verify(productFacade, times(1)).ensureAttribute(eq("COLOR"), any(), any(), any(), any(), any());
 
     // 16 + 24 + 3 rolls, 48 yarn cartons, 2 waste rolls — each graded through the service.
     verify(stockUnitService, times(93))
@@ -228,14 +232,32 @@ class SalesQuoteDemoSeederTest {
   }
 
   @Test
-  void seedFor_neverThrowsWhenDependencyFails() {
+  void seedFor_propagatesDependencyFailure_soOwnTransactionRollsBack() {
     when(tradingPartnerService.searchByName(TENANT_ID, SalesQuoteDemoSeeder.CUSTOMER_ALBION))
         .thenReturn(List.of());
     when(qualityGradeService.findByProductType(any(ProductType.class)))
         .thenThrow(new IllegalStateException("grades unavailable"));
 
-    assertThatCode(() -> seeder.seedFor(TENANT_ID)).doesNotThrowAnyException();
+    // SalesDemoSeeder pattern: failures must ESCAPE seedFor so the REQUIRES_NEW transaction rolls
+    // back cleanly; DemoTransactionSeeder catches them outside the boundary. Swallowing inside
+    // would commit a rollback-only/aborted transaction and poison the caller's signup transaction.
+    assertThatThrownBy(() -> seeder.seedFor(TENANT_ID))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("grades unavailable");
     verify(tradingPartnerService, never()).createPartner(any());
+    // The finally block must still restore the previous tenant context.
+    assertThat(TenantContext.getCurrentTenantIdOrNull()).isNull();
+  }
+
+  @Test
+  void seedFor_declaresItsOwnTransactionBoundary() throws NoSuchMethodException {
+    Transactional transactional =
+        SalesQuoteDemoSeeder.class
+            .getMethod("seedFor", UUID.class)
+            .getAnnotation(Transactional.class);
+
+    assertThat(transactional).as("seedFor must run in its own transaction").isNotNull();
+    assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
   }
 
   private void stubHappyPath() {
@@ -300,14 +322,16 @@ class SalesQuoteDemoSeederTest {
               return colour;
             });
 
-    when(productAttributeRepository.findByAttributeCode("COLOR")).thenReturn(Optional.empty());
-    when(productAttributeRepository.save(any(ProductAttribute.class)))
+    when(productFacade.ensureAttribute(eq("COLOR"), any(), any(), any(), any(), any()))
         .thenAnswer(
-            invocation -> {
-              ProductAttribute attribute = invocation.getArgument(0);
-              attribute.setId(UUID.randomUUID());
-              return attribute;
-            });
+            invocation ->
+                ProductAttributeDto.builder()
+                    .id(UUID.randomUUID())
+                    .attributeCode(invocation.getArgument(0))
+                    .attributeName(invocation.getArgument(1))
+                    .attributeGroup(invocation.getArgument(2))
+                    .productScope(invocation.getArgument(3))
+                    .build());
 
     when(productFacade.createProduct(any(CreateProductRequest.class)))
         .thenAnswer(
@@ -335,25 +359,6 @@ class SalesQuoteDemoSeederTest {
                   .productType(req.getProductType())
                   .build();
             });
-    when(batchRepository.findByIdAndTenantId(any(UUID.class), eq(TENANT_ID)))
-        .thenAnswer(
-            invocation -> {
-              Batch batch =
-                  Batch.builder()
-                      .productId(UUID.randomUUID())
-                      .productType(ProductType.FABRIC)
-                      .batchCode("LOT-TEST")
-                      .quantity(BigDecimal.ONE)
-                      .unit("M")
-                      .status(BatchStatus.PENDING_QC)
-                      .build();
-              batch.setId(invocation.getArgument(0));
-              batch.setTenantId(TENANT_ID);
-              return Optional.of(batch);
-            });
-    when(batchRepository.save(any(Batch.class)))
-        .thenAnswer(invocation -> invocation.getArgument(0));
-
     when(stockUnitService.create(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
             any()))

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
@@ -1,0 +1,95 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchCertificationRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchReservationRepository;
+import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberQualityStandardRepository;
+import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class BatchServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Mock private BatchRepository batchRepository;
+  @Mock private BatchReservationRepository reservationRepository;
+  @Mock private BatchCertificationRepository batchCertificationRepository;
+  @Mock private FiberRepository fiberRepository;
+  @Mock private FiberQualityStandardRepository qualityStandardRepository;
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+  @InjectMocks private BatchService batchService;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void releaseFromQc_transitionsPendingQcBatchToAvailable() {
+    Batch batch = pendingQcBatch();
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+    when(batchRepository.save(any(Batch.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    BatchDto result = batchService.releaseFromQc(BATCH_ID);
+
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+    assertThat(result.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+    verify(batchRepository).save(batch);
+  }
+
+  @Test
+  void releaseFromQc_whenBatchNotFoundForTenant_throwsNotFound() {
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> batchService.releaseFromQc(BATCH_ID))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining(BATCH_ID.toString());
+    verify(batchRepository, never()).save(any());
+  }
+
+  private Batch pendingQcBatch() {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(ProductType.FABRIC)
+            .batchCode("LOT-24011")
+            .quantity(new BigDecimal("2000"))
+            .unit("M")
+            .status(BatchStatus.PENDING_QC)
+            .build();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    return batch;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/product/app/ProductServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/product/app/ProductServiceTest.java
@@ -1,21 +1,30 @@
 package com.fabricmanagement.production.masterdata.product.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.masterdata.fiber.api.facade.FiberFacade;
 import com.fabricmanagement.production.masterdata.fiber.dto.FiberDto;
 import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
+import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -35,6 +44,11 @@ class ProductServiceTest {
     productService =
         new ProductService(
             productRepository, productAttributeRepository, fiberFacade, eventPublisher);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
   }
 
   @Test
@@ -95,5 +109,68 @@ class ProductServiceTest {
     ProductDto dto = result.get(0);
     assertThat(dto.getProductType()).isEqualTo(ProductType.YARN);
     assertThat(dto.getDisplayName()).isEqualTo("PRD-2000");
+  }
+
+  @Test
+  void ensureAttribute_whenAttributeExistsForTenant_returnsItWithoutCreating() {
+    // Arrange
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    ProductAttribute existing =
+        ProductAttribute.builder()
+            .attributeCode("COLOR")
+            .attributeName("Colour")
+            .attributeGroup("VARIANT")
+            .productScope("ALL")
+            .build();
+    existing.setId(UUID.randomUUID());
+    existing.setTenantId(tenantId);
+
+    when(productAttributeRepository.findFirstByTenantIdAndAttributeCode(tenantId, "COLOR"))
+        .thenReturn(Optional.of(existing));
+
+    // Act
+    ProductAttributeDto result =
+        productService.ensureAttribute(
+            "COLOR", "Colour", "VARIANT", "ALL", "Colour card reference", 100);
+
+    // Assert
+    assertThat(result.id()).isEqualTo(existing.getId());
+    assertThat(result.attributeCode()).isEqualTo("COLOR");
+    verify(productAttributeRepository, never()).save(any());
+  }
+
+  @Test
+  void ensureAttribute_whenMissing_createsTenantScopedAttribute() {
+    // Arrange
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    when(productAttributeRepository.findFirstByTenantIdAndAttributeCode(tenantId, "COLOR"))
+        .thenReturn(Optional.empty());
+    when(productAttributeRepository.save(any(ProductAttribute.class)))
+        .thenAnswer(
+            invocation -> {
+              ProductAttribute attribute = invocation.getArgument(0);
+              attribute.setId(UUID.randomUUID());
+              return attribute;
+            });
+
+    // Act
+    ProductAttributeDto result =
+        productService.ensureAttribute(
+            "COLOR", "Colour", "VARIANT", "ALL", "Colour card reference", 100);
+
+    // Assert
+    ArgumentCaptor<ProductAttribute> captor = ArgumentCaptor.forClass(ProductAttribute.class);
+    verify(productAttributeRepository).save(captor.capture());
+    ProductAttribute saved = captor.getValue();
+    assertThat(saved.getTenantId()).isEqualTo(tenantId);
+    assertThat(saved.getAttributeCode()).isEqualTo("COLOR");
+    assertThat(saved.getAttributeGroup()).isEqualTo("VARIANT");
+    assertThat(saved.getProductScope()).isEqualTo("ALL");
+    assertThat(result.id()).isNotNull();
+    assertThat(result.displayOrder()).isEqualTo(100);
   }
 }


### PR DESCRIPTION
…ng idempotency insert

triggerPlannedCost() ran with default @Transactional (REQUIRED), joining the REQUIRES_NEW transaction opened by IdempotentEventHandler.executeOnce(). When a WorkOrder was missing moduleType/outputProductId (or cost calc failed for any other reason), the exception was caught and swallowed in WorkOrderPlannedCostListener as intended, but the joined transaction had already been marked rollback-only by Spring. On commit this threw UnexpectedRollbackException, which also rolled back the idempotency INSERT — so Spring Modulith kept retrying the same event on every restart, spamming ERROR logs indefinitely (see 2026-07-01 WorkOrderApprovedEvent retries still firing on 2026-07-08).

Switch triggerPlannedCost() to Propagation.REQUIRES_NEW so a cost-calculation failure rolls back its own transaction only, leaving the idempotency bookkeeping transaction free to commit normally. This was already the intended behavior per the class's own Javadoc ("cost failure must not fail WorkOrder approval") — the propagation gap was the last piece stopping that guarantee from holding.