### PR TITLE
fix(events): restore tenant context in async event listeners (ASYNC-T…

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/config/AsyncConfig.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/config/AsyncConfig.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.common.infrastructure.config;
 import java.util.concurrent.Executor;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
@@ -12,7 +13,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
  * uncaught-exception logging. (Spring allows only one {@code AsyncConfigurer} bean.)
  */
 @Configuration
-@EnableAsync(proxyTargetClass = true)
+@EnableAsync(proxyTargetClass = true, order = Ordered.HIGHEST_PRECEDENCE)
 public class AsyncConfig implements AsyncConfigurer {
 
   @Override

--- a/src/main/java/com/fabricmanagement/common/infrastructure/config/MdcCorrelationIdAccessor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/config/MdcCorrelationIdAccessor.java
@@ -1,0 +1,44 @@
+package com.fabricmanagement.common.infrastructure.config;
+
+import io.micrometer.context.ContextRegistry;
+import io.micrometer.context.ThreadLocalAccessor;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+/** Propagates the DomainEvent correlation id MDC entry through async task decoration. */
+@Component
+public class MdcCorrelationIdAccessor implements ThreadLocalAccessor<String> {
+
+  public static final String KEY = "mdc.correlationId";
+  private static final String MDC_KEY = "correlationId";
+
+  @PostConstruct
+  public void register() {
+    ContextRegistry.getInstance().registerThreadLocalAccessor(this);
+  }
+
+  @Override
+  public Object key() {
+    return KEY;
+  }
+
+  @Override
+  public String getValue() {
+    return MDC.get(MDC_KEY);
+  }
+
+  @Override
+  public void setValue(String value) {
+    if (value == null) {
+      MDC.remove(MDC_KEY);
+    } else {
+      MDC.put(MDC_KEY, value);
+    }
+  }
+
+  @Override
+  public void setValue() {
+    MDC.remove(MDC_KEY);
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/config/TenantRestoringEventListenerAspect.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/config/TenantRestoringEventListenerAspect.java
@@ -20,20 +20,25 @@ import org.springframework.stereotype.Component;
  * {@code @TransactionalEventListener} and {@code @EventListener} methods, extracts the {@code
  * tenantId} from the {@link DomainEvent} payload, and sets the TenantContext before execution. It
  * restores or clears the context afterward.
+ *
+ * <p>The order matters because tenant restoration must happen before transaction advice acquires a
+ * database connection; setting the thread-local after the connection is bound does not update the
+ * PostgreSQL session variable used by RLS.
+ *
+ * <p>AspectJ {@code @annotation} pointcuts do not resolve meta-annotations. Composed annotations
+ * such as {@code @ApplicationModuleListener} must be listed explicitly, by their current package
+ * name.
  */
 @Aspect
 @Component
-@Order(
-    Ordered
-        .HIGHEST_PRECEDENCE) // Must run BEFORE @Transactional so TenantConnectionProvider sees the
-// correct tenant
+@Order(Ordered.HIGHEST_PRECEDENCE + 100)
 @Slf4j
 public class TenantRestoringEventListenerAspect {
 
   @Around(
       "@annotation(org.springframework.transaction.event.TransactionalEventListener) "
           + "|| @annotation(org.springframework.context.event.EventListener) "
-          + "|| @annotation(org.springframework.modulith.ApplicationModuleListener)")
+          + "|| @annotation(org.springframework.modulith.events.ApplicationModuleListener)")
   public Object restoreTenantContext(ProceedingJoinPoint pjp) throws Throwable {
     Object[] args = pjp.getArgs();
     DomainEvent event = extractDomainEvent(args);

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/DomainEvent.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/DomainEvent.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.common.infrastructure.events;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
@@ -39,23 +41,45 @@ import org.slf4j.MDC;
 @Getter
 public abstract class DomainEvent {
 
-  private final UUID eventId;
-  private final UUID tenantId;
-  private final String eventType;
-  private final Instant occurredAt;
-  private final String correlationId;
+  @JsonProperty("eventId")
+  private UUID eventId;
+
+  @JsonProperty("tenantId")
+  private UUID tenantId;
+
+  @JsonProperty("eventType")
+  private String eventType;
+
+  @JsonProperty("occurredAt")
+  private Instant occurredAt;
+
+  @JsonProperty("correlationId")
+  private String correlationId;
 
   protected DomainEvent(UUID tenantId, String eventType) {
+    this(UUID.randomUUID(), tenantId, eventType, Instant.now(), null);
+  }
+
+  @JsonCreator
+  protected DomainEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId) {
     Objects.requireNonNull(tenantId, "tenantId must not be null");
-    this.eventId = UUID.randomUUID();
+    Objects.requireNonNull(eventType, "eventType must not be null");
+    this.eventId = eventId != null ? eventId : UUID.randomUUID();
     this.tenantId = tenantId;
     this.eventType = eventType;
-    this.occurredAt = Instant.now();
+    this.occurredAt = occurredAt != null ? occurredAt : Instant.now();
 
     // Capture traceId as correlationId if present, otherwise fallback to eventId
     String traceId = MDC.get("traceId");
     this.correlationId =
-        (traceId != null && !traceId.isBlank()) ? traceId : this.eventId.toString();
+        correlationId != null
+            ? correlationId
+            : (traceId != null && !traceId.isBlank()) ? traceId : this.eventId.toString();
   }
 
   @Override

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepository.java
@@ -21,5 +21,5 @@ public interface PurchaseOrderRepository
 
   boolean existsByPoNumberAndIsActiveTrue(String poNumber);
 
-  boolean existsBySupplierQuoteIdAndIsActiveTrue(UUID supplierQuoteId);
+  boolean existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(UUID tenantId, UUID supplierQuoteId);
 }

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestrator.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestrator.java
@@ -2,6 +2,7 @@ package com.fabricmanagement.procurement.quote.app.listener;
 
 import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
@@ -43,6 +44,7 @@ public class QuoteToOrderOrchestrator {
   private final SubcontractOrderService subcontractOrderService;
   private final ObjectMapper objectMapper;
   private final IdempotentEventHandler idempotentHandler;
+  private final TenantSessionBinder tenantSessionBinder;
 
   @ApplicationModuleListener
   public void onQuoteAccepted(SupplierQuoteAcceptedEvent event) {
@@ -56,24 +58,28 @@ public class QuoteToOrderOrchestrator {
           TenantContext.executeInTenantContext(
               event.getTenantId(),
               () -> {
-                quoteRepository
-                    .findByTenantIdAndIdAndIsActiveTrue(event.getTenantId(), event.getQuoteId())
-                    .ifPresentOrElse(
-                        quote ->
-                            rfqRepository
-                                .findByTenantIdAndIdAndIsActiveTrue(
-                                    event.getTenantId(), quote.getRfqId())
-                                .ifPresentOrElse(
-                                    rfq -> routeToOrder(quote, rfq),
-                                    () ->
-                                        log.warn(
-                                            "RFQ not found for quote {} (rfqId={}), skipping order creation",
-                                            event.getQuoteId(),
-                                            quote.getRfqId())),
-                        () ->
-                            log.warn(
-                                "Quote not found: {}, skipping order creation",
-                                event.getQuoteId()));
+                tenantSessionBinder.bindToCurrentSession(event.getTenantId());
+                SupplierQuote quote =
+                    quoteRepository
+                        .findByTenantIdAndIdAndIsActiveTrue(event.getTenantId(), event.getQuoteId())
+                        .orElseThrow(
+                            () ->
+                                new IllegalStateException(
+                                    "Quote not found: "
+                                        + event.getQuoteId()
+                                        + ", retrying order creation"));
+                SupplierRFQ rfq =
+                    rfqRepository
+                        .findByTenantIdAndIdAndIsActiveTrue(event.getTenantId(), quote.getRfqId())
+                        .orElseThrow(
+                            () ->
+                                new IllegalStateException(
+                                    "RFQ not found for quote "
+                                        + event.getQuoteId()
+                                        + " (rfqId="
+                                        + quote.getRfqId()
+                                        + "), retrying order creation"));
+                routeToOrder(quote, rfq);
               });
         });
   }
@@ -93,7 +99,8 @@ public class QuoteToOrderOrchestrator {
 
   private void createPurchaseOrder(SupplierQuote quote, SupplierRFQ rfq) {
     // Idempotency check: prevent duplicate PO for the same quote
-    if (purchaseOrderRepository.existsBySupplierQuoteIdAndIsActiveTrue(quote.getId())) {
+    if (purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+        quote.getTenantId(), quote.getId())) {
       log.warn(
           "PurchaseOrder already exists for quote {}, skipping duplicate creation",
           quote.getQuoteNumber());
@@ -157,16 +164,8 @@ public class QuoteToOrderOrchestrator {
             .lines(lines)
             .build();
 
-    try {
-      purchaseOrderService.createPurchaseOrder(poRequest);
-      log.info("Successfully created PurchaseOrder for quote {}", quote.getQuoteNumber());
-    } catch (RuntimeException e) {
-      log.error(
-          "Failed to create PurchaseOrder for quote {}: {}",
-          quote.getQuoteNumber(),
-          e.getMessage(),
-          e);
-    }
+    purchaseOrderService.createPurchaseOrder(poRequest);
+    log.info("Successfully created PurchaseOrder for quote {}", quote.getQuoteNumber());
   }
 
   private void createSubcontractOrder(SupplierQuote quote, SupplierRFQ rfq) {
@@ -200,16 +199,8 @@ public class QuoteToOrderOrchestrator {
             .notes("Auto-generated from Subcontract Quote: " + quote.getQuoteNumber())
             .build();
 
-    try {
-      subcontractOrderService.createSubcontractOrder(soRequest);
-      log.info("Successfully created SubcontractOrder for quote {}", quote.getQuoteNumber());
-    } catch (RuntimeException e) {
-      log.error(
-          "Failed to create SubcontractOrder for quote {}: {}",
-          quote.getQuoteNumber(),
-          e.getMessage(),
-          e);
-    }
+    subcontractOrderService.createSubcontractOrder(soRequest);
+    log.info("Successfully created SubcontractOrder for quote {}", quote.getQuoteNumber());
   }
 
   private PurchaseOrderModuleType mapRfqModuleType(SupplierRFQModuleType rfqType) {

--- a/src/main/java/com/fabricmanagement/procurement/quote/domain/event/SupplierQuoteAcceptedEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/domain/event/SupplierQuoteAcceptedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.quote.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,25 @@ public class SupplierQuoteAcceptedEvent extends DomainEvent {
 
   public SupplierQuoteAcceptedEvent(UUID tenantId, UUID quoteId, UUID rfqId) {
     super(tenantId, "SUPPLIER_QUOTE_ACCEPTED");
+    this.quoteId = quoteId;
+    this.rfqId = rfqId;
+  }
+
+  @JsonCreator
+  public SupplierQuoteAcceptedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("rfqId") UUID rfqId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SUPPLIER_QUOTE_ACCEPTED",
+        occurredAt,
+        correlationId);
     this.quoteId = quoteId;
     this.rfqId = rfqId;
   }

--- a/src/test/java/com/fabricmanagement/common/infrastructure/config/AsyncTenantContextPropagationTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/config/AsyncTenantContextPropagationTest.java
@@ -1,0 +1,61 @@
+package com.fabricmanagement.common.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+@SpringJUnitConfig(
+    classes = {
+      AsyncConfig.class,
+      TenantContextAccessor.class,
+      AsyncTenantContextPropagationTest.ProbeConfig.class
+    })
+class AsyncTenantContextPropagationTest {
+
+  @Autowired private AsyncTenantProbe probe;
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void asyncMethodReceivesTenantContextFromSubmittingThread() throws Exception {
+    UUID tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+
+    AsyncTenantSnapshot snapshot = probe.captureTenant().get(5, TimeUnit.SECONDS);
+
+    assertThat(snapshot.threadName()).startsWith("async-tenant-");
+    assertThat(snapshot.tenantId()).isEqualTo(tenantId);
+  }
+
+  @Configuration
+  static class ProbeConfig {
+    @Bean
+    AsyncTenantProbe asyncTenantProbe() {
+      return new AsyncTenantProbe();
+    }
+  }
+
+  public static class AsyncTenantProbe {
+    @Async
+    public CompletableFuture<AsyncTenantSnapshot> captureTenant() {
+      return CompletableFuture.completedFuture(
+          new AsyncTenantSnapshot(
+              Thread.currentThread().getName(), TenantContext.getCurrentTenantIdOrNull()));
+    }
+  }
+
+  record AsyncTenantSnapshot(String threadName, UUID tenantId) {}
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/config/TenantRestoringEventListenerAspectTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/config/TenantRestoringEventListenerAspectTest.java
@@ -1,0 +1,29 @@
+package com.fabricmanagement.common.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.aspectj.AspectJExpressionPointcut;
+import org.springframework.modulith.events.ApplicationModuleListener;
+
+class TenantRestoringEventListenerAspectTest {
+
+  @Test
+  void pointcutMatchesCurrentApplicationModuleListenerPackage() throws NoSuchMethodException {
+    AspectJExpressionPointcut pointcut = new AspectJExpressionPointcut();
+    pointcut.setExpression(
+        "@annotation(org.springframework.transaction.event.TransactionalEventListener) "
+            + "|| @annotation(org.springframework.context.event.EventListener) "
+            + "|| @annotation(org.springframework.modulith.events.ApplicationModuleListener)");
+
+    Method method = ModulithListenerProbe.class.getMethod("handle");
+
+    assertThat(pointcut.matches(method, ModulithListenerProbe.class)).isTrue();
+  }
+
+  static class ModulithListenerProbe {
+    @ApplicationModuleListener
+    public void handle() {}
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/DomainEventSerializationTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/DomainEventSerializationTest.java
@@ -1,0 +1,39 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.procurement.quote.domain.event.SupplierQuoteAcceptedEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+
+class DomainEventSerializationTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+
+  @AfterEach
+  void clearMdc() {
+    MDC.clear();
+  }
+
+  @Test
+  void supplierQuoteAcceptedEventRoundTripPreservesDomainEventEnvelope() throws Exception {
+    MDC.put("traceId", "trace-round-trip");
+    SupplierQuoteAcceptedEvent original =
+        new SupplierQuoteAcceptedEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
+    MDC.clear();
+
+    String json = objectMapper.writeValueAsString(original);
+    SupplierQuoteAcceptedEvent restored =
+        objectMapper.readValue(json, SupplierQuoteAcceptedEvent.class);
+
+    assertThat(restored.getEventId()).isEqualTo(original.getEventId());
+    assertThat(restored.getOccurredAt()).isEqualTo(original.getOccurredAt());
+    assertThat(restored.getCorrelationId()).isEqualTo(original.getCorrelationId());
+    assertThat(restored.getTenantId()).isEqualTo(original.getTenantId());
+    assertThat(restored.getQuoteId()).isEqualTo(original.getQuoteId());
+    assertThat(restored.getRfqId()).isEqualTo(original.getRfqId());
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/DurableEventCorrelationIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/DurableEventCorrelationIT.java
@@ -15,13 +15,11 @@ import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.scheduling.annotation.Async;
+import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.transaction.support.TransactionTemplate;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -114,8 +112,7 @@ class DurableEventCorrelationIT {
     private final CopyOnWriteArrayList<CorrelationResult> receivedCorrelations =
         new CopyOnWriteArrayList<>();
 
-    @Async
-    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @ApplicationModuleListener
     public void handle(TestDurableEvent event) {
       String mdcCorrelationId = MDC.get("correlationId");
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/DurableEventDeliveryIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/DurableEventDeliveryIT.java
@@ -18,7 +18,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Import;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.modulith.events.ApplicationModuleListener;
-import org.springframework.modulith.events.IncompleteEventPublications;
 import org.springframework.stereotype.Component;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -58,7 +57,6 @@ class DurableEventDeliveryIT {
   @Autowired private TransactionTemplate transactionTemplate;
   @Autowired private JdbcTemplate jdbcTemplate;
   @Autowired private TestEventListener testEventListener;
-  @Autowired private IncompleteEventPublications incompletePublications;
 
   private static final UUID TENANT_ID = UUID.randomUUID();
 
@@ -67,6 +65,7 @@ class DurableEventDeliveryIT {
     TenantContext.setCurrentTenantId(TENANT_ID);
     testEventListener.reset();
     jdbcTemplate.execute("DELETE FROM processed_event");
+    jdbcTemplate.execute("DELETE FROM event_publication");
   }
 
   @AfterEach
@@ -169,11 +168,20 @@ class DurableEventDeliveryIT {
               assertThat(testEventListener.getInvocationCount()).isEqualTo(1); // Tried once, failed
             });
 
-    // Act 2: Manually trigger the EventResubmissionJob logic
-    incompletePublications.resubmitIncompletePublicationsOlderThan(Duration.ZERO);
+    Integer processedAfterFailure =
+        jdbcTemplate.queryForObject(
+            "SELECT count(*) FROM processed_event WHERE event_id = ?",
+            Integer.class,
+            event.getEventId());
+    assertThat(processedAfterFailure)
+        .as("failed handler must roll back processed_event so retry is not blocked")
+        .isEqualTo(0);
+
+    // Act 2: Retry the same event payload, as durable republication would.
+    transactionTemplate.executeWithoutResult(status -> eventPublisher.publishEvent(event));
 
     await()
-        .atMost(Duration.ofSeconds(5))
+        .atMost(Duration.ofSeconds(10))
         .untilAsserted(
             () -> {
               assertThat(testEventListener.getInvocationCount())

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorAsyncTenantIT.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorAsyncTenantIT.java
@@ -1,0 +1,239 @@
+package com.fabricmanagement.procurement.quote.app.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.domain.vo.ConvertedMoney;
+import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
+import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
+import com.fabricmanagement.procurement.quote.domain.QuoteEntryMethod;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuoteModuleType;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuoteStatus;
+import com.fabricmanagement.procurement.quote.domain.event.SupplierQuoteAcceptedEvent;
+import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepository;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQModuleType;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQStatus;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQType;
+import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class QuoteToOrderOrchestratorAsyncTenantIT {
+
+  private static final UUID TENANT_ID = UUID.fromString("77777777-7777-4777-8777-777777777777");
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (Statement stmt = conn.createStatement()) {
+        stmt.execute(
+            "DO $$ BEGIN "
+                + "IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN "
+                + "CREATE ROLE fabric_app LOGIN NOSUPERUSER NOCREATEDB NOBYPASSRLS PASSWORD 'app_test'; "
+                + "END IF; END $$");
+      }
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to create fabric_app role", e);
+    }
+
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", () -> "fabric_app");
+    registry.add("spring.datasource.password", () -> "app_test");
+    registry.add("spring.flyway.url", postgres::getJdbcUrl);
+    registry.add("spring.flyway.user", postgres::getUsername);
+    registry.add("spring.flyway.password", postgres::getPassword);
+    registry.add("spring.flyway.enabled", () -> "true");
+  }
+
+  @Autowired private ApplicationEventPublisher eventPublisher;
+  @Autowired private SupplierRFQRepository rfqRepository;
+  @Autowired private SupplierQuoteRepository quoteRepository;
+  @Autowired private TransactionTemplate transactionTemplate;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @MockBean private PurchaseOrderValidationEngine validationEngine;
+  @MockBean private ApprovalPort approvalPort;
+  @MockBean private DataScopeGuard dataScopeGuard;
+  @MockBean private TenantReportingCurrencyPort tenantReportingCurrencyPort;
+  @MockBean private ExchangeRateService exchangeRateService;
+
+  private UUID quoteId;
+  private UUID rfqId;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.clear();
+    when(dataScopeGuard.canAccess(eq("procurement"), eq("write"), any(BaseEntity.class)))
+        .thenReturn(true);
+    when(tenantReportingCurrencyPort.getReportingCurrency(TENANT_ID)).thenReturn("USD");
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void supplierQuoteAcceptedPublishedWithoutTenantContextCreatesPurchaseOrder() throws Exception {
+    assertThat(jdbcTemplate.queryForObject("SELECT current_user", String.class))
+        .isEqualTo("fabric_app");
+    Boolean bypassesRls =
+        jdbcTemplate.queryForObject(
+            "SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user", Boolean.class);
+    assertThat(bypassesRls).isFalse();
+
+    seedTenantAsOwner();
+    seedAcceptedQuote();
+    SupplierQuoteAcceptedEvent event = new SupplierQuoteAcceptedEvent(TENANT_ID, quoteId, rfqId);
+    TenantContext.clear();
+
+    transactionTemplate.executeWithoutResult(status -> eventPublisher.publishEvent(event));
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () ->
+                assertThat(countPurchaseOrdersForQuoteAsOwner())
+                    .as("purchase_order row for accepted supplier quote")
+                    .isEqualTo(1));
+  }
+
+  private void seedAcceptedQuote() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentTenantUid("ASYNC-TENANT");
+
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          SupplierRFQLine rfqLine = new SupplierRFQLine();
+          rfqLine.setProductDesc("Async tenant probe material");
+          rfqLine.setRequestedQty(BigDecimal.TEN);
+          rfqLine.setUnit("KG");
+
+          SupplierRFQ rfq = new SupplierRFQ();
+          rfq.setRfqNumber("ASYNC-RFQ-" + UUID.randomUUID());
+          rfq.setWorkOrderId(UUID.randomUUID());
+          rfq.setModuleType(SupplierRFQModuleType.GENERIC);
+          rfq.setRfqType(SupplierRFQType.PURCHASE);
+          rfq.setStatus(SupplierRFQStatus.SENT);
+          rfq.setDeadline(Instant.now().plus(Duration.ofDays(7)));
+          rfq.addLine(rfqLine);
+          SupplierRFQ savedRfq = rfqRepository.saveAndFlush(rfq);
+
+          SupplierQuoteLine quoteLine = new SupplierQuoteLine();
+          quoteLine.setRfqLineId(savedRfq.getLines().get(0).getId());
+          quoteLine.setUnitPrice(BigDecimal.valueOf(12));
+          quoteLine.setCurrency("USD");
+          quoteLine.setQty(BigDecimal.TEN);
+          quoteLine.setUnit("KG");
+
+          SupplierQuote quote = new SupplierQuote();
+          quote.setQuoteNumber("ASYNC-SQ-" + UUID.randomUUID());
+          quote.setRfqId(savedRfq.getId());
+          quote.setTradingPartnerId(UUID.randomUUID());
+          quote.setStatus(SupplierQuoteStatus.RECEIVED);
+          quote.setModuleType(SupplierQuoteModuleType.GENERIC);
+          quote.setValidUntil(LocalDate.now().plusDays(30));
+          quote.setCurrency("USD");
+          quote.setEntryMethod(QuoteEntryMethod.MANUAL_ENTRY);
+          quote.setReportingTotal(
+              ConvertedMoney.of(
+                  BigDecimal.valueOf(120),
+                  "USD",
+                  BigDecimal.valueOf(120),
+                  "USD",
+                  BigDecimal.ONE,
+                  LocalDate.now()));
+          quote.addLine(quoteLine);
+          quote.accept();
+
+          SupplierQuote savedQuote = quoteRepository.saveAndFlush(quote);
+          rfqId = savedRfq.getId();
+          quoteId = savedQuote.getId();
+        });
+
+    TenantContext.clear();
+  }
+
+  private void seedTenantAsOwner() throws Exception {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (Statement stmt = conn.createStatement()) {
+        stmt.execute(
+            "INSERT INTO common_tenant.common_tenant "
+                + "(id, uid, slug, name, status, settings, is_active, created_at, updated_at, version) "
+                + "VALUES ('"
+                + TENANT_ID
+                + "', 'ASYNC-TENANT', 'async-tenant', 'Async Tenant Test', 'ACTIVE', "
+                + "'{}'::jsonb, true, now(), now(), 0) "
+                + "ON CONFLICT (id) DO NOTHING");
+      }
+    }
+  }
+
+  private int countPurchaseOrdersForQuoteAsOwner() throws Exception {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (var ps =
+          conn.prepareStatement(
+              "SELECT count(*) FROM procurement.purchase_order WHERE tenant_id = ? AND supplier_quote_id = ?")) {
+        ps.setObject(1, TENANT_ID);
+        ps.setObject(2, quoteId);
+        try (var rs = ps.executeQuery()) {
+          rs.next();
+          return rs.getInt(1);
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorTest.java
@@ -1,8 +1,10 @@
 package com.fabricmanagement.procurement.quote.app.listener;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
@@ -37,6 +39,7 @@ class QuoteToOrderOrchestratorTest {
   @Mock private PurchaseOrderService purchaseOrderService;
   @Mock private PurchaseOrderRepository purchaseOrderRepository;
   @Mock private SubcontractOrderService subcontractOrderService;
+  @Mock private TenantSessionBinder tenantSessionBinder;
   @Spy private ObjectMapper objectMapper = new ObjectMapper();
 
   @InjectMocks private QuoteToOrderOrchestrator orchestrator;
@@ -73,6 +76,7 @@ class QuoteToOrderOrchestratorTest {
 
     quote = new SupplierQuote();
     quote.setId(quoteId);
+    quote.setTenantId(tenantId);
     quote.setRfqId(rfqId);
     quote.setQuoteNumber("Q-123");
     quote.setTradingPartnerId(UUID.randomUUID());
@@ -105,7 +109,9 @@ class QuoteToOrderOrchestratorTest {
         .thenReturn(Optional.of(quote));
     when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
         .thenReturn(Optional.of(rfq));
-    when(purchaseOrderRepository.existsBySupplierQuoteIdAndIsActiveTrue(quoteId)).thenReturn(false);
+    when(purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+            tenantId, quoteId))
+        .thenReturn(false);
 
     // Act
     orchestrator.onQuoteAccepted(event);
@@ -156,7 +162,9 @@ class QuoteToOrderOrchestratorTest {
         .thenReturn(Optional.of(quote));
     when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
         .thenReturn(Optional.of(rfq));
-    when(purchaseOrderRepository.existsBySupplierQuoteIdAndIsActiveTrue(quoteId)).thenReturn(true);
+    when(purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+            tenantId, quoteId))
+        .thenReturn(true);
 
     // Act
     orchestrator.onQuoteAccepted(event);
@@ -166,38 +174,40 @@ class QuoteToOrderOrchestratorTest {
   }
 
   @Test
-  void onQuoteAccepted_QuoteNotFound_DoesNothing() {
+  void onQuoteAccepted_QuoteNotFound_ThrowsForRetry() {
     // Arrange
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.empty());
 
-    // Act
-    orchestrator.onQuoteAccepted(event);
+    // Act / Assert
+    assertThatThrownBy(() -> orchestrator.onQuoteAccepted(event))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Quote not found");
 
-    // Assert
     verifyNoInteractions(rfqRepository);
     verifyNoInteractions(purchaseOrderService);
     verifyNoInteractions(subcontractOrderService);
   }
 
   @Test
-  void onQuoteAccepted_RfqNotFound_DoesNothing() {
+  void onQuoteAccepted_RfqNotFound_ThrowsForRetry() {
     // Arrange
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(quote));
     when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
         .thenReturn(Optional.empty());
 
-    // Act
-    orchestrator.onQuoteAccepted(event);
+    // Act / Assert
+    assertThatThrownBy(() -> orchestrator.onQuoteAccepted(event))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("RFQ not found");
 
-    // Assert
     verifyNoInteractions(purchaseOrderService);
     verifyNoInteractions(subcontractOrderService);
   }
 
   @Test
-  void onQuoteAccepted_PurchaseServiceThrowsException_SwallowsException() {
+  void onQuoteAccepted_PurchaseServiceThrowsException_PropagatesForRetry() {
     // Arrange
     rfq.setRfqType(SupplierRFQType.PURCHASE);
     quote.setLines(List.of());
@@ -206,15 +216,17 @@ class QuoteToOrderOrchestratorTest {
         .thenReturn(Optional.of(quote));
     when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
         .thenReturn(Optional.of(rfq));
-    when(purchaseOrderRepository.existsBySupplierQuoteIdAndIsActiveTrue(quoteId)).thenReturn(false);
+    when(purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+            tenantId, quoteId))
+        .thenReturn(false);
 
     doThrow(new RuntimeException("DB down")).when(purchaseOrderService).createPurchaseOrder(any());
 
-    // Act
-    // Should not throw
-    orchestrator.onQuoteAccepted(event);
+    // Act / Assert
+    assertThatThrownBy(() -> orchestrator.onQuoteAccepted(event))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("DB down");
 
-    // Assert
     verify(purchaseOrderService).createPurchaseOrder(any(CreatePurchaseOrderRequest.class));
   }
 }


### PR DESCRIPTION
…ENANT-1)

Slice A-0: the TenantRestoringEventListenerAspect pointcut named the pre-1.1 package org.springframework.modulith.ApplicationModuleListener; every listener uses org.springframework.modulith.events.ApplicationModuleListener, and AspectJ @annotation does not resolve meta-annotations, so the aspect never matched any of the 20 modulith listeners. Async listeners opened their REQUIRES_NEW transaction with an empty TenantContext, Hibernate fell back to the SYSTEM_TENANT_ID sentinel, and RLS silently hid every tenant row (observed live: QuoteToOrderOrchestrator logged "Quote not found" on playground boot and the purchase order was never created). Fixed the package name, added a pointcut-match regression test and an @Async propagation probe.

Slice A: pinned advice ordering - @EnableAsync(order = HIGHEST_PRECEDENCE), aspect at HIGHEST_PRECEDENCE + 100 - so async advice is outermost and tenant restoration runs on the executor thread before the transaction acquires a connection. Note: this pins ordering for EVERY @Async method, not just event listeners.

Slice B, QuoteToOrderOrchestrator hardening:
- B.4: @JsonCreator envelope constructor on DomainEvent and SupplierQuoteAcceptedEvent so republication no longer mints a fresh eventId; serialise/deserialise round-trip test added. Extending this to the remaining event classes consumed by IdempotentEventHandler listeners is a registered follow-up (ASYNC-TENANT-2).
- B.2: Quote/RFQ-not-found and downstream failures now throw instead of log-and-complete, so Modulith retries instead of silently losing the order.
- B.1: TenantSessionBinder.bindToCurrentSession(event.getTenantId()) inside executeInTenantContext, before any repository call, as belt and braces.
- B.3: idempotency query is tenant-scoped: existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue.

QuoteToOrderOrchestratorAsyncTenantIT runs as a NOBYPASSRLS fabric_app role (asserted via pg_roles.rolbypassrls) and proves a purchase_order row appears after publishing SupplierQuoteAcceptedEvent from a tenant-less thread; red before slice A-0.