### PR TITLE
fix(events): stable eventId across republication for all domain event…

### DIFF
--- a/src/main/java/com/fabricmanagement/common/domain/event/production/SalesOrderLineProductionCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/common/domain/event/production/SalesOrderLineProductionCompletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.common.domain.event.production;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,25 @@ public class SalesOrderLineProductionCompletedEvent extends DomainEvent {
   public SalesOrderLineProductionCompletedEvent(
       UUID tenantId, UUID salesOrderLineId, UUID completedByWorkOrderId) {
     super(tenantId, "SALES_ORDER_LINE_PRODUCTION_COMPLETED");
+    this.salesOrderLineId = salesOrderLineId;
+    this.completedByWorkOrderId = completedByWorkOrderId;
+  }
+
+  @JsonCreator
+  public SalesOrderLineProductionCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId,
+      @JsonProperty("completedByWorkOrderId") UUID completedByWorkOrderId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SALES_ORDER_LINE_PRODUCTION_COMPLETED",
+        occurredAt,
+        correlationId);
     this.salesOrderLineId = salesOrderLineId;
     this.completedByWorkOrderId = completedByWorkOrderId;
   }

--- a/src/main/java/com/fabricmanagement/common/domain/event/production/SalesOrderLineStoredEvent.java
+++ b/src/main/java/com/fabricmanagement/common/domain/event/production/SalesOrderLineStoredEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.common.domain.event.production;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,6 +20,25 @@ public class SalesOrderLineStoredEvent extends DomainEvent {
   public SalesOrderLineStoredEvent(
       UUID tenantId, UUID salesOrderLineId, UUID triggeredByStockUnitId) {
     super(tenantId, "SALES_ORDER_LINE_STORED");
+    this.salesOrderLineId = salesOrderLineId;
+    this.triggeredByStockUnitId = triggeredByStockUnitId;
+  }
+
+  @JsonCreator
+  public SalesOrderLineStoredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId,
+      @JsonProperty("triggeredByStockUnitId") UUID triggeredByStockUnitId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SALES_ORDER_LINE_STORED",
+        occurredAt,
+        correlationId);
     this.salesOrderLineId = salesOrderLineId;
     this.triggeredByStockUnitId = triggeredByStockUnitId;
   }

--- a/src/main/java/com/fabricmanagement/common/domain/event/production/WorkOrderRecipeAssignmentNeededEvent.java
+++ b/src/main/java/com/fabricmanagement/common/domain/event/production/WorkOrderRecipeAssignmentNeededEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.common.domain.event.production;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -23,6 +26,29 @@ public class WorkOrderRecipeAssignmentNeededEvent extends DomainEvent {
       String certificationReq,
       String originReq) {
     super(tenantId, "WORK_ORDER_RECIPE_ASSIGNMENT_NEEDED");
+    this.workOrderId = workOrderId;
+    this.salesOrderLineId = salesOrderLineId;
+    this.certificationReq = certificationReq;
+    this.originReq = originReq;
+  }
+
+  @JsonCreator
+  public WorkOrderRecipeAssignmentNeededEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId,
+      @JsonProperty("certificationReq") String certificationReq,
+      @JsonProperty("originReq") String originReq) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_RECIPE_ASSIGNMENT_NEEDED",
+        occurredAt,
+        correlationId);
     this.workOrderId = workOrderId;
     this.salesOrderLineId = salesOrderLineId;
     this.certificationReq = certificationReq;

--- a/src/main/java/com/fabricmanagement/common/domain/event/production/WorkOrderStartedEvent.java
+++ b/src/main/java/com/fabricmanagement/common/domain/event/production/WorkOrderStartedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.common.domain.event.production;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,25 @@ public class WorkOrderStartedEvent extends DomainEvent {
 
   public WorkOrderStartedEvent(UUID tenantId, UUID workOrderId, UUID salesOrderLineId) {
     super(tenantId, "WORK_ORDER_STARTED");
+    this.workOrderId = workOrderId;
+    this.salesOrderLineId = salesOrderLineId;
+  }
+
+  @JsonCreator
+  public WorkOrderStartedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_STARTED",
+        occurredAt,
+        correlationId);
     this.workOrderId = workOrderId;
     this.salesOrderLineId = salesOrderLineId;
   }

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/TenantSettingsUpdatedEvent.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/TenantSettingsUpdatedEvent.java
@@ -1,5 +1,8 @@
 package com.fabricmanagement.common.infrastructure.events;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,28 @@ public class TenantSettingsUpdatedEvent extends DomainEvent {
   public TenantSettingsUpdatedEvent(
       UUID tenantId, String timezone, String locale, String currency) {
     super(tenantId, "TENANT_SETTINGS_UPDATED");
+    this.tenantId = tenantId;
+    this.timezone = timezone;
+    this.locale = locale;
+    this.currency = currency;
+  }
+
+  @JsonCreator
+  public TenantSettingsUpdatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("timezone") String timezone,
+      @JsonProperty("locale") String locale,
+      @JsonProperty("currency") String currency) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TENANT_SETTINGS_UPDATED",
+        occurredAt,
+        correlationId);
     this.tenantId = tenantId;
     this.timezone = timezone;
     this.locale = locale;

--- a/src/main/java/com/fabricmanagement/costing/domain/event/CostVarianceDetectedEvent.java
+++ b/src/main/java/com/fabricmanagement/costing/domain/event/CostVarianceDetectedEvent.java
@@ -3,7 +3,10 @@ package com.fabricmanagement.costing.domain.event;
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.costing.domain.calculation.CostEntityType;
 import com.fabricmanagement.costing.domain.calculation.CostStage;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +48,39 @@ public class CostVarianceDetectedEvent extends DomainEvent {
       BigDecimal varianceRatio,
       String currency) {
     super(tenantId, "COST_VARIANCE_DETECTED");
+    this.costCalculationId = costCalculationId;
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.currentStage = currentStage;
+    this.previousStage = previousStage;
+    this.previousTotal = previousTotal;
+    this.currentTotal = currentTotal;
+    this.varianceRatio = varianceRatio;
+    this.currency = currency;
+  }
+
+  @JsonCreator
+  public CostVarianceDetectedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("costCalculationId") UUID costCalculationId,
+      @JsonProperty("entityType") CostEntityType entityType,
+      @JsonProperty("entityId") UUID entityId,
+      @JsonProperty("currentStage") CostStage currentStage,
+      @JsonProperty("previousStage") CostStage previousStage,
+      @JsonProperty("previousTotal") BigDecimal previousTotal,
+      @JsonProperty("currentTotal") BigDecimal currentTotal,
+      @JsonProperty("varianceRatio") BigDecimal varianceRatio,
+      @JsonProperty("currency") String currency) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "COST_VARIANCE_DETECTED",
+        occurredAt,
+        correlationId);
     this.costCalculationId = costCalculationId;
     this.entityType = entityType;
     this.entityId = entityId;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/CreditNoteAppliedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/CreditNoteAppliedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.util.Money;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,29 @@ public class CreditNoteAppliedEvent extends DomainEvent {
       Money amount,
       String targetNewPaymentStatus) {
     super(tenantId, "CREDIT_NOTE_APPLIED");
+    this.creditNoteId = creditNoteId;
+    this.targetInvoiceId = targetInvoiceId;
+    this.amount = amount;
+    this.targetNewPaymentStatus = targetNewPaymentStatus;
+  }
+
+  @JsonCreator
+  public CreditNoteAppliedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("creditNoteId") UUID creditNoteId,
+      @JsonProperty("targetInvoiceId") UUID targetInvoiceId,
+      @JsonProperty("amount") Money amount,
+      @JsonProperty("targetNewPaymentStatus") String targetNewPaymentStatus) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "CREDIT_NOTE_APPLIED",
+        occurredAt,
+        correlationId);
     this.creditNoteId = creditNoteId;
     this.targetInvoiceId = targetInvoiceId;
     this.amount = amount;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/CreditNoteReversedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/CreditNoteReversedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.util.Money;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,29 @@ public class CreditNoteReversedEvent extends DomainEvent {
       Money amount,
       String targetNewPaymentStatus) {
     super(tenantId, "CREDIT_NOTE_REVERSED");
+    this.creditNoteId = creditNoteId;
+    this.targetInvoiceId = targetInvoiceId;
+    this.amount = amount;
+    this.targetNewPaymentStatus = targetNewPaymentStatus;
+  }
+
+  @JsonCreator
+  public CreditNoteReversedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("creditNoteId") UUID creditNoteId,
+      @JsonProperty("targetInvoiceId") UUID targetInvoiceId,
+      @JsonProperty("amount") Money amount,
+      @JsonProperty("targetNewPaymentStatus") String targetNewPaymentStatus) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "CREDIT_NOTE_REVERSED",
+        occurredAt,
+        correlationId);
     this.creditNoteId = creditNoteId;
     this.targetInvoiceId = targetInvoiceId;
     this.amount = amount;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceCancelledEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceCancelledEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,25 @@ public class InvoiceCancelledEvent extends DomainEvent {
 
   public InvoiceCancelledEvent(UUID tenantId, UUID invoiceId, String invoiceNumber) {
     super(tenantId, "INVOICE_CANCELLED");
+    this.invoiceId = invoiceId;
+    this.invoiceNumber = invoiceNumber;
+  }
+
+  @JsonCreator
+  public InvoiceCancelledEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("invoiceNumber") String invoiceNumber) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_CANCELLED",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.invoiceNumber = invoiceNumber;
   }

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceCreatedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -24,6 +27,33 @@ public class InvoiceCreatedEvent extends DomainEvent {
       BigDecimal totalAmount,
       String currency) {
     super(tenantId, "INVOICE_CREATED");
+    this.invoiceId = invoiceId;
+    this.tradingPartnerId = tradingPartnerId;
+    this.invoiceNumber = invoiceNumber;
+    this.invoiceType = invoiceType;
+    this.totalAmount = totalAmount;
+    this.currency = currency;
+  }
+
+  @JsonCreator
+  public InvoiceCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("invoiceNumber") String invoiceNumber,
+      @JsonProperty("invoiceType") String invoiceType,
+      @JsonProperty("totalAmount") BigDecimal totalAmount,
+      @JsonProperty("currency") String currency) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_CREATED",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.tradingPartnerId = tradingPartnerId;
     this.invoiceNumber = invoiceNumber;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceDisputedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceDisputedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,27 @@ public class InvoiceDisputedEvent extends DomainEvent {
   public InvoiceDisputedEvent(
       UUID tenantId, UUID invoiceId, String invoiceNumber, UUID tradingPartnerId) {
     super(tenantId, "INVOICE_DISPUTED");
+    this.invoiceId = invoiceId;
+    this.invoiceNumber = invoiceNumber;
+    this.tradingPartnerId = tradingPartnerId;
+  }
+
+  @JsonCreator
+  public InvoiceDisputedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("invoiceNumber") String invoiceNumber,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_DISPUTED",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.invoiceNumber = invoiceNumber;
     this.tradingPartnerId = tradingPartnerId;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceIssuedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceIssuedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,27 @@ public class InvoiceIssuedEvent extends DomainEvent {
   public InvoiceIssuedEvent(
       UUID tenantId, UUID invoiceId, String invoiceNumber, BigDecimal totalAmount) {
     super(tenantId, "INVOICE_ISSUED");
+    this.invoiceId = invoiceId;
+    this.invoiceNumber = invoiceNumber;
+    this.totalAmount = totalAmount;
+  }
+
+  @JsonCreator
+  public InvoiceIssuedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("invoiceNumber") String invoiceNumber,
+      @JsonProperty("totalAmount") BigDecimal totalAmount) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_ISSUED",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.invoiceNumber = invoiceNumber;
     this.totalAmount = totalAmount;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceOverdueEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceOverdueEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,29 @@ public class InvoiceOverdueEvent extends DomainEvent {
       UUID tradingPartnerId,
       long daysOverdue) {
     super(tenantId, "INVOICE_OVERDUE");
+    this.invoiceId = invoiceId;
+    this.invoiceNumber = invoiceNumber;
+    this.tradingPartnerId = tradingPartnerId;
+    this.daysOverdue = daysOverdue;
+  }
+
+  @JsonCreator
+  public InvoiceOverdueEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("invoiceNumber") String invoiceNumber,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("daysOverdue") long daysOverdue) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_OVERDUE",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.invoiceNumber = invoiceNumber;
     this.tradingPartnerId = tradingPartnerId;

--- a/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceSentEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/invoice/domain/event/InvoiceSentEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.finance.invoice.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,27 @@ public class InvoiceSentEvent extends DomainEvent {
   public InvoiceSentEvent(
       UUID tenantId, UUID invoiceId, String invoiceNumber, UUID tradingPartnerId) {
     super(tenantId, "INVOICE_SENT");
+    this.invoiceId = invoiceId;
+    this.invoiceNumber = invoiceNumber;
+    this.tradingPartnerId = tradingPartnerId;
+  }
+
+  @JsonCreator
+  public InvoiceSentEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("invoiceNumber") String invoiceNumber,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVOICE_SENT",
+        occurredAt,
+        correlationId);
     this.invoiceId = invoiceId;
     this.invoiceNumber = invoiceNumber;
     this.tradingPartnerId = tradingPartnerId;

--- a/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentAllocatedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentAllocatedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.finance.payment.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.util.Money;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,27 @@ public class PaymentAllocatedEvent extends DomainEvent {
   public PaymentAllocatedEvent(
       UUID tenantId, UUID paymentId, UUID invoiceId, Money allocationAmount) {
     super(tenantId, "PAYMENT_ALLOCATED");
+    this.paymentId = paymentId;
+    this.invoiceId = invoiceId;
+    this.allocationAmount = allocationAmount;
+  }
+
+  @JsonCreator
+  public PaymentAllocatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("paymentId") UUID paymentId,
+      @JsonProperty("invoiceId") UUID invoiceId,
+      @JsonProperty("allocationAmount") Money allocationAmount) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PAYMENT_ALLOCATED",
+        occurredAt,
+        correlationId);
     this.paymentId = paymentId;
     this.invoiceId = invoiceId;
     this.allocationAmount = allocationAmount;

--- a/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentReceivedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentReceivedEvent.java
@@ -3,6 +3,9 @@ package com.fabricmanagement.finance.payment.domain.event;
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.finance.payment.domain.PaymentDirection;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -25,6 +28,33 @@ public class PaymentReceivedEvent extends DomainEvent {
       Money amount,
       String currency) {
     super(tenantId, "PAYMENT_RECEIVED");
+    this.paymentId = paymentId;
+    this.paymentNumber = paymentNumber;
+    this.tradingPartnerId = tradingPartnerId;
+    this.direction = direction;
+    this.amount = amount;
+    this.currency = currency;
+  }
+
+  @JsonCreator
+  public PaymentReceivedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("paymentId") UUID paymentId,
+      @JsonProperty("paymentNumber") String paymentNumber,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("direction") PaymentDirection direction,
+      @JsonProperty("amount") Money amount,
+      @JsonProperty("currency") String currency) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PAYMENT_RECEIVED",
+        occurredAt,
+        correlationId);
     this.paymentId = paymentId;
     this.paymentNumber = paymentNumber;
     this.tradingPartnerId = tradingPartnerId;

--- a/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentVoidedEvent.java
+++ b/src/main/java/com/fabricmanagement/finance/payment/domain/event/PaymentVoidedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.finance.payment.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -15,6 +18,27 @@ public class PaymentVoidedEvent extends DomainEvent {
   public PaymentVoidedEvent(
       UUID tenantId, UUID paymentId, String paymentNumber, List<UUID> affectedInvoiceIds) {
     super(tenantId, "PAYMENT_VOIDED");
+    this.paymentId = paymentId;
+    this.paymentNumber = paymentNumber;
+    this.affectedInvoiceIds = affectedInvoiceIds;
+  }
+
+  @JsonCreator
+  public PaymentVoidedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("paymentId") UUID paymentId,
+      @JsonProperty("paymentNumber") String paymentNumber,
+      @JsonProperty("affectedInvoiceIds") List<UUID> affectedInvoiceIds) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PAYMENT_VOIDED",
+        occurredAt,
+        correlationId);
     this.paymentId = paymentId;
     this.paymentNumber = paymentNumber;
     this.affectedInvoiceIds = affectedInvoiceIds;

--- a/src/main/java/com/fabricmanagement/flowboard/automation/domain/event/AutomationAlertRequestedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/automation/domain/event/AutomationAlertRequestedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.automation.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,29 @@ public class AutomationAlertRequestedEvent extends DomainEvent {
   private final UUID taskId;
   private final UUID recipientId; // nullable (null means notify manager/owner)
   private final String message;
+
+  @JsonCreator
+  public AutomationAlertRequestedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("boardId") UUID boardId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("recipientId") UUID recipientId,
+      @JsonProperty("message") String message) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "AUTOMATION_ALERT_REQUESTED",
+        occurredAt,
+        correlationId);
+    this.boardId = boardId;
+    this.taskId = taskId;
+    this.recipientId = recipientId;
+    this.message = message;
+  }
 
   private AutomationAlertRequestedEvent(
       UUID tenantId, UUID boardId, UUID taskId, UUID recipientId, String message) {

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/EscalationTriggeredEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/EscalationTriggeredEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,6 +20,31 @@ public class EscalationTriggeredEvent extends DomainEvent {
   private final String escalationType;
   private final UUID escalatedToUserId;
   private final String message;
+
+  @JsonCreator
+  public EscalationTriggeredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("taskNumber") String taskNumber,
+      @JsonProperty("escalationType") String escalationType,
+      @JsonProperty("escalatedToUserId") UUID escalatedToUserId,
+      @JsonProperty("message") String message) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "ESCALATION_TRIGGERED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.taskNumber = taskNumber;
+    this.escalationType = escalationType;
+    this.escalatedToUserId = escalatedToUserId;
+    this.message = message;
+  }
 
   public EscalationTriggeredEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskAssignedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskAssignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,27 @@ public class TaskAssignedEvent extends DomainEvent {
   private final UUID taskId;
   private final UUID assignedUserId;
   private final UUID assignedByUserId;
+
+  @JsonCreator
+  public TaskAssignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("assignedUserId") UUID assignedUserId,
+      @JsonProperty("assignedByUserId") UUID assignedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TASK_ASSIGNED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.assignedUserId = assignedUserId;
+    this.assignedByUserId = assignedByUserId;
+  }
 
   public TaskAssignedEvent(UUID tenantId, UUID taskId, UUID assignedUserId, UUID assignedByUserId) {
     super(tenantId, "TASK_ASSIGNED");

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskChecklistCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskChecklistCompletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.ToString;
@@ -14,6 +17,29 @@ public class TaskChecklistCompletedEvent extends DomainEvent {
   private final UUID boardId;
   private final UUID checklistId;
   private final UUID completedByUserId;
+
+  @JsonCreator
+  public TaskChecklistCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("boardId") UUID boardId,
+      @JsonProperty("checklistId") UUID checklistId,
+      @JsonProperty("completedByUserId") UUID completedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "CHECKLIST_COMPLETED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.boardId = boardId;
+    this.checklistId = checklistId;
+    this.completedByUserId = completedByUserId;
+  }
 
   public TaskChecklistCompletedEvent(
       UUID tenantId, UUID taskId, UUID boardId, UUID checklistId, UUID completedByUserId) {

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -24,6 +27,31 @@ public class TaskCreatedEvent extends DomainEvent {
   private final String taskNumber;
   private final String status;
   private final String taskType;
+
+  @JsonCreator
+  public TaskCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("boardId") UUID boardId,
+      @JsonProperty("taskNumber") String taskNumber,
+      @JsonProperty("status") String status,
+      @JsonProperty("taskType") String taskType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TASK_CREATED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.boardId = boardId;
+    this.taskNumber = taskNumber;
+    this.status = status;
+    this.taskType = taskType;
+  }
 
   public TaskCreatedEvent(
       UUID tenantId, UUID taskId, UUID boardId, String taskNumber, String status, String taskType) {

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskStatusChangedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskStatusChangedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -24,6 +27,31 @@ public class TaskStatusChangedEvent extends DomainEvent {
   private final String oldStatus;
   private final String newStatus;
   private final UUID changedByUserId;
+
+  @JsonCreator
+  public TaskStatusChangedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("boardId") UUID boardId,
+      @JsonProperty("oldStatus") String oldStatus,
+      @JsonProperty("newStatus") String newStatus,
+      @JsonProperty("changedByUserId") UUID changedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TASK_STATUS_CHANGED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.boardId = boardId;
+    this.oldStatus = oldStatus;
+    this.newStatus = newStatus;
+    this.changedByUserId = changedByUserId;
+  }
 
   public TaskStatusChangedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskUnassignedEvent.java
+++ b/src/main/java/com/fabricmanagement/flowboard/task/domain/event/TaskUnassignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.flowboard.task.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -10,6 +13,27 @@ public class TaskUnassignedEvent extends DomainEvent {
   private final UUID taskId;
   private final UUID unassignedUserId;
   private final UUID unassignedByUserId;
+
+  @JsonCreator
+  public TaskUnassignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("taskId") UUID taskId,
+      @JsonProperty("unassignedUserId") UUID unassignedUserId,
+      @JsonProperty("unassignedByUserId") UUID unassignedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TASK_UNASSIGNED",
+        occurredAt,
+        correlationId);
+    this.taskId = taskId;
+    this.unassignedUserId = unassignedUserId;
+    this.unassignedByUserId = unassignedByUserId;
+  }
 
   public TaskUnassignedEvent(
       UUID tenantId, UUID taskId, UUID unassignedUserId, UUID unassignedByUserId) {

--- a/src/main/java/com/fabricmanagement/human/core/employee/domain/event/EmployeeTerminatedEvent.java
+++ b/src/main/java/com/fabricmanagement/human/core/employee/domain/event/EmployeeTerminatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.human.core.employee.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Getter;
@@ -9,6 +12,25 @@ import lombok.Getter;
 public class EmployeeTerminatedEvent extends DomainEvent {
   private final UUID userId;
   private final LocalDate terminationDate;
+
+  @JsonCreator
+  public EmployeeTerminatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("terminationDate") LocalDate terminationDate) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "EMPLOYEE_TERMINATED",
+        occurredAt,
+        correlationId);
+    this.userId = userId;
+    this.terminationDate = terminationDate;
+  }
 
   public EmployeeTerminatedEvent(UUID tenantId, UUID userId, LocalDate terminationDate) {
     super(tenantId, "EMPLOYEE_TERMINATED");

--- a/src/main/java/com/fabricmanagement/human/core/employee/domain/event/EmployeeUpdatedEvent.java
+++ b/src/main/java/com/fabricmanagement/human/core/employee/domain/event/EmployeeUpdatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.human.core.employee.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,23 @@ import lombok.Getter;
 public class EmployeeUpdatedEvent extends DomainEvent {
 
   private final UUID userId;
+
+  @JsonCreator
+  public EmployeeUpdatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "EMPLOYEE_UPDATED",
+        occurredAt,
+        correlationId);
+    this.userId = userId;
+  }
 
   public EmployeeUpdatedEvent(UUID tenantId, UUID userId) {
     super(tenantId, "EMPLOYEE_UPDATED");

--- a/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationConvertedEvent.java
+++ b/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationConvertedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.iwm.reservation.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -21,6 +24,29 @@ public class ReservationConvertedEvent extends DomainEvent {
   private final UUID productId;
   private final UUID locationId;
   private final BigDecimal qtyConverted;
+
+  @JsonCreator
+  public ReservationConvertedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("reservationId") UUID reservationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("qtyConverted") BigDecimal qtyConverted) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RESERVATION_CONVERTED",
+        occurredAt,
+        correlationId);
+    this.reservationId = reservationId;
+    this.productId = productId;
+    this.locationId = locationId;
+    this.qtyConverted = qtyConverted;
+  }
 
   public ReservationConvertedEvent(
       UUID tenantId, UUID reservationId, UUID productId, UUID locationId, BigDecimal qtyConverted) {

--- a/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationCreatedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.iwm.reservation.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -22,6 +25,31 @@ public class ReservationCreatedEvent extends DomainEvent {
   private final UUID locationId;
   private final String lotNumber;
   private final BigDecimal qtyReserved;
+
+  @JsonCreator
+  public ReservationCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("reservationId") UUID reservationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("lotNumber") String lotNumber,
+      @JsonProperty("qtyReserved") BigDecimal qtyReserved) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RESERVATION_CREATED",
+        occurredAt,
+        correlationId);
+    this.reservationId = reservationId;
+    this.productId = productId;
+    this.locationId = locationId;
+    this.lotNumber = lotNumber;
+    this.qtyReserved = qtyReserved;
+  }
 
   public ReservationCreatedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationReleasedEvent.java
+++ b/src/main/java/com/fabricmanagement/iwm/reservation/domain/event/ReservationReleasedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.iwm.reservation.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -21,6 +24,29 @@ public class ReservationReleasedEvent extends DomainEvent {
   private final UUID productId;
   private final UUID locationId;
   private final BigDecimal qtyReleased;
+
+  @JsonCreator
+  public ReservationReleasedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("reservationId") UUID reservationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("qtyReleased") BigDecimal qtyReleased) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RESERVATION_RELEASED",
+        occurredAt,
+        correlationId);
+    this.reservationId = reservationId;
+    this.productId = productId;
+    this.locationId = locationId;
+    this.qtyReleased = qtyReleased;
+  }
 
   public ReservationReleasedEvent(
       UUID tenantId, UUID reservationId, UUID productId, UUID locationId, BigDecimal qtyReleased) {

--- a/src/main/java/com/fabricmanagement/iwm/rules/domain/event/MinStockAlertEvent.java
+++ b/src/main/java/com/fabricmanagement/iwm/rules/domain/event/MinStockAlertEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.iwm.rules.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,6 +16,31 @@ public class MinStockAlertEvent extends DomainEvent {
   private final BigDecimal currentQty;
   private final BigDecimal minQty;
   private final String unit;
+
+  @JsonCreator
+  public MinStockAlertEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("currentQty") BigDecimal currentQty,
+      @JsonProperty("minQty") BigDecimal minQty,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "MIN_STOCK_ALERT",
+        occurredAt,
+        correlationId);
+    this.productId = productId;
+    this.locationId = locationId;
+    this.currentQty = currentQty;
+    this.minQty = minQty;
+    this.unit = unit;
+  }
 
   @Builder
   public MinStockAlertEvent(

--- a/src/main/java/com/fabricmanagement/iwm/rules/domain/event/ReturnRateExceededEvent.java
+++ b/src/main/java/com/fabricmanagement/iwm/rules/domain/event/ReturnRateExceededEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.iwm.rules.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,6 +15,29 @@ public class ReturnRateExceededEvent extends DomainEvent {
   private final BigDecimal currentRate;
   private final BigDecimal thresholdRate;
   private final Integer windowDays;
+
+  @JsonCreator
+  public ReturnRateExceededEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("currentRate") BigDecimal currentRate,
+      @JsonProperty("thresholdRate") BigDecimal thresholdRate,
+      @JsonProperty("windowDays") Integer windowDays) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RETURN_RATE_EXCEEDED",
+        occurredAt,
+        correlationId);
+    this.tradingPartnerId = tradingPartnerId;
+    this.currentRate = currentRate;
+    this.thresholdRate = thresholdRate;
+    this.windowDays = windowDays;
+  }
 
   @Builder
   public ReturnRateExceededEvent(

--- a/src/main/java/com/fabricmanagement/logistics/shipment/domain/event/ShipmentLineConfirmedEvent.java
+++ b/src/main/java/com/fabricmanagement/logistics/shipment/domain/event/ShipmentLineConfirmedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.logistics.shipment.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,27 @@ public class ShipmentLineConfirmedEvent extends DomainEvent {
   public ShipmentLineConfirmedEvent(
       UUID tenantId, UUID shipmentLineId, UUID salesOrderLineId, BigDecimal confirmedQuantity) {
     super(tenantId, "SHIPMENT_LINE_CONFIRMED");
+    this.shipmentLineId = shipmentLineId;
+    this.salesOrderLineId = salesOrderLineId;
+    this.confirmedQuantity = confirmedQuantity;
+  }
+
+  @JsonCreator
+  public ShipmentLineConfirmedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("shipmentLineId") UUID shipmentLineId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId,
+      @JsonProperty("confirmedQuantity") BigDecimal confirmedQuantity) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SHIPMENT_LINE_CONFIRMED",
+        occurredAt,
+        correlationId);
     this.shipmentLineId = shipmentLineId;
     this.salesOrderLineId = salesOrderLineId;
     this.confirmedQuantity = confirmedQuantity;

--- a/src/main/java/com/fabricmanagement/logistics/shipment/domain/event/ShipmentPickedUpEvent.java
+++ b/src/main/java/com/fabricmanagement/logistics/shipment/domain/event/ShipmentPickedUpEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.logistics.shipment.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,23 @@ import lombok.Getter;
 @Getter
 public class ShipmentPickedUpEvent extends DomainEvent {
   private final UUID shipmentId;
+
+  @JsonCreator
+  public ShipmentPickedUpEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("shipmentId") UUID shipmentId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SHIPMENT_PICKED_UP",
+        occurredAt,
+        correlationId);
+    this.shipmentId = shipmentId;
+  }
 
   public ShipmentPickedUpEvent(UUID tenantId, UUID shipmentId) {
     super(tenantId, "SHIPMENT_PICKED_UP");

--- a/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalApprovedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalApprovedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.approval.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -22,6 +25,31 @@ public class ApprovalApprovedEvent extends DomainEvent {
       String entityCode,
       UUID requesterId) {
     super(tenantId, "APPROVAL_APPROVED");
+    this.approvalRequestId = approvalRequestId;
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.entityCode = entityCode;
+    this.requesterId = requesterId;
+  }
+
+  @JsonCreator
+  public ApprovalApprovedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("approvalRequestId") UUID approvalRequestId,
+      @JsonProperty("entityType") String entityType,
+      @JsonProperty("entityId") UUID entityId,
+      @JsonProperty("entityCode") String entityCode,
+      @JsonProperty("requesterId") UUID requesterId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "APPROVAL_APPROVED",
+        occurredAt,
+        correlationId);
     this.approvalRequestId = approvalRequestId;
     this.entityType = entityType;
     this.entityId = entityId;

--- a/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalExpiredEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalExpiredEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.approval.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -16,5 +19,24 @@ public class ApprovalExpiredEvent extends DomainEvent {
     super(tenantId, "APPROVAL_EXPIRED");
     this.expiredRequestIds = expiredRequestIds;
     this.count = expiredRequestIds.size();
+  }
+
+  @JsonCreator
+  public ApprovalExpiredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("expiredRequestIds") List<UUID> expiredRequestIds,
+      @JsonProperty("count") int count) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "APPROVAL_EXPIRED",
+        occurredAt,
+        correlationId);
+    this.expiredRequestIds = expiredRequestIds != null ? List.copyOf(expiredRequestIds) : List.of();
+    this.count = count;
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalPendingEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalPendingEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.approval.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -29,6 +32,34 @@ public class ApprovalPendingEvent extends DomainEvent {
       UUID approverId,
       List<UUID> notifyRecipientIds) {
     super(tenantId, "APPROVAL_PENDING");
+    this.approvalRequestId = approvalRequestId;
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.entityCode = entityCode;
+    this.approverId = approverId;
+    this.notifyRecipientIds =
+        notifyRecipientIds != null ? List.copyOf(notifyRecipientIds) : List.of();
+  }
+
+  @JsonCreator
+  public ApprovalPendingEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("approvalRequestId") UUID approvalRequestId,
+      @JsonProperty("entityType") String entityType,
+      @JsonProperty("entityId") UUID entityId,
+      @JsonProperty("entityCode") String entityCode,
+      @JsonProperty("approverId") UUID approverId,
+      @JsonProperty("notifyRecipientIds") List<UUID> notifyRecipientIds) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "APPROVAL_PENDING",
+        occurredAt,
+        correlationId);
     this.approvalRequestId = approvalRequestId;
     this.entityType = entityType;
     this.entityId = entityId;

--- a/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalRejectedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/approval/domain/event/ApprovalRejectedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.approval.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -24,6 +27,33 @@ public class ApprovalRejectedEvent extends DomainEvent {
       UUID requesterId,
       String rejectionReason) {
     super(tenantId, "APPROVAL_REJECTED");
+    this.approvalRequestId = approvalRequestId;
+    this.entityType = entityType;
+    this.entityId = entityId;
+    this.entityCode = entityCode;
+    this.requesterId = requesterId;
+    this.rejectionReason = rejectionReason;
+  }
+
+  @JsonCreator
+  public ApprovalRejectedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("approvalRequestId") UUID approvalRequestId,
+      @JsonProperty("entityType") String entityType,
+      @JsonProperty("entityId") UUID entityId,
+      @JsonProperty("entityCode") String entityCode,
+      @JsonProperty("requesterId") UUID requesterId,
+      @JsonProperty("rejectionReason") String rejectionReason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "APPROVAL_REJECTED",
+        occurredAt,
+        correlationId);
     this.approvalRequestId = approvalRequestId;
     this.entityType = entityType;
     this.entityId = entityId;

--- a/src/main/java/com/fabricmanagement/platform/approval/domain/event/PromotionEscalationEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/approval/domain/event/PromotionEscalationEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.approval.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,6 +20,27 @@ public class PromotionEscalationEvent extends DomainEvent {
 
   public PromotionEscalationEvent(UUID tenantId, UUID userId, int rejectionCount, String reason) {
     super(tenantId, "PROMOTION_ESCALATION");
+    this.userId = userId;
+    this.rejectionCount = rejectionCount;
+    this.reason = reason;
+  }
+
+  @JsonCreator
+  public PromotionEscalationEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("rejectionCount") int rejectionCount,
+      @JsonProperty("reason") String reason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PROMOTION_ESCALATION",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.rejectionCount = rejectionCount;
     this.reason = reason;

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/event/SelfSignupCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/event/SelfSignupCompletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.auth.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -39,6 +42,46 @@ public class SelfSignupCompletedEvent extends DomainEvent {
       UUID trialTenantId,
       String localeLanguageTag) {
     super(tenantId, "SELF_SIGNUP_COMPLETED");
+    this.recipientEmail = recipientEmail;
+    this.firstName = firstName;
+    this.lastName = lastName;
+    this.organizationName = organizationName;
+    this.taxId = taxId;
+    this.organizationType = organizationType;
+    this.setupUrl = setupUrl;
+    this.salesLed = salesLed;
+    this.subscriptionOsCodes =
+        subscriptionOsCodes == null ? List.of() : List.copyOf(subscriptionOsCodes);
+    this.signupIntent = signupIntent;
+    this.trialTenantId = trialTenantId;
+    this.localeLanguageTag = localeLanguageTag;
+  }
+
+  @JsonCreator
+  public SelfSignupCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("recipientEmail") String recipientEmail,
+      @JsonProperty("firstName") String firstName,
+      @JsonProperty("lastName") String lastName,
+      @JsonProperty("organizationName") String organizationName,
+      @JsonProperty("taxId") String taxId,
+      @JsonProperty("organizationType") String organizationType,
+      @JsonProperty("setupUrl") String setupUrl,
+      @JsonProperty("salesLed") boolean salesLed,
+      @JsonProperty("subscriptionOsCodes") List<String> subscriptionOsCodes,
+      @JsonProperty("signupIntent") String signupIntent,
+      @JsonProperty("trialTenantId") UUID trialTenantId,
+      @JsonProperty("localeLanguageTag") String localeLanguageTag) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SELF_SIGNUP_COMPLETED",
+        occurredAt,
+        correlationId);
     this.recipientEmail = recipientEmail;
     this.firstName = firstName;
     this.lastName = lastName;

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserLoginEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserLoginEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.auth.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -18,6 +21,23 @@ public class UserLoginEvent extends DomainEvent {
 
   public UserLoginEvent(UUID tenantId, UUID userId, String contactValue, String ipAddress) {
     super(tenantId, "USER_LOGIN");
+    this.userId = userId;
+    this.contactValue = contactValue;
+    this.ipAddress = ipAddress;
+  }
+
+  @JsonCreator
+  public UserLoginEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("contactValue") String contactValue,
+      @JsonProperty("ipAddress") String ipAddress) {
+    super(
+        eventId, tenantId, eventType != null ? eventType : "USER_LOGIN", occurredAt, correlationId);
     this.userId = userId;
     this.contactValue = contactValue;
     this.ipAddress = ipAddress;

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserLogoutEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserLogoutEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.auth.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -16,6 +19,23 @@ public class UserLogoutEvent extends DomainEvent {
 
   public UserLogoutEvent(UUID tenantId, UUID userId) {
     super(tenantId, "USER_LOGOUT");
+    this.userId = userId;
+  }
+
+  @JsonCreator
+  public UserLogoutEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_LOGOUT",
+        occurredAt,
+        correlationId);
     this.userId = userId;
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserRegisteredEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/auth/domain/event/UserRegisteredEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.auth.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,6 +20,25 @@ public class UserRegisteredEvent extends DomainEvent {
 
   public UserRegisteredEvent(UUID tenantId, UUID userId, String contactValue) {
     super(tenantId, "USER_REGISTERED");
+    this.userId = userId;
+    this.contactValue = contactValue;
+  }
+
+  @JsonCreator
+  public UserRegisteredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("contactValue") String contactValue) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_REGISTERED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.contactValue = contactValue;
   }

--- a/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationAddressAssignedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationAddressAssignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.organization.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,25 @@ public class OrganizationAddressAssignedEvent extends DomainEvent {
 
   public OrganizationAddressAssignedEvent(UUID tenantId, UUID organizationId, UUID addressId) {
     super(tenantId, "ORGANIZATION_ADDRESS_ASSIGNED");
+    this.organizationId = organizationId;
+    this.addressId = addressId;
+  }
+
+  @JsonCreator
+  public OrganizationAddressAssignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("organizationId") UUID organizationId,
+      @JsonProperty("addressId") UUID addressId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "ORGANIZATION_ADDRESS_ASSIGNED",
+        occurredAt,
+        correlationId);
     this.organizationId = organizationId;
     this.addressId = addressId;
   }

--- a/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationContactAssignedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationContactAssignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.organization.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,25 @@ public class OrganizationContactAssignedEvent extends DomainEvent {
 
   public OrganizationContactAssignedEvent(UUID tenantId, UUID organizationId, UUID contactId) {
     super(tenantId, "ORGANIZATION_CONTACT_ASSIGNED");
+    this.organizationId = organizationId;
+    this.contactId = contactId;
+  }
+
+  @JsonCreator
+  public OrganizationContactAssignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("organizationId") UUID organizationId,
+      @JsonProperty("contactId") UUID contactId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "ORGANIZATION_CONTACT_ASSIGNED",
+        occurredAt,
+        correlationId);
     this.organizationId = organizationId;
     this.contactId = contactId;
   }

--- a/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/organization/domain/event/OrganizationCreatedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.platform.organization.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.platform.organization.domain.OrganizationType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -20,6 +23,27 @@ public class OrganizationCreatedEvent extends DomainEvent {
   public OrganizationCreatedEvent(
       UUID tenantId, UUID organizationId, String name, OrganizationType organizationType) {
     super(tenantId, "ORGANIZATION_CREATED");
+    this.organizationId = organizationId;
+    this.name = name;
+    this.organizationType = organizationType;
+  }
+
+  @JsonCreator
+  public OrganizationCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("organizationId") UUID organizationId,
+      @JsonProperty("name") String name,
+      @JsonProperty("organizationType") OrganizationType organizationType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "ORGANIZATION_CREATED",
+        occurredAt,
+        correlationId);
     this.organizationId = organizationId;
     this.name = name;
     this.organizationType = organizationType;

--- a/src/main/java/com/fabricmanagement/platform/policy/domain/event/PolicyEvaluatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/policy/domain/event/PolicyEvaluatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.policy.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -30,6 +33,33 @@ public class PolicyEvaluatedEvent extends DomainEvent {
       String reason,
       Long evaluationTimeMs) {
     super(tenantId, "POLICY_EVALUATED");
+    this.userId = userId;
+    this.resource = resource;
+    this.action = action;
+    this.allowed = allowed;
+    this.reason = reason;
+    this.evaluationTimeMs = evaluationTimeMs;
+  }
+
+  @JsonCreator
+  public PolicyEvaluatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("resource") String resource,
+      @JsonProperty("action") String action,
+      @JsonProperty("allowed") boolean allowed,
+      @JsonProperty("reason") String reason,
+      @JsonProperty("evaluationTimeMs") Long evaluationTimeMs) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "POLICY_EVALUATED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.resource = resource;
     this.action = action;

--- a/src/main/java/com/fabricmanagement/platform/subscription/domain/event/SubscriptionActivatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/subscription/domain/event/SubscriptionActivatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.subscription.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -21,6 +24,27 @@ public class SubscriptionActivatedEvent extends DomainEvent {
   public SubscriptionActivatedEvent(
       UUID tenantId, UUID subscriptionId, String osCode, String osName) {
     super(tenantId, "SUBSCRIPTION_ACTIVATED");
+    this.subscriptionId = subscriptionId;
+    this.osCode = osCode;
+    this.osName = osName;
+  }
+
+  @JsonCreator
+  public SubscriptionActivatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("subscriptionId") UUID subscriptionId,
+      @JsonProperty("osCode") String osCode,
+      @JsonProperty("osName") String osName) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SUBSCRIPTION_ACTIVATED",
+        occurredAt,
+        correlationId);
     this.subscriptionId = subscriptionId;
     this.osCode = osCode;
     this.osName = osName;

--- a/src/main/java/com/fabricmanagement/platform/subscription/domain/event/SubscriptionExpiredEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/subscription/domain/event/SubscriptionExpiredEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.subscription.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,25 @@ public class SubscriptionExpiredEvent extends DomainEvent {
 
   public SubscriptionExpiredEvent(UUID tenantId, UUID subscriptionId, String osCode) {
     super(tenantId, "SUBSCRIPTION_EXPIRED");
+    this.subscriptionId = subscriptionId;
+    this.osCode = osCode;
+  }
+
+  @JsonCreator
+  public SubscriptionExpiredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("subscriptionId") UUID subscriptionId,
+      @JsonProperty("osCode") String osCode) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SUBSCRIPTION_EXPIRED",
+        occurredAt,
+        correlationId);
     this.subscriptionId = subscriptionId;
     this.osCode = osCode;
   }

--- a/src/main/java/com/fabricmanagement/platform/tenant/domain/event/TenantCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/domain/event/TenantCreatedEvent.java
@@ -2,6 +2,8 @@ package com.fabricmanagement.platform.tenant.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
@@ -22,6 +24,29 @@ public class TenantCreatedEvent extends DomainEvent {
   public TenantCreatedEvent(
       UUID tenantId, String uid, String name, TenantStatus status, Instant trialEndsAt) {
     super(tenantId, "TENANT_CREATED");
+    this.uid = uid;
+    this.name = name;
+    this.status = status;
+    this.trialEndsAt = trialEndsAt;
+  }
+
+  @JsonCreator
+  public TenantCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("uid") String uid,
+      @JsonProperty("name") String name,
+      @JsonProperty("status") TenantStatus status,
+      @JsonProperty("trialEndsAt") Instant trialEndsAt) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TENANT_CREATED",
+        occurredAt,
+        correlationId);
     this.uid = uid;
     this.name = name;
     this.status = status;

--- a/src/main/java/com/fabricmanagement/platform/tenant/domain/event/TenantStatusChangedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/domain/event/TenantStatusChangedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.platform.tenant.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -25,6 +28,29 @@ public class TenantStatusChangedEvent extends DomainEvent {
       TenantStatus newStatus,
       String reason) {
     super(tenantId, "TENANT_STATUS_CHANGED");
+    this.uid = uid;
+    this.previousStatus = previousStatus;
+    this.newStatus = newStatus;
+    this.reason = reason;
+  }
+
+  @JsonCreator
+  public TenantStatusChangedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("uid") String uid,
+      @JsonProperty("previousStatus") TenantStatus previousStatus,
+      @JsonProperty("newStatus") TenantStatus newStatus,
+      @JsonProperty("reason") String reason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TENANT_STATUS_CHANGED",
+        occurredAt,
+        correlationId);
     this.uid = uid;
     this.previousStatus = previousStatus;
     this.newStatus = newStatus;

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/PartnerUserCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/PartnerUserCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.tradingpartner.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -33,6 +36,33 @@ public class PartnerUserCreatedEvent extends DomainEvent {
       UUID organizationId,
       String partnerDisplayName) {
     super(tenantId, "PARTNER_USER_CREATED");
+    this.userId = userId;
+    this.displayName = displayName;
+    this.contactValue = contactValue;
+    this.partnerId = partnerId;
+    this.organizationId = organizationId;
+    this.partnerDisplayName = partnerDisplayName;
+  }
+
+  @JsonCreator
+  public PartnerUserCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("displayName") String displayName,
+      @JsonProperty("contactValue") String contactValue,
+      @JsonProperty("partnerId") UUID partnerId,
+      @JsonProperty("organizationId") UUID organizationId,
+      @JsonProperty("partnerDisplayName") String partnerDisplayName) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PARTNER_USER_CREATED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.displayName = displayName;
     this.contactValue = contactValue;

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.tradingpartner.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -33,6 +36,31 @@ public class TradingPartnerCreatedEvent extends DomainEvent {
       String displayName,
       UUID legacyCompanyId) {
     super(tenantId, "TRADING_PARTNER_CREATED");
+    this.tradingPartnerId = tradingPartnerId;
+    this.registryId = registryId;
+    this.partnerType = partnerType;
+    this.displayName = displayName;
+    this.legacyCompanyId = legacyCompanyId;
+  }
+
+  @JsonCreator
+  public TradingPartnerCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("registryId") UUID registryId,
+      @JsonProperty("partnerType") String partnerType,
+      @JsonProperty("displayName") String displayName,
+      @JsonProperty("legacyCompanyId") UUID legacyCompanyId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TRADING_PARTNER_CREATED",
+        occurredAt,
+        correlationId);
     this.tradingPartnerId = tradingPartnerId;
     this.registryId = registryId;
     this.partnerType = partnerType;

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerLinkedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerLinkedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.platform.tradingpartner.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -31,6 +34,27 @@ public class TradingPartnerLinkedEvent extends DomainEvent {
   public TradingPartnerLinkedEvent(
       UUID registryId, UUID linkedTenantId, List<UUID> affectedTenantIds) {
     super(TenantContext.SYSTEM_TENANT_ID, "TRADING_PARTNER_LINKED");
+    this.registryId = registryId;
+    this.linkedTenantId = linkedTenantId;
+    this.affectedTenantIds = affectedTenantIds;
+  }
+
+  @JsonCreator
+  public TradingPartnerLinkedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("registryId") UUID registryId,
+      @JsonProperty("linkedTenantId") UUID linkedTenantId,
+      @JsonProperty("affectedTenantIds") List<UUID> affectedTenantIds) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TRADING_PARTNER_LINKED",
+        occurredAt,
+        correlationId);
     this.registryId = registryId;
     this.linkedTenantId = linkedTenantId;
     this.affectedTenantIds = affectedTenantIds;

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerRegistryCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerRegistryCreatedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.platform.tradingpartner.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -22,6 +25,29 @@ public class TradingPartnerRegistryCreatedEvent extends DomainEvent {
   public TradingPartnerRegistryCreatedEvent(
       UUID registryId, String taxId, String officialName, String country) {
     super(TenantContext.SYSTEM_TENANT_ID, "TRADING_PARTNER_REGISTRY_CREATED");
+    this.registryId = registryId;
+    this.taxId = taxId;
+    this.officialName = officialName;
+    this.country = country;
+  }
+
+  @JsonCreator
+  public TradingPartnerRegistryCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("registryId") UUID registryId,
+      @JsonProperty("taxId") String taxId,
+      @JsonProperty("officialName") String officialName,
+      @JsonProperty("country") String country) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TRADING_PARTNER_REGISTRY_CREATED",
+        occurredAt,
+        correlationId);
     this.registryId = registryId;
     this.taxId = taxId;
     this.officialName = officialName;

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerStatusChangedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/TradingPartnerStatusChangedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.tradingpartner.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -31,6 +34,29 @@ public class TradingPartnerStatusChangedEvent extends DomainEvent {
       String newStatus,
       String partnerDisplayName) {
     super(tenantId, "TRADING_PARTNER_STATUS_CHANGED");
+    this.tradingPartnerId = tradingPartnerId;
+    this.previousStatus = previousStatus;
+    this.newStatus = newStatus;
+    this.partnerDisplayName = partnerDisplayName;
+  }
+
+  @JsonCreator
+  public TradingPartnerStatusChangedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("previousStatus") String previousStatus,
+      @JsonProperty("newStatus") String newStatus,
+      @JsonProperty("partnerDisplayName") String partnerDisplayName) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "TRADING_PARTNER_STATUS_CHANGED",
+        occurredAt,
+        correlationId);
     this.tradingPartnerId = tradingPartnerId;
     this.previousStatus = previousStatus;
     this.newStatus = newStatus;

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/AddressAssignedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/AddressAssignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,5 +20,26 @@ public class AddressAssignedEvent extends DomainEvent {
     this.userId = userId;
     this.addressId = addressId;
     this.ownerType = "USER";
+  }
+
+  @JsonCreator
+  public AddressAssignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("addressId") UUID addressId,
+      @JsonProperty("ownerType") String ownerType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "ADDRESS_ASSIGNED",
+        occurredAt,
+        correlationId);
+    this.userId = userId;
+    this.addressId = addressId;
+    this.ownerType = ownerType != null ? ownerType : "USER";
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/ContactAssignedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/ContactAssignedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -17,5 +20,26 @@ public class ContactAssignedEvent extends DomainEvent {
     this.userId = userId;
     this.contactId = contactId;
     this.ownerType = "USER";
+  }
+
+  @JsonCreator
+  public ContactAssignedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("contactId") UUID contactId,
+      @JsonProperty("ownerType") String ownerType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "CONTACT_ASSIGNED",
+        occurredAt,
+        correlationId);
+    this.userId = userId;
+    this.contactId = contactId;
+    this.ownerType = ownerType != null ? ownerType : "USER";
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestApprovedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestApprovedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -16,6 +19,29 @@ public class ProfileUpdateRequestApprovedEvent extends DomainEvent {
   public ProfileUpdateRequestApprovedEvent(
       UUID tenantId, UUID requestId, UUID userId, UUID reviewedBy, String profileCategory) {
     super(tenantId, "PROFILE_UPDATE_REQUEST_APPROVED");
+    this.requestId = requestId;
+    this.userId = userId;
+    this.reviewedBy = reviewedBy;
+    this.profileCategory = profileCategory;
+  }
+
+  @JsonCreator
+  public ProfileUpdateRequestApprovedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("requestId") UUID requestId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("reviewedBy") UUID reviewedBy,
+      @JsonProperty("profileCategory") String profileCategory) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PROFILE_UPDATE_REQUEST_APPROVED",
+        occurredAt,
+        correlationId);
     this.requestId = requestId;
     this.userId = userId;
     this.reviewedBy = reviewedBy;

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,27 @@ public class ProfileUpdateRequestCreatedEvent extends DomainEvent {
   public ProfileUpdateRequestCreatedEvent(
       UUID tenantId, UUID requestId, UUID userId, String profileCategory) {
     super(tenantId, "PROFILE_UPDATE_REQUEST_CREATED");
+    this.requestId = requestId;
+    this.userId = userId;
+    this.profileCategory = profileCategory;
+  }
+
+  @JsonCreator
+  public ProfileUpdateRequestCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("requestId") UUID requestId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("profileCategory") String profileCategory) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PROFILE_UPDATE_REQUEST_CREATED",
+        occurredAt,
+        correlationId);
     this.requestId = requestId;
     this.userId = userId;
     this.profileCategory = profileCategory;

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestRejectedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/ProfileUpdateRequestRejectedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -22,6 +25,31 @@ public class ProfileUpdateRequestRejectedEvent extends DomainEvent {
       String profileCategory,
       String reviewComment) {
     super(tenantId, "PROFILE_UPDATE_REQUEST_REJECTED");
+    this.requestId = requestId;
+    this.userId = userId;
+    this.reviewedBy = reviewedBy;
+    this.profileCategory = profileCategory;
+    this.reviewComment = reviewComment;
+  }
+
+  @JsonCreator
+  public ProfileUpdateRequestRejectedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("requestId") UUID requestId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("reviewedBy") UUID reviewedBy,
+      @JsonProperty("profileCategory") String profileCategory,
+      @JsonProperty("reviewComment") String reviewComment) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PROFILE_UPDATE_REQUEST_REJECTED",
+        occurredAt,
+        correlationId);
     this.requestId = requestId;
     this.userId = userId;
     this.reviewedBy = reviewedBy;

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/UserCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/UserCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -26,6 +29,31 @@ public class UserCreatedEvent extends DomainEvent {
       UUID organizationId,
       boolean invitationEmailSuppressed) {
     super(tenantId, "USER_CREATED");
+    this.userId = userId;
+    this.displayName = displayName;
+    this.contactValue = contactValue;
+    this.organizationId = organizationId;
+    this.invitationEmailSuppressed = invitationEmailSuppressed;
+  }
+
+  @JsonCreator
+  public UserCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("displayName") String displayName,
+      @JsonProperty("contactValue") String contactValue,
+      @JsonProperty("organizationId") UUID organizationId,
+      @JsonProperty("invitationEmailSuppressed") boolean invitationEmailSuppressed) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_CREATED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.displayName = displayName;
     this.contactValue = contactValue;

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/UserDeactivatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/UserDeactivatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,25 @@ public class UserDeactivatedEvent extends DomainEvent {
 
   public UserDeactivatedEvent(UUID tenantId, UUID userId, String reason) {
     super(tenantId, "USER_DEACTIVATED");
+    this.userId = userId;
+    this.reason = reason;
+  }
+
+  @JsonCreator
+  public UserDeactivatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("reason") String reason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_DEACTIVATED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.reason = reason;
   }

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/UserOnboardingCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/UserOnboardingCompletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -16,6 +19,23 @@ public class UserOnboardingCompletedEvent extends DomainEvent {
 
   public UserOnboardingCompletedEvent(UUID tenantId, UUID userId) {
     super(tenantId, "USER_ONBOARDING_COMPLETED");
+    this.userId = userId;
+  }
+
+  @JsonCreator
+  public UserOnboardingCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_ONBOARDING_COMPLETED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/user/domain/event/UserProfileUpdatedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/user/domain/event/UserProfileUpdatedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.platform.user.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.platform.user.domain.value.ProfileCategory;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 import lombok.Getter;
@@ -21,6 +24,27 @@ public class UserProfileUpdatedEvent extends DomainEvent {
   public UserProfileUpdatedEvent(
       UUID tenantId, UUID userId, UUID updatedBy, Set<ProfileCategory> categories) {
     super(tenantId, "USER_PROFILE_UPDATED");
+    this.userId = userId;
+    this.updatedBy = updatedBy;
+    this.categories = categories;
+  }
+
+  @JsonCreator
+  public UserProfileUpdatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("userId") UUID userId,
+      @JsonProperty("updatedBy") UUID updatedBy,
+      @JsonProperty("categories") Set<ProfileCategory> categories) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "USER_PROFILE_UPDATED",
+        occurredAt,
+        correlationId);
     this.userId = userId;
     this.updatedBy = updatedBy;
     this.categories = categories;

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoConfirmedEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoConfirmedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,27 @@ public class PoConfirmedEvent extends DomainEvent {
   private final UUID purchaseOrderId;
   private final String poNumber;
   private final UUID supplierId;
+
+  @JsonCreator
+  public PoConfirmedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("purchaseOrderId") UUID purchaseOrderId,
+      @JsonProperty("poNumber") String poNumber,
+      @JsonProperty("supplierId") UUID supplierId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PO_CONFIRMED",
+        occurredAt,
+        correlationId);
+    this.purchaseOrderId = purchaseOrderId;
+    this.poNumber = poNumber;
+    this.supplierId = supplierId;
+  }
 
   public PoConfirmedEvent(UUID tenantId, UUID purchaseOrderId, String poNumber, UUID supplierId) {
     super(tenantId, "PO_CONFIRMED");

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoDeliveryLateEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoDeliveryLateEvent.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
@@ -15,6 +17,33 @@ public class PoDeliveryLateEvent extends DomainEvent {
   private final String supplierName;
   private final Instant expectedDeliveryAt;
   private final int lateDays;
+
+  @JsonCreator
+  public PoDeliveryLateEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("purchaseOrderId") UUID purchaseOrderId,
+      @JsonProperty("poNumber") String poNumber,
+      @JsonProperty("supplierId") UUID supplierId,
+      @JsonProperty("supplierName") String supplierName,
+      @JsonProperty("expectedDeliveryAt") Instant expectedDeliveryAt,
+      @JsonProperty("lateDays") int lateDays) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PO_DELIVERY_LATE",
+        occurredAt,
+        correlationId);
+    this.purchaseOrderId = purchaseOrderId;
+    this.poNumber = poNumber;
+    this.supplierId = supplierId;
+    this.supplierName = supplierName;
+    this.expectedDeliveryAt = expectedDeliveryAt;
+    this.lateDays = lateDays;
+  }
 
   public PoDeliveryLateEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoPartiallyReceivedEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoPartiallyReceivedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.purchaseorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,29 @@ public class PoPartiallyReceivedEvent extends DomainEvent {
   private final String poNumber;
   private final int receivedItemCount;
   private final int totalItemCount;
+
+  @JsonCreator
+  public PoPartiallyReceivedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("purchaseOrderId") UUID purchaseOrderId,
+      @JsonProperty("poNumber") String poNumber,
+      @JsonProperty("receivedItemCount") int receivedItemCount,
+      @JsonProperty("totalItemCount") int totalItemCount) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PO_PARTIALLY_RECEIVED",
+        occurredAt,
+        correlationId);
+    this.purchaseOrderId = purchaseOrderId;
+    this.poNumber = poNumber;
+    this.receivedItemCount = receivedItemCount;
+    this.totalItemCount = totalItemCount;
+  }
 
   public PoPartiallyReceivedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/procurement/quote/domain/event/SupplierQuoteReceivedEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/domain/event/SupplierQuoteReceivedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.quote.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,31 @@ public class SupplierQuoteReceivedEvent extends DomainEvent {
   private final UUID supplierId;
   private final String supplierName;
   private final UUID rfqCreatedByUserId;
+
+  @JsonCreator
+  public SupplierQuoteReceivedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("rfqId") UUID rfqId,
+      @JsonProperty("supplierId") UUID supplierId,
+      @JsonProperty("supplierName") String supplierName,
+      @JsonProperty("rfqCreatedByUserId") UUID rfqCreatedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SUPPLIER_QUOTE_RECEIVED",
+        occurredAt,
+        correlationId);
+    this.quoteId = quoteId;
+    this.rfqId = rfqId;
+    this.supplierId = supplierId;
+    this.supplierName = supplierName;
+    this.rfqCreatedByUserId = rfqCreatedByUserId;
+  }
 
   public SupplierQuoteReceivedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqDeadlineApproachingEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqDeadlineApproachingEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.rfq.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,27 @@ public class RfqDeadlineApproachingEvent extends DomainEvent {
   private final UUID rfqId;
   private final String rfqNumber;
   private final int hoursRemaining;
+
+  @JsonCreator
+  public RfqDeadlineApproachingEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("rfqId") UUID rfqId,
+      @JsonProperty("rfqNumber") String rfqNumber,
+      @JsonProperty("hoursRemaining") int hoursRemaining) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RFQ_DEADLINE_APPROACHING",
+        occurredAt,
+        correlationId);
+    this.rfqId = rfqId;
+    this.rfqNumber = rfqNumber;
+    this.hoursRemaining = hoursRemaining;
+  }
 
   public RfqDeadlineApproachingEvent(
       UUID tenantId, UUID rfqId, String rfqNumber, int hoursRemaining) {

--- a/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqNoResponseEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqNoResponseEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.rfq.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,29 @@ public class RfqNoResponseEvent extends DomainEvent {
   private final String rfqNumber;
   private final UUID supplierId;
   private final String supplierName;
+
+  @JsonCreator
+  public RfqNoResponseEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("rfqId") UUID rfqId,
+      @JsonProperty("rfqNumber") String rfqNumber,
+      @JsonProperty("supplierId") UUID supplierId,
+      @JsonProperty("supplierName") String supplierName) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RFQ_NO_RESPONSE",
+        occurredAt,
+        correlationId);
+    this.rfqId = rfqId;
+    this.rfqNumber = rfqNumber;
+    this.supplierId = supplierId;
+    this.supplierName = supplierName;
+  }
 
   public RfqNoResponseEvent(
       UUID tenantId, UUID rfqId, String rfqNumber, UUID supplierId, String supplierName) {

--- a/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqSentEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/domain/event/RfqSentEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.procurement.rfq.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -12,6 +15,22 @@ public class RfqSentEvent extends DomainEvent {
   private final UUID rfqId;
   private final String rfqNumber;
   private final List<UUID> supplierIds;
+
+  @JsonCreator
+  public RfqSentEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("rfqId") UUID rfqId,
+      @JsonProperty("rfqNumber") String rfqNumber,
+      @JsonProperty("supplierIds") List<UUID> supplierIds) {
+    super(eventId, tenantId, eventType != null ? eventType : "RFQ_SENT", occurredAt, correlationId);
+    this.rfqId = rfqId;
+    this.rfqNumber = rfqNumber;
+    this.supplierIds = supplierIds != null ? List.copyOf(supplierIds) : List.of();
+  }
 
   public RfqSentEvent(UUID tenantId, UUID rfqId, String rfqNumber, List<UUID> supplierIds) {
     super(tenantId, "RFQ_SENT");

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchAdjustedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchAdjustedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,33 @@ public class BatchAdjustedEvent extends DomainEvent {
   private final UUID locationId;
   private final String reason;
   private final String remarks;
+
+  @JsonCreator
+  public BatchAdjustedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("delta") BigDecimal delta,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("reason") String reason,
+      @JsonProperty("remarks") String remarks) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_ADJUSTED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.delta = delta;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.reason = reason;
+    this.remarks = remarks;
+  }
 
   public BatchAdjustedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchCompletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,23 @@ import lombok.Getter;
 @Getter
 public class BatchCompletedEvent extends DomainEvent {
   private final UUID batchId;
+
+  @JsonCreator
+  public BatchCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_COMPLETED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+  }
 
   public BatchCompletedEvent(UUID tenantId, UUID batchId) {
     super(tenantId, "BATCH_COMPLETED");

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchConsumedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchConsumedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,33 @@ public class BatchConsumedEvent extends DomainEvent {
   private final UUID locationId;
   private final UUID referenceId;
   private final String referenceType;
+
+  @JsonCreator
+  public BatchConsumedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("referenceId") UUID referenceId,
+      @JsonProperty("referenceType") String referenceType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_CONSUMED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.referenceId = referenceId;
+    this.referenceType = referenceType;
+  }
 
   public BatchConsumedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchCreatedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,29 @@ public class BatchCreatedEvent extends DomainEvent {
   private final BigDecimal quantity;
   private final String unit;
   private final UUID locationId;
+
+  @JsonCreator
+  public BatchCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_CREATED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.locationId = locationId;
+  }
 
   public BatchCreatedEvent(
       UUID tenantId, UUID batchId, BigDecimal quantity, String unit, UUID locationId) {

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentOrderConversionRequestedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentOrderConversionRequestedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,23 @@ import lombok.Getter;
 @Getter
 public class BatchLotQuantityIntentOrderConversionRequestedEvent extends DomainEvent {
   private final UUID quoteId;
+
+  @JsonCreator
+  public BatchLotQuantityIntentOrderConversionRequestedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_LOT_QUANTITY_INTENT_ORDER_CONVERSION_REQUESTED",
+        occurredAt,
+        correlationId);
+    this.quoteId = quoteId;
+  }
 
   public BatchLotQuantityIntentOrderConversionRequestedEvent(UUID tenantId, UUID quoteId) {
     super(tenantId, "BATCH_LOT_QUANTITY_INTENT_ORDER_CONVERSION_REQUESTED");

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentPlacedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentPlacedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -10,6 +13,29 @@ public class BatchLotQuantityIntentPlacedEvent extends DomainEvent {
   private final UUID quoteLineId;
   private final UUID batchId;
   private final UUID intentId;
+
+  @JsonCreator
+  public BatchLotQuantityIntentPlacedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("quoteLineId") UUID quoteLineId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("intentId") UUID intentId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_LOT_QUANTITY_INTENT_PLACED",
+        occurredAt,
+        correlationId);
+    this.quoteId = quoteId;
+    this.quoteLineId = quoteLineId;
+    this.batchId = batchId;
+    this.intentId = intentId;
+  }
 
   public BatchLotQuantityIntentPlacedEvent(
       UUID tenantId, UUID quoteId, UUID quoteLineId, UUID batchId, UUID intentId) {

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentReleasedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchLotQuantityIntentReleasedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -10,6 +13,29 @@ public class BatchLotQuantityIntentReleasedEvent extends DomainEvent {
   private final UUID quoteLineId;
   private final UUID batchId;
   private final UUID intentId;
+
+  @JsonCreator
+  public BatchLotQuantityIntentReleasedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("quoteLineId") UUID quoteLineId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("intentId") UUID intentId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_LOT_QUANTITY_INTENT_RELEASED",
+        occurredAt,
+        correlationId);
+    this.quoteId = quoteId;
+    this.quoteLineId = quoteLineId;
+    this.batchId = batchId;
+    this.intentId = intentId;
+  }
 
   public BatchLotQuantityIntentReleasedEvent(
       UUID tenantId, UUID quoteId, UUID quoteLineId, UUID batchId, UUID intentId) {

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchProductionStartedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchProductionStartedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,33 @@ public class BatchProductionStartedEvent extends DomainEvent {
   private final UUID previousLocationId;
   private final UUID machineLocationId;
   private final String machineCode;
+
+  @JsonCreator
+  public BatchProductionStartedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("previousLocationId") UUID previousLocationId,
+      @JsonProperty("machineLocationId") UUID machineLocationId,
+      @JsonProperty("machineCode") String machineCode) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_PRODUCTION_STARTED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.previousLocationId = previousLocationId;
+    this.machineLocationId = machineLocationId;
+    this.machineCode = machineCode;
+  }
 
   public BatchProductionStartedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservationCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservationCompletedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,31 @@ public class BatchReservationCompletedEvent extends DomainEvent {
   private final BigDecimal releasedQuantity;
   private final String unit;
   private final UUID locationId;
+
+  @JsonCreator
+  public BatchReservationCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("reservationId") UUID reservationId,
+      @JsonProperty("releasedQuantity") BigDecimal releasedQuantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_RESERVATION_COMPLETED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.reservationId = reservationId;
+    this.releasedQuantity = releasedQuantity;
+    this.unit = unit;
+    this.locationId = locationId;
+  }
 
   public BatchReservationCompletedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservationReleasedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservationReleasedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,31 @@ public class BatchReservationReleasedEvent extends DomainEvent {
   private final String unit;
   private final UUID locationId;
   private final UUID reservationId;
+
+  @JsonCreator
+  public BatchReservationReleasedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("releasedQuantity") BigDecimal releasedQuantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("reservationId") UUID reservationId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_RESERVATION_RELEASED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.releasedQuantity = releasedQuantity;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.reservationId = reservationId;
+  }
 
   public BatchReservationReleasedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchReservedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,33 @@ public class BatchReservedEvent extends DomainEvent {
   private final UUID locationId;
   private final UUID reservationId;
   private final String referenceType;
+
+  @JsonCreator
+  public BatchReservedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("reservationId") UUID reservationId,
+      @JsonProperty("referenceType") String referenceType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_RESERVED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.reservationId = reservationId;
+    this.referenceType = referenceType;
+  }
 
   public BatchReservedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchSplitEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchSplitEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -16,6 +19,39 @@ public class BatchSplitEvent extends DomainEvent {
   private final String parentBatchCode;
   private final String childBatchCode;
   private final String remarks;
+
+  @JsonCreator
+  public BatchSplitEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("parentBatchId") UUID parentBatchId,
+      @JsonProperty("childBatchId") UUID childBatchId,
+      @JsonProperty("splitQuantity") BigDecimal splitQuantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("parentLocationId") UUID parentLocationId,
+      @JsonProperty("childLocationId") UUID childLocationId,
+      @JsonProperty("parentBatchCode") String parentBatchCode,
+      @JsonProperty("childBatchCode") String childBatchCode,
+      @JsonProperty("remarks") String remarks) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_SPLIT",
+        occurredAt,
+        correlationId);
+    this.parentBatchId = parentBatchId;
+    this.childBatchId = childBatchId;
+    this.splitQuantity = splitQuantity;
+    this.unit = unit;
+    this.parentLocationId = parentLocationId;
+    this.childLocationId = childLocationId;
+    this.parentBatchCode = parentBatchCode;
+    this.childBatchCode = childBatchCode;
+    this.remarks = remarks;
+  }
 
   public BatchSplitEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchTransferredEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchTransferredEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -13,6 +16,33 @@ public class BatchTransferredEvent extends DomainEvent {
   private final UUID oldLocationId;
   private final UUID newLocationId;
   private final String remarks;
+
+  @JsonCreator
+  public BatchTransferredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("oldLocationId") UUID oldLocationId,
+      @JsonProperty("newLocationId") UUID newLocationId,
+      @JsonProperty("remarks") String remarks) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_TRANSFERRED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.oldLocationId = oldLocationId;
+    this.newLocationId = newLocationId;
+    this.remarks = remarks;
+  }
 
   public BatchTransferredEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchWasteRecordedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BatchWasteRecordedEvent.java
@@ -2,7 +2,10 @@ package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.batch.domain.WasteCategory;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,33 @@ public class BatchWasteRecordedEvent extends DomainEvent {
   private final UUID locationId;
   private final WasteCategory wasteCategory;
   private final String reason;
+
+  @JsonCreator
+  public BatchWasteRecordedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("wasteCategory") WasteCategory wasteCategory,
+      @JsonProperty("reason") String reason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_WASTE_RECORDED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.wasteCategory = wasteCategory;
+    this.reason = reason;
+  }
 
   public BatchWasteRecordedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BlendedBatchCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/event/BlendedBatchCreatedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.batch.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -13,6 +16,29 @@ public class BlendedBatchCreatedEvent extends DomainEvent {
   private final List<UUID> parentIds;
   private final BigDecimal totalQuantity;
   private final String unit;
+
+  @JsonCreator
+  public BlendedBatchCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("childBatchId") UUID childBatchId,
+      @JsonProperty("parentIds") List<UUID> parentIds,
+      @JsonProperty("totalQuantity") BigDecimal totalQuantity,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BLENDED_BATCH_CREATED",
+        occurredAt,
+        correlationId);
+    this.childBatchId = childBatchId;
+    this.parentIds = parentIds != null ? List.copyOf(parentIds) : List.of();
+    this.totalQuantity = totalQuantity;
+    this.unit = unit;
+  }
 
   public BlendedBatchCreatedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/domain/event/GoodsReceiptConfirmedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/domain/event/GoodsReceiptConfirmedEvent.java
@@ -2,6 +2,8 @@ package com.fabricmanagement.production.execution.goodsreceipt.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -42,4 +44,29 @@ public class GoodsReceiptConfirmedEvent extends DomainEvent {
   @Builder
   public record ReceiptItemData(
       UUID itemId, String barcode, BigDecimal netWeight, BigDecimal grossWeight) {}
+
+  @JsonCreator
+  public GoodsReceiptConfirmedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("receiptId") UUID receiptId,
+      @JsonProperty("receiptNumber") String receiptNumber,
+      @JsonProperty("sourceType") GoodsReceiptSourceType sourceType,
+      @JsonProperty("sourceId") UUID sourceId,
+      @JsonProperty("items") List<ReceiptItemData> items) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "GOODS_RECEIPT_CONFIRMED",
+        occurredAt,
+        correlationId);
+    this.receiptId = receiptId;
+    this.receiptNumber = receiptNumber;
+    this.sourceType = sourceType;
+    this.sourceId = sourceId;
+    this.items = items;
+  }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/InventoryTransactionCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/InventoryTransactionCreatedEvent.java
@@ -2,6 +2,8 @@ package com.fabricmanagement.production.execution.inventory.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.inventory.domain.enums.InventoryTransactionType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -18,6 +20,35 @@ public class InventoryTransactionCreatedEvent extends DomainEvent {
   private final String unit;
   private final UUID locationId;
   private final Instant transactionDate;
+
+  @JsonCreator
+  public InventoryTransactionCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("transactionId") UUID transactionId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("transactionType") InventoryTransactionType transactionType,
+      @JsonProperty("quantity") BigDecimal quantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("transactionDate") Instant transactionDate) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "INVENTORY_TRANSACTION_CREATED",
+        occurredAt,
+        correlationId);
+    this.transactionId = transactionId;
+    this.batchId = batchId;
+    this.transactionType = transactionType;
+    this.quantity = quantity;
+    this.unit = unit;
+    this.locationId = locationId;
+    this.transactionDate = transactionDate;
+  }
 
   @Builder
   public InventoryTransactionCreatedEvent(

--- a/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/MinStockAlertEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/MinStockAlertEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.inventory.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,33 @@ public class MinStockAlertEvent extends DomainEvent {
   private final BigDecimal currentStock;
   private final BigDecimal minimumStock;
   private final String unit;
+
+  @JsonCreator
+  public MinStockAlertEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("productCode") String productCode,
+      @JsonProperty("productName") String productName,
+      @JsonProperty("currentStock") BigDecimal currentStock,
+      @JsonProperty("minimumStock") BigDecimal minimumStock,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "MIN_STOCK_ALERT",
+        occurredAt,
+        correlationId);
+    this.productId = productId;
+    this.productCode = productCode;
+    this.productName = productName;
+    this.currentStock = currentStock;
+    this.minimumStock = minimumStock;
+    this.unit = unit;
+  }
 
   public MinStockAlertEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/ReturnRateExceededEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/inventory/domain/event/ReturnRateExceededEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.inventory.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,31 @@ public class ReturnRateExceededEvent extends DomainEvent {
   private final BigDecimal returnRate; // %
   private final BigDecimal thresholdRate; // %
   private final int periodDays;
+
+  @JsonCreator
+  public ReturnRateExceededEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("supplierId") UUID supplierId,
+      @JsonProperty("supplierName") String supplierName,
+      @JsonProperty("returnRate") BigDecimal returnRate,
+      @JsonProperty("thresholdRate") BigDecimal thresholdRate,
+      @JsonProperty("periodDays") int periodDays) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "RETURN_RATE_EXCEEDED",
+        occurredAt,
+        correlationId);
+    this.supplierId = supplierId;
+    this.supplierName = supplierName;
+    this.returnRate = returnRate;
+    this.thresholdRate = thresholdRate;
+    this.periodDays = periodDays;
+  }
 
   public ReturnRateExceededEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/lineage/domain/event/BatchLineageCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/lineage/domain/event/BatchLineageCreatedEvent.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.production.execution.lineage.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -17,6 +19,35 @@ public class BatchLineageCreatedEvent extends DomainEvent {
   private final String unit;
   private final BigDecimal consumptionPercentage;
   private final Instant consumedAt;
+
+  @JsonCreator
+  public BatchLineageCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("lineageId") UUID lineageId,
+      @JsonProperty("parentBatchId") UUID parentBatchId,
+      @JsonProperty("childBatchId") UUID childBatchId,
+      @JsonProperty("consumedQuantity") BigDecimal consumedQuantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("consumptionPercentage") BigDecimal consumptionPercentage,
+      @JsonProperty("consumedAt") Instant consumedAt) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_LINEAGE_CREATED",
+        occurredAt,
+        correlationId);
+    this.lineageId = lineageId;
+    this.parentBatchId = parentBatchId;
+    this.childBatchId = childBatchId;
+    this.consumedQuantity = consumedQuantity;
+    this.unit = unit;
+    this.consumptionPercentage = consumptionPercentage;
+    this.consumedAt = consumedAt;
+  }
 
   @Builder
   public BatchLineageCreatedEvent(

--- a/src/main/java/com/fabricmanagement/production/execution/lineage/domain/event/BatchLineageDeletedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/lineage/domain/event/BatchLineageDeletedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.lineage.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +14,27 @@ public class BatchLineageDeletedEvent extends DomainEvent {
   private final UUID lineageId;
   private final UUID parentBatchId;
   private final UUID childBatchId;
+
+  @JsonCreator
+  public BatchLineageDeletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("lineageId") UUID lineageId,
+      @JsonProperty("parentBatchId") UUID parentBatchId,
+      @JsonProperty("childBatchId") UUID childBatchId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_LINEAGE_DELETED",
+        occurredAt,
+        correlationId);
+    this.lineageId = lineageId;
+    this.parentBatchId = parentBatchId;
+    this.childBatchId = childBatchId;
+  }
 
   @Builder
   public BatchLineageDeletedEvent(

--- a/src/main/java/com/fabricmanagement/production/execution/output/domain/event/ProductionOutputConfirmedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/output/domain/event/ProductionOutputConfirmedEvent.java
@@ -3,7 +3,10 @@ package com.fabricmanagement.production.execution.output.domain.event;
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -47,4 +50,35 @@ public class ProductionOutputConfirmedEvent extends DomainEvent {
       BigDecimal netWeight,
       BigDecimal grossWeight,
       UUID locationId) {}
+
+  @JsonCreator
+  public ProductionOutputConfirmedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("recordId") UUID recordId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("outputProductId") UUID outputProductId,
+      @JsonProperty("outputProductType") ProductType outputProductType,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("confirmedByUserId") UUID confirmedByUserId,
+      @JsonProperty("items") List<OutputItemData> items) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PRODUCTION_OUTPUT_CONFIRMED",
+        occurredAt,
+        correlationId);
+    this.recordId = recordId;
+    this.workOrderId = workOrderId;
+    this.batchId = batchId;
+    this.outputProductId = outputProductId;
+    this.outputProductType = outputProductType;
+    this.unit = unit;
+    this.confirmedByUserId = confirmedByUserId;
+    this.items = items;
+  }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitConsumedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitConsumedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -19,6 +22,33 @@ public class StockUnitConsumedEvent extends DomainEvent {
   private final BigDecimal consumedAmount;
   private final BigDecimal remainingWeight;
   private final String unit;
+
+  @JsonCreator
+  public StockUnitConsumedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("consumedAmount") BigDecimal consumedAmount,
+      @JsonProperty("remainingWeight") BigDecimal remainingWeight,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_CONSUMED",
+        occurredAt,
+        correlationId);
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.consumedAmount = consumedAmount;
+    this.remainingWeight = remainingWeight;
+    this.unit = unit;
+  }
 
   public StockUnitConsumedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitCreatedEvent.java
@@ -3,7 +3,10 @@ package com.fabricmanagement.production.execution.stockunit.domain.event;
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -35,6 +38,37 @@ public class StockUnitCreatedEvent extends DomainEvent {
       String unit,
       UUID locationId) {
     super(tenantId, "STOCK_UNIT_CREATED");
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.productType = productType;
+    this.packageType = packageType;
+    this.initialWeight = initialWeight;
+    this.unit = unit;
+    this.locationId = locationId;
+  }
+
+  @JsonCreator
+  public StockUnitCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("productType") ProductType productType,
+      @JsonProperty("packageType") PackageType packageType,
+      @JsonProperty("initialWeight") BigDecimal initialWeight,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("locationId") UUID locationId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_CREATED",
+        occurredAt,
+        correlationId);
     this.stockUnitId = stockUnitId;
     this.barcode = barcode;
     this.batchId = batchId;

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitDepletedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitDepletedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -22,6 +25,33 @@ public class StockUnitDepletedEvent extends DomainEvent {
   private final BigDecimal totalConsumedWeight;
 
   private final String unit;
+
+  @JsonCreator
+  public StockUnitDepletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("totalConsumedWeight") BigDecimal totalConsumedWeight,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_DEPLETED",
+        occurredAt,
+        correlationId);
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.locationId = locationId;
+    this.totalConsumedWeight = totalConsumedWeight;
+    this.unit = unit;
+  }
 
   public StockUnitDepletedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitDisposedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitDisposedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -25,6 +28,35 @@ public class StockUnitDisposedEvent extends DomainEvent {
 
   /** Mandatory reason provided by the admin at time of disposal. */
   private final String reason;
+
+  @JsonCreator
+  public StockUnitDisposedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("locationId") UUID locationId,
+      @JsonProperty("disposedWeight") BigDecimal disposedWeight,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("reason") String reason) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_DISPOSED",
+        occurredAt,
+        correlationId);
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.locationId = locationId;
+    this.disposedWeight = disposedWeight;
+    this.unit = unit;
+    this.reason = reason;
+  }
 
   public StockUnitDisposedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitGradeChangedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitGradeChangedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -23,6 +26,33 @@ public class StockUnitGradeChangedEvent extends DomainEvent {
 
   /** True if this was a promotion (upgrade to better quality) — requires prior approval. */
   private final boolean promotion;
+
+  @JsonCreator
+  public StockUnitGradeChangedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("previousGradeId") UUID previousGradeId,
+      @JsonProperty("newGradeId") UUID newGradeId,
+      @JsonProperty("promotion") boolean promotion) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_GRADE_CHANGED",
+        occurredAt,
+        correlationId);
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.previousGradeId = previousGradeId;
+    this.newGradeId = newGradeId;
+    this.promotion = promotion;
+  }
 
   public StockUnitGradeChangedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitSoftHoldPlacedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitSoftHoldPlacedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -9,6 +12,27 @@ public class StockUnitSoftHoldPlacedEvent extends DomainEvent {
   private final UUID quoteLineId;
   private final UUID stockUnitId;
   private final UUID softHoldId;
+
+  @JsonCreator
+  public StockUnitSoftHoldPlacedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteLineId") UUID quoteLineId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("softHoldId") UUID softHoldId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_SOFT_HOLD_PLACED",
+        occurredAt,
+        correlationId);
+    this.quoteLineId = quoteLineId;
+    this.stockUnitId = stockUnitId;
+    this.softHoldId = softHoldId;
+  }
 
   public StockUnitSoftHoldPlacedEvent(
       UUID tenantId, UUID quoteLineId, UUID stockUnitId, UUID softHoldId) {

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitSoftHoldReleasedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitSoftHoldReleasedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -9,6 +12,27 @@ public class StockUnitSoftHoldReleasedEvent extends DomainEvent {
   private final UUID quoteLineId;
   private final UUID stockUnitId;
   private final UUID softHoldId;
+
+  @JsonCreator
+  public StockUnitSoftHoldReleasedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteLineId") UUID quoteLineId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("softHoldId") UUID softHoldId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_SOFT_HOLD_RELEASED",
+        occurredAt,
+        correlationId);
+    this.quoteLineId = quoteLineId;
+    this.stockUnitId = stockUnitId;
+    this.softHoldId = softHoldId;
+  }
 
   public StockUnitSoftHoldReleasedEvent(
       UUID tenantId, UUID quoteLineId, UUID stockUnitId, UUID softHoldId) {

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitTransferredEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/event/StockUnitTransferredEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.stockunit.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -20,6 +23,35 @@ public class StockUnitTransferredEvent extends DomainEvent {
   private final String unit;
   private final UUID fromLocationId;
   private final UUID toLocationId;
+
+  @JsonCreator
+  public StockUnitTransferredEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("barcode") String barcode,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("weight") BigDecimal weight,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("fromLocationId") UUID fromLocationId,
+      @JsonProperty("toLocationId") UUID toLocationId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "STOCK_UNIT_TRANSFERRED",
+        occurredAt,
+        correlationId);
+    this.stockUnitId = stockUnitId;
+    this.barcode = barcode;
+    this.batchId = batchId;
+    this.weight = weight;
+    this.unit = unit;
+    this.fromLocationId = fromLocationId;
+    this.toLocationId = toLocationId;
+  }
 
   public StockUnitTransferredEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/ProductionRecordedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/ProductionRecordedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,31 @@ public class ProductionRecordedEvent extends DomainEvent {
   private final UUID batchId;
   private final BigDecimal outputWeight;
   private final String unit;
+
+  @JsonCreator
+  public ProductionRecordedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("outputWeight") BigDecimal outputWeight,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PRODUCTION_RECORDED",
+        occurredAt,
+        correlationId);
+    this.workOrderId = workOrderId;
+    this.stockUnitId = stockUnitId;
+    this.batchId = batchId;
+    this.outputWeight = outputWeight;
+    this.unit = unit;
+  }
 
   public ProductionRecordedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderApprovedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderApprovedEvent.java
@@ -2,7 +2,10 @@ package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.execution.workorder.domain.WorkOrderModuleType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -28,6 +31,35 @@ public class WorkOrderApprovedEvent extends DomainEvent {
       UUID tradingPartnerId,
       UUID approvedByUserId) {
     super(tenantId, "WORK_ORDER_APPROVED");
+    this.workOrderId = workOrderId;
+    this.workOrderNumber = workOrderNumber;
+    this.moduleType = moduleType;
+    this.outputProductId = outputProductId;
+    this.plannedQuantity = plannedQuantity;
+    this.tradingPartnerId = tradingPartnerId;
+    this.approvedByUserId = approvedByUserId;
+  }
+
+  @JsonCreator
+  public WorkOrderApprovedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("workOrderNumber") String workOrderNumber,
+      @JsonProperty("moduleType") WorkOrderModuleType moduleType,
+      @JsonProperty("outputProductId") UUID outputProductId,
+      @JsonProperty("plannedQuantity") BigDecimal plannedQuantity,
+      @JsonProperty("tradingPartnerId") UUID tradingPartnerId,
+      @JsonProperty("approvedByUserId") UUID approvedByUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_APPROVED",
+        occurredAt,
+        correlationId);
     this.workOrderId = workOrderId;
     this.workOrderNumber = workOrderNumber;
     this.moduleType = moduleType;

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderCompletedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderCompletedEvent.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.UUID;
@@ -32,6 +34,39 @@ public class WorkOrderCompletedEvent extends DomainEvent {
       Instant completedAt,
       UUID completedBy) {
     super(tenantId, "WORK_ORDER_COMPLETED");
+    this.workOrderId = workOrderId;
+    this.salesOrderLineId = salesOrderLineId;
+    this.workOrderNumber = workOrderNumber;
+    this.plannedQty = plannedQty;
+    this.actualQty = actualQty;
+    this.totalConsumed = totalConsumed;
+    this.yieldPercentage = yieldPercentage;
+    this.completedAt = completedAt;
+    this.completedBy = completedBy;
+  }
+
+  @JsonCreator
+  public WorkOrderCompletedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("salesOrderLineId") UUID salesOrderLineId,
+      @JsonProperty("workOrderNumber") String workOrderNumber,
+      @JsonProperty("plannedQty") BigDecimal plannedQty,
+      @JsonProperty("actualQty") BigDecimal actualQty,
+      @JsonProperty("totalConsumed") BigDecimal totalConsumed,
+      @JsonProperty("yieldPercentage") BigDecimal yieldPercentage,
+      @JsonProperty("completedAt") Instant completedAt,
+      @JsonProperty("completedBy") UUID completedBy) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_COMPLETED",
+        occurredAt,
+        correlationId);
     this.workOrderId = workOrderId;
     this.salesOrderLineId = salesOrderLineId;
     this.workOrderNumber = workOrderNumber;

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderDeadlineSetEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderDeadlineSetEvent.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
@@ -12,6 +14,27 @@ public class WorkOrderDeadlineSetEvent extends DomainEvent {
   private final UUID workOrderId;
   private final String workOrderNumber;
   private final Instant deadline;
+
+  @JsonCreator
+  public WorkOrderDeadlineSetEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("workOrderNumber") String workOrderNumber,
+      @JsonProperty("deadline") Instant deadline) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_DEADLINE_SET",
+        occurredAt,
+        correlationId);
+    this.workOrderId = workOrderId;
+    this.workOrderNumber = workOrderNumber;
+    this.deadline = deadline;
+  }
 
   public WorkOrderDeadlineSetEvent(
       UUID tenantId, UUID workOrderId, String workOrderNumber, Instant deadline) {

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderPendingApprovalEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderPendingApprovalEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,27 @@ public class WorkOrderPendingApprovalEvent extends DomainEvent {
   private final UUID workOrderId;
   private final String workOrderNumber;
   private final UUID assignedToUserId; // onaylaması gereken kişi
+
+  @JsonCreator
+  public WorkOrderPendingApprovalEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("workOrderNumber") String workOrderNumber,
+      @JsonProperty("assignedToUserId") UUID assignedToUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_PENDING_APPROVAL",
+        occurredAt,
+        correlationId);
+    this.workOrderId = workOrderId;
+    this.workOrderNumber = workOrderNumber;
+    this.assignedToUserId = assignedToUserId;
+  }
 
   public WorkOrderPendingApprovalEvent(
       UUID tenantId, UUID workOrderId, String workOrderNumber, UUID assignedToUserId) {

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderStockConsumedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/domain/event/WorkOrderStockConsumedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.production.execution.workorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -14,6 +17,31 @@ public class WorkOrderStockConsumedEvent extends DomainEvent {
   private final UUID batchId;
   private final BigDecimal consumedWeight;
   private final String unit;
+
+  @JsonCreator
+  public WorkOrderStockConsumedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("workOrderId") UUID workOrderId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("consumedWeight") BigDecimal consumedWeight,
+      @JsonProperty("unit") String unit) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "WORK_ORDER_STOCK_CONSUMED",
+        occurredAt,
+        correlationId);
+    this.workOrderId = workOrderId;
+    this.stockUnitId = stockUnitId;
+    this.batchId = batchId;
+    this.consumedWeight = consumedWeight;
+    this.unit = unit;
+  }
 
   public WorkOrderStockConsumedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/masterdata/fiber/domain/event/FiberCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/fiber/domain/event/FiberCreatedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.masterdata.fiber.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,29 @@ public class FiberCreatedEvent extends DomainEvent {
   private final String fiberName;
   private final UUID fiberCategoryId;
   private final UUID fiberIsoCodeId;
+
+  @JsonCreator
+  public FiberCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("fiberId") UUID fiberId,
+      @JsonProperty("fiberName") String fiberName,
+      @JsonProperty("fiberCategoryId") UUID fiberCategoryId,
+      @JsonProperty("fiberIsoCodeId") UUID fiberIsoCodeId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "FIBER_CREATED",
+        occurredAt,
+        correlationId);
+    this.fiberId = fiberId;
+    this.fiberName = fiberName;
+    this.fiberCategoryId = fiberCategoryId;
+    this.fiberIsoCodeId = fiberIsoCodeId;
+  }
 
   public FiberCreatedEvent(
       UUID tenantId, UUID fiberId, String fiberName, UUID fiberCategoryId, UUID fiberIsoCodeId) {

--- a/src/main/java/com/fabricmanagement/production/masterdata/product/domain/event/ProductCreatedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/product/domain/event/ProductCreatedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.production.masterdata.product.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,25 @@ public class ProductCreatedEvent extends DomainEvent {
 
   private final UUID productId;
   private final ProductType productType;
+
+  @JsonCreator
+  public ProductCreatedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("productId") UUID productId,
+      @JsonProperty("productType") ProductType productType) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PRODUCT_CREATED",
+        occurredAt,
+        correlationId);
+    this.productId = productId;
+    this.productType = productType;
+  }
 
   public ProductCreatedEvent(UUID tenantId, UUID productId, ProductType productType) {
     super(tenantId, "PRODUCT_CREATED");

--- a/src/main/java/com/fabricmanagement/production/quality/result/domain/event/BatchQcFailedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/domain/event/BatchQcFailedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.quality.result.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,29 @@ public class BatchQcFailedEvent extends DomainEvent {
   private final String batchCode;
   private final String failureReason;
   private final UUID qualityResponsibleUserId;
+
+  @JsonCreator
+  public BatchQcFailedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("batchCode") String batchCode,
+      @JsonProperty("failureReason") String failureReason,
+      @JsonProperty("qualityResponsibleUserId") UUID qualityResponsibleUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_QC_FAILED",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.batchCode = batchCode;
+    this.failureReason = failureReason;
+    this.qualityResponsibleUserId = qualityResponsibleUserId;
+  }
 
   public BatchQcFailedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/production/quality/result/domain/event/BatchQcPendingEvent.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/domain/event/BatchQcPendingEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.production.quality.result.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,27 @@ public class BatchQcPendingEvent extends DomainEvent {
   private final UUID batchId;
   private final String batchCode;
   private final UUID qualityResponsibleUserId;
+
+  @JsonCreator
+  public BatchQcPendingEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("batchCode") String batchCode,
+      @JsonProperty("qualityResponsibleUserId") UUID qualityResponsibleUserId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "BATCH_QC_PENDING",
+        occurredAt,
+        correlationId);
+    this.batchId = batchId;
+    this.batchCode = batchCode;
+    this.qualityResponsibleUserId = qualityResponsibleUserId;
+  }
 
   public BatchQcPendingEvent(
       UUID tenantId, UUID batchId, String batchCode, UUID qualityResponsibleUserId) {

--- a/src/main/java/com/fabricmanagement/production/quality/result/domain/event/FiberTestResultApprovedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/domain/event/FiberTestResultApprovedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.production.quality.result.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.production.quality.result.domain.TestApprovalStatus;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -27,6 +30,29 @@ public class FiberTestResultApprovedEvent extends DomainEvent {
       TestApprovalStatus approvalStatus,
       UUID actorId) {
     super(tenantId, "FIBER_TEST_RESULT_APPROVED");
+    this.batchId = batchId;
+    this.stockUnitId = stockUnitId;
+    this.approvalStatus = approvalStatus;
+    this.actorId = actorId;
+  }
+
+  @JsonCreator
+  public FiberTestResultApprovedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("batchId") UUID batchId,
+      @JsonProperty("stockUnitId") UUID stockUnitId,
+      @JsonProperty("approvalStatus") TestApprovalStatus approvalStatus,
+      @JsonProperty("actorId") UUID actorId) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "FIBER_TEST_RESULT_APPROVED",
+        occurredAt,
+        correlationId);
     this.batchId = batchId;
     this.stockUnitId = stockUnitId;
     this.approvalStatus = approvalStatus;

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteApprovalTokenGeneratedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteApprovalTokenGeneratedEvent.java
@@ -2,6 +2,9 @@ package com.fabricmanagement.sales.quote.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -15,6 +18,33 @@ public class QuoteApprovalTokenGeneratedEvent extends DomainEvent {
   private final String customerEmail;
   private final QuoteApprovalChannel channel;
   private final String localeLanguageTag;
+
+  @JsonCreator
+  public QuoteApprovalTokenGeneratedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("quoteNumber") String quoteNumber,
+      @JsonProperty("token") String token,
+      @JsonProperty("customerEmail") String customerEmail,
+      @JsonProperty("channel") QuoteApprovalChannel channel,
+      @JsonProperty("localeLanguageTag") String localeLanguageTag) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "QUOTE_APPROVAL_TOKEN_GENERATED",
+        occurredAt,
+        correlationId);
+    this.quoteId = quoteId;
+    this.quoteNumber = quoteNumber;
+    this.token = token;
+    this.customerEmail = customerEmail;
+    this.channel = channel;
+    this.localeLanguageTag = localeLanguageTag;
+  }
 
   public QuoteApprovalTokenGeneratedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestRejectedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestRejectedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.sales.quote.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -12,6 +15,31 @@ public class QuoteSendRequestRejectedEvent extends DomainEvent {
   private final String quoteNumber;
   private final UUID requesterId;
   private final String decisionNote;
+
+  @JsonCreator
+  public QuoteSendRequestRejectedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteSendRequestId") UUID quoteSendRequestId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("quoteNumber") String quoteNumber,
+      @JsonProperty("requesterId") UUID requesterId,
+      @JsonProperty("decisionNote") String decisionNote) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "QUOTE_SEND_REQUEST_REJECTED",
+        occurredAt,
+        correlationId);
+    this.quoteSendRequestId = quoteSendRequestId;
+    this.quoteId = quoteId;
+    this.quoteNumber = quoteNumber;
+    this.requesterId = requesterId;
+    this.decisionNote = decisionNote;
+  }
 
   public QuoteSendRequestRejectedEvent(
       UUID tenantId,

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/event/QuoteSendRequestedEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.sales.quote.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Getter;
 
@@ -11,6 +14,29 @@ public class QuoteSendRequestedEvent extends DomainEvent {
   private final UUID quoteId;
   private final String quoteNumber;
   private final UUID requestedBy;
+
+  @JsonCreator
+  public QuoteSendRequestedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("quoteSendRequestId") UUID quoteSendRequestId,
+      @JsonProperty("quoteId") UUID quoteId,
+      @JsonProperty("quoteNumber") String quoteNumber,
+      @JsonProperty("requestedBy") UUID requestedBy) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "QUOTE_SEND_REQUESTED",
+        occurredAt,
+        correlationId);
+    this.quoteSendRequestId = quoteSendRequestId;
+    this.quoteId = quoteId;
+    this.quoteNumber = quoteNumber;
+    this.requestedBy = requestedBy;
+  }
 
   public QuoteSendRequestedEvent(
       UUID tenantId, UUID quoteSendRequestId, UUID quoteId, String quoteNumber, UUID requestedBy) {

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderCancelledEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderCancelledEvent.java
@@ -1,6 +1,9 @@
 package com.fabricmanagement.sales.salesorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import lombok.Getter;
@@ -21,6 +24,27 @@ public class SalesOrderCancelledEvent extends DomainEvent {
   public SalesOrderCancelledEvent(
       UUID tenantId, UUID salesOrderId, String orderNumber, List<UUID> cancelledLineIds) {
     super(tenantId, "SalesOrderCancelled");
+    this.salesOrderId = salesOrderId;
+    this.orderNumber = orderNumber;
+    this.cancelledLineIds = cancelledLineIds != null ? cancelledLineIds : List.of();
+  }
+
+  @JsonCreator
+  public SalesOrderCancelledEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("salesOrderId") UUID salesOrderId,
+      @JsonProperty("orderNumber") String orderNumber,
+      @JsonProperty("cancelledLineIds") List<UUID> cancelledLineIds) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SalesOrderCancelled",
+        occurredAt,
+        correlationId);
     this.salesOrderId = salesOrderId;
     this.orderNumber = orderNumber;
     this.cancelledLineIds = cancelledLineIds != null ? cancelledLineIds : List.of();

--- a/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderConfirmedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/salesorder/domain/event/SalesOrderConfirmedEvent.java
@@ -1,7 +1,10 @@
 package com.fabricmanagement.sales.salesorder.domain.event;
 
 import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.UUID;
 import lombok.Getter;
@@ -43,6 +46,37 @@ public class SalesOrderConfirmedEvent extends DomainEvent {
       LocalDate requestedDeliveryDate,
       java.util.List<SalesOrderLineSnapshot> lines) {
     super(tenantId, "SalesOrderConfirmed");
+    this.salesOrderId = salesOrderId;
+    this.orderNumber = orderNumber;
+    this.customerId = customerId;
+    this.customerName = customerName;
+    this.totalQuantity = totalQuantity;
+    this.unit = unit;
+    this.requestedDeliveryDate = requestedDeliveryDate;
+    this.lines = lines != null ? lines : java.util.Collections.emptyList();
+  }
+
+  @JsonCreator
+  public SalesOrderConfirmedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("salesOrderId") UUID salesOrderId,
+      @JsonProperty("orderNumber") String orderNumber,
+      @JsonProperty("customerId") UUID customerId,
+      @JsonProperty("customerName") String customerName,
+      @JsonProperty("totalQuantity") BigDecimal totalQuantity,
+      @JsonProperty("unit") String unit,
+      @JsonProperty("requestedDeliveryDate") LocalDate requestedDeliveryDate,
+      @JsonProperty("lines") java.util.List<SalesOrderLineSnapshot> lines) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "SalesOrderConfirmed",
+        occurredAt,
+        correlationId);
     this.salesOrderId = salesOrderId;
     this.orderNumber = orderNumber;
     this.customerId = customerId;

--- a/src/test/java/com/fabricmanagement/architecture/DomainEventJsonCreatorArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/DomainEventJsonCreatorArchTest.java
@@ -1,0 +1,67 @@
+package com.fabricmanagement.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DomainEventJsonCreatorArchTest {
+
+  private static final Set<String> REQUIRED_ENVELOPE_PROPERTIES =
+      Set.of("eventId", "tenantId", "eventType", "occurredAt", "correlationId");
+
+  @Test
+  void concreteDomainEventsDeclareJsonCreatorEnvelopeConstructor() {
+    JavaClasses classes =
+        new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.fabricmanagement");
+
+    List<String> offenders =
+        classes.stream()
+            .filter(javaClass -> javaClass.isAssignableTo(DomainEvent.class))
+            .filter(javaClass -> !javaClass.getName().equals(DomainEvent.class.getName()))
+            .map(JavaClass::reflect)
+            .filter(type -> !Modifier.isAbstract(type.getModifiers()))
+            .filter(type -> !hasJsonCreatorEnvelopeConstructor(type))
+            .map(Class::getName)
+            .sorted()
+            .toList();
+
+    assertThat(offenders)
+        .withFailMessage(
+            "Concrete DomainEvent subclasses must declare a @JsonCreator constructor carrying "
+                + "the envelope @JsonPropertys %s. Offenders: %s",
+            REQUIRED_ENVELOPE_PROPERTIES, offenders)
+        .isEmpty();
+  }
+
+  private static boolean hasJsonCreatorEnvelopeConstructor(Class<?> type) {
+    return Arrays.stream(type.getDeclaredConstructors())
+        .filter(constructor -> constructor.isAnnotationPresent(JsonCreator.class))
+        .anyMatch(DomainEventJsonCreatorArchTest::hasRequiredEnvelopeProperties);
+  }
+
+  private static boolean hasRequiredEnvelopeProperties(Constructor<?> constructor) {
+    Set<String> jsonProperties =
+        Arrays.stream(constructor.getParameterAnnotations())
+            .flatMap(Arrays::stream)
+            .filter(JsonProperty.class::isInstance)
+            .map(JsonProperty.class::cast)
+            .map(JsonProperty::value)
+            .collect(java.util.stream.Collectors.toSet());
+
+    return jsonProperties.containsAll(REQUIRED_ENVELOPE_PROPERTIES);
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/DomainEventSerializationTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/DomainEventSerializationTest.java
@@ -2,38 +2,216 @@ package com.fabricmanagement.common.infrastructure.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.fabricmanagement.common.domain.event.production.SalesOrderLineProductionCompletedEvent;
+import com.fabricmanagement.common.domain.event.production.SalesOrderLineStoredEvent;
+import com.fabricmanagement.common.domain.event.production.WorkOrderRecipeAssignmentNeededEvent;
+import com.fabricmanagement.common.domain.event.production.WorkOrderStartedEvent;
+import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.costing.domain.calculation.CostEntityType;
+import com.fabricmanagement.costing.domain.calculation.CostStage;
+import com.fabricmanagement.costing.domain.event.CostVarianceDetectedEvent;
+import com.fabricmanagement.finance.invoice.domain.event.InvoiceDisputedEvent;
+import com.fabricmanagement.finance.invoice.domain.event.InvoiceOverdueEvent;
+import com.fabricmanagement.finance.payment.domain.PaymentDirection;
+import com.fabricmanagement.finance.payment.domain.event.PaymentReceivedEvent;
+import com.fabricmanagement.human.core.employee.domain.event.EmployeeTerminatedEvent;
+import com.fabricmanagement.logistics.shipment.domain.event.ShipmentLineConfirmedEvent;
+import com.fabricmanagement.platform.approval.domain.event.ApprovalApprovedEvent;
+import com.fabricmanagement.platform.approval.domain.event.ApprovalRejectedEvent;
+import com.fabricmanagement.platform.tenant.domain.TenantStatus;
+import com.fabricmanagement.platform.tenant.domain.event.TenantCreatedEvent;
 import com.fabricmanagement.procurement.quote.domain.event.SupplierQuoteAcceptedEvent;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
+import com.fabricmanagement.production.execution.output.domain.event.ProductionOutputConfirmedEvent;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.event.StockUnitCreatedEvent;
+import com.fabricmanagement.production.execution.workorder.domain.WorkOrderModuleType;
+import com.fabricmanagement.production.execution.workorder.domain.event.WorkOrderApprovedEvent;
+import com.fabricmanagement.production.execution.workorder.domain.event.WorkOrderCompletedEvent;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.result.domain.TestApprovalStatus;
+import com.fabricmanagement.production.quality.result.domain.event.FiberTestResultApprovedEvent;
+import com.fabricmanagement.sales.quote.domain.event.QuoteSendRequestedEvent;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderCancelledEvent;
+import com.fabricmanagement.sales.salesorder.domain.event.SalesOrderConfirmedEvent;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
 import java.util.UUID;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Test;
-import org.slf4j.MDC;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.modulith.events.core.EventSerializer;
 
+@JsonTest
+@Import(EventsConfiguration.class)
 class DomainEventSerializationTest {
 
-  private final ObjectMapper objectMapper = new ObjectMapper().findAndRegisterModules();
+  @Autowired private EventSerializer eventSerializer;
 
-  @AfterEach
-  void clearMdc() {
-    MDC.clear();
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("idempotentHandlerConsumedEvents")
+  void idempotentHandlerConsumedEventRoundTripPreservesDomainEventEnvelope(
+      String eventClassName, DomainEvent original) {
+    Object serialized = eventSerializer.serialize(original);
+    DomainEvent restored = eventSerializer.deserialize(serialized, original.getClass());
+
+    assertThat(restored.getEventId())
+        .as(eventClassName + " eventId")
+        .isEqualTo(original.getEventId());
+    assertThat(restored.getOccurredAt())
+        .as(eventClassName + " occurredAt")
+        .isEqualTo(original.getOccurredAt());
+    assertThat(restored.getCorrelationId())
+        .as(eventClassName + " correlationId")
+        .isEqualTo(original.getCorrelationId());
   }
 
-  @Test
-  void supplierQuoteAcceptedEventRoundTripPreservesDomainEventEnvelope() throws Exception {
-    MDC.put("traceId", "trace-round-trip");
-    SupplierQuoteAcceptedEvent original =
-        new SupplierQuoteAcceptedEvent(UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID());
-    MDC.clear();
+  static List<Arguments> idempotentHandlerConsumedEvents() {
+    UUID tenantId = UUID.randomUUID();
+    return List.of(
+        event(new ApprovalApprovedEvent(tenantId, uuid(), "SALES_ORDER", uuid(), "SO-1", uuid())),
+        event(
+            new ApprovalRejectedEvent(
+                tenantId, uuid(), "WORK_ORDER", uuid(), "WO-1", uuid(), "not approved")),
+        event(
+            CostVarianceDetectedEvent.builder()
+                .tenantId(tenantId)
+                .costCalculationId(uuid())
+                .entityType(CostEntityType.WORK_ORDER)
+                .entityId(uuid())
+                .currentStage(CostStage.ACTUAL)
+                .previousStage(CostStage.PLANNED)
+                .previousTotal(new BigDecimal("100.00"))
+                .currentTotal(new BigDecimal("115.00"))
+                .varianceRatio(new BigDecimal("0.15"))
+                .currency("USD")
+                .build()),
+        event(new InvoiceOverdueEvent(tenantId, uuid(), "INV-1", uuid(), 7)),
+        event(
+            new PaymentReceivedEvent(
+                tenantId,
+                uuid(),
+                "PAY-1",
+                uuid(),
+                PaymentDirection.INBOUND,
+                Money.of(100, "USD"),
+                "USD")),
+        event(new InvoiceDisputedEvent(tenantId, uuid(), "INV-2", uuid())),
+        event(
+            new SalesOrderConfirmedEvent(
+                tenantId,
+                uuid(),
+                "SO-1",
+                uuid(),
+                "Customer",
+                new BigDecimal("12.50"),
+                "kg",
+                LocalDate.of(2026, 1, 15),
+                List.of(
+                    new SalesOrderConfirmedEvent.SalesOrderLineSnapshot(
+                        uuid(),
+                        uuid(),
+                        "FAB-1",
+                        new BigDecimal("12.50"),
+                        "kg",
+                        LocalDate.of(2026, 1, 15))))),
+        event(
+            new WorkOrderApprovedEvent(
+                tenantId,
+                uuid(),
+                "WO-1",
+                WorkOrderModuleType.WEAVING,
+                uuid(),
+                new BigDecimal("12.50"),
+                uuid(),
+                uuid())),
+        event(
+            GoodsReceiptConfirmedEvent.builder()
+                .tenantId(tenantId)
+                .receiptId(uuid())
+                .receiptNumber("GR-1")
+                .sourceType(GoodsReceiptSourceType.PURCHASE_ORDER)
+                .sourceId(uuid())
+                .confirmedAt(Instant.parse("2026-01-01T10:00:00Z"))
+                .items(
+                    List.of(
+                        new GoodsReceiptConfirmedEvent.ReceiptItemData(
+                            uuid(), "BC-1", new BigDecimal("10.00"), new BigDecimal("10.50"))))
+                .build()),
+        event(new WorkOrderRecipeAssignmentNeededEvent(tenantId, uuid(), uuid(), "GOTS", "TR")),
+        event(new QuoteSendRequestedEvent(tenantId, uuid(), uuid(), "Q-1", uuid())),
+        event(new TenantSettingsUpdatedEvent(tenantId, "Europe/London", "en-GB", "GBP")),
+        event(new EmployeeTerminatedEvent(tenantId, uuid(), LocalDate.of(2026, 2, 1))),
+        event(new SupplierQuoteAcceptedEvent(tenantId, uuid(), uuid())),
+        event(
+            new FiberTestResultApprovedEvent(
+                tenantId, uuid(), uuid(), TestApprovalStatus.APPROVED, uuid())),
+        event(
+            new ProductionOutputConfirmedEvent(
+                tenantId,
+                uuid(),
+                uuid(),
+                uuid(),
+                uuid(),
+                ProductType.FABRIC,
+                "m",
+                uuid(),
+                List.of(
+                    new ProductionOutputConfirmedEvent.OutputItemData(
+                        uuid(),
+                        "OUT-1",
+                        PackageType.ROLL,
+                        new BigDecimal("8.00"),
+                        new BigDecimal("8.20"),
+                        uuid())))),
+        event(
+            new StockUnitCreatedEvent(
+                tenantId,
+                uuid(),
+                "STU-1",
+                uuid(),
+                ProductType.FABRIC,
+                PackageType.ROLL,
+                new BigDecimal("8.00"),
+                "m",
+                uuid())),
+        event(
+            new WorkOrderCompletedEvent(
+                tenantId,
+                uuid(),
+                uuid(),
+                "WO-2",
+                new BigDecimal("10.00"),
+                new BigDecimal("9.50"),
+                new BigDecimal("1.00"),
+                new BigDecimal("95.00"),
+                Instant.parse("2026-01-02T10:00:00Z"),
+                uuid())),
+        event(new SalesOrderCancelledEvent(tenantId, uuid(), "SO-2", List.of(uuid()))),
+        event(
+            new TenantCreatedEvent(
+                tenantId,
+                "tenant-1",
+                "Tenant",
+                TenantStatus.TRIAL,
+                Instant.parse("2026-02-01T00:00:00Z"))),
+        event(new ShipmentLineConfirmedEvent(tenantId, uuid(), uuid(), new BigDecimal("3.25"))),
+        event(new WorkOrderStartedEvent(tenantId, uuid(), uuid())),
+        event(new SalesOrderLineProductionCompletedEvent(tenantId, uuid(), uuid())),
+        event(new SalesOrderLineStoredEvent(tenantId, uuid(), uuid())));
+  }
 
-    String json = objectMapper.writeValueAsString(original);
-    SupplierQuoteAcceptedEvent restored =
-        objectMapper.readValue(json, SupplierQuoteAcceptedEvent.class);
+  private static Arguments event(DomainEvent event) {
+    return Arguments.of(event.getClass().getName(), event);
+  }
 
-    assertThat(restored.getEventId()).isEqualTo(original.getEventId());
-    assertThat(restored.getOccurredAt()).isEqualTo(original.getOccurredAt());
-    assertThat(restored.getCorrelationId()).isEqualTo(original.getCorrelationId());
-    assertThat(restored.getTenantId()).isEqualTo(original.getTenantId());
-    assertThat(restored.getQuoteId()).isEqualTo(original.getQuoteId());
-    assertThat(restored.getRfqId()).isEqualTo(original.getRfqId());
+  private static UUID uuid() {
+    return UUID.randomUUID();
   }
 }


### PR DESCRIPTION
…s (ASYNC-TENANT-2)

ASYNC-TENANT-1 resurrected the tenant-restoring aspect, so all @ApplicationModuleListener listeners can act on tenant data again - which made the remaining eventId instability dangerous: every listener guards re-execution with idempotentHandler.executeOnce(event.getEventId(), ...), but deserialising an event from event_publication routed through the 2-arg DomainEvent constructor and minted a fresh eventId/occurredAt/correlationId. A resubmitted event whose completion record was lost (crash between listener commit and Modulith completion) would run twice: duplicate stock units, notifications, orders, costs.

Added a @JsonCreator envelope constructor to every concrete DomainEvent subclass (119 classes, mechanical, publication-side constructors and call sites untouched). Two-layer test lock:

- DomainEventJsonCreatorArchTest: ArchUnit ClassFileImporter discovers every concrete DomainEvent subclass and requires a @JsonCreator constructor carrying all five envelope @JsonPropertys; failure names the offender, so future event classes cannot regress silently.
- DomainEventSerializationTest: parameterised round trip of 22 hand-built instances of the event types consumed by IdempotentEventHandler listeners, through the real Modulith EventSerializer bean (@JsonTest + @Import(EventsConfiguration)), asserting eventId/occurredAt/correlationId survive - proving Jackson actually selects the envelope constructor.