### PR TITLE
fix(api): unique OpenAPI schema names for supplier quote DTOs (QUOTE-…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -26158,7 +26158,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AddQuoteLineRequest"
+              $ref: "#/components/schemas/SupplierQuoteAddLineRequest"
         required: true
       responses:
         "200":
@@ -51055,6 +51055,27 @@ components:
             description: CIELab L* target
             example: "45.0"
       description: Dye/finishing-specific purchase order specifications
+    DyeQuoteSpecs:
+      allOf:
+      - $ref: "#/components/schemas/SupplierQuoteSpecs"
+      - type: object
+        properties:
+          color:
+            type: string
+            description: Color code or name
+          finish:
+            type: string
+            description: "Finishing treatments (e.g., Sanforized, Water Repellent)"
+          processNotes:
+            type: string
+            description: Additional processing notes
+          processType:
+            type: string
+            description: "Dyeing process type (e.g., Reactive, Disperse)"
+          shrinkageExpected:
+            type: number
+            description: Expected shrinkage after wash
+      description: Dyeing and finishing specific quote specifications
     DyeRFQSpecs:
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
@@ -51364,6 +51385,30 @@ components:
             description: Width in cm (100-320)
             example: 150
       description: Fabric-specific purchase order specifications
+    FabricQuoteSpecs:
+      allOf:
+      - $ref: "#/components/schemas/SupplierQuoteSpecs"
+      - type: object
+        properties:
+          construction:
+            type: string
+            description: "Fabric construction (e.g., 20x20/60x60)"
+          fabricNotes:
+            type: string
+            description: Additional fabric notes
+          gsm:
+            type: number
+            description: Grams per square meter (GSM)
+          shrinkagePercentage:
+            type: number
+            description: Shrinkage percentage
+          type:
+            type: string
+            description: Weave or knit type
+          widthCm:
+            type: number
+            description: Fabric width in cm
+      description: Fabric-specific quote specifications
     FabricRFQSpecs:
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
@@ -51710,6 +51755,27 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FiberQualityStandardDto"
+    FiberQuoteSpecs:
+      allOf:
+      - $ref: "#/components/schemas/SupplierQuoteSpecs"
+      - type: object
+        properties:
+          micronaire:
+            type: number
+            description: Micronaire value
+          qualityNotes:
+            type: string
+            description: Additional fiber quality notes
+          stapleLengthMm:
+            type: number
+            description: Staple length in mm
+          strength:
+            type: number
+            description: Strength in g/tex
+          trashContentPercentage:
+            type: number
+            description: Trash content percentage
+      description: Fiber-specific quote specifications
     FiberRFQSpecs:
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
@@ -52061,6 +52127,15 @@ components:
             type: string
             description: Free-text description for untyped POs
       description: Generic purchase order specifications for unclassified items
+    GenericQuoteSpecs:
+      allOf:
+      - $ref: "#/components/schemas/SupplierQuoteSpecs"
+      - type: object
+        properties:
+          notes:
+            type: string
+            description: Any additional processing or requirement notes
+      description: Generic quote specs for undefined or basic modules
     GenericRFQSpecs:
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"
@@ -57260,6 +57335,91 @@ components:
           type: string
         type:
           type: string
+    SupplierQuoteAddLineRequest:
+      type: object
+      description: Request to add a line to a supplier quote
+      properties:
+        currency:
+          type: string
+          description: Currency code
+          example: GBP
+          minLength: 1
+        moduleSpecs:
+          $ref: "#/components/schemas/SupplierQuoteSpecs"
+          description: Module-specific specifications
+        notes:
+          type: string
+          description: Line notes
+        qty:
+          type: number
+          description: Quantity
+          minimum: 0.001
+        rfqLineId:
+          type: string
+          format: uuid
+          description: RFQ Line ID
+        unit:
+          type: string
+          description: Unit of measure
+          minLength: 1
+        unitPrice:
+          type: number
+          description: Unit price
+          minimum: 0.0001
+        volumeDiscounts:
+          type: object
+          additionalProperties: {}
+          description: Volume discounts
+      required:
+      - currency
+      - qty
+      - rfqLineId
+      - unit
+      - unitPrice
+    SupplierQuoteLineResponse:
+      type: object
+      description: Supplier Quote Line Response
+      properties:
+        currency:
+          type: string
+          description: Currency
+        id:
+          type: string
+          format: uuid
+          description: Line ID
+        lineTotal:
+          type: number
+          description: Total Line Amount
+        moduleSpecs:
+          $ref: "#/components/schemas/SupplierQuoteSpecs"
+          description: Module Specs
+        notes:
+          type: string
+          description: Line Notes
+        productDesc:
+          type: string
+          description: Product description resolved from the RFQ line
+        productId:
+          type: string
+          format: uuid
+          description: Product ID resolved from the RFQ line
+        qty:
+          type: number
+          description: Quantity
+        rfqLineId:
+          type: string
+          format: uuid
+          description: RFQ Line ID
+        unit:
+          type: string
+          description: Unit of Measure
+        unitPrice:
+          type: number
+          description: Unit Price
+        volumeDiscounts:
+          type: object
+          additionalProperties: true
+          description: Volume Discounts
     SupplierQuoteResponse:
       type: object
       description: Supplier Quote Response
@@ -57287,7 +57447,7 @@ components:
           type: array
           description: Quote Lines
           items:
-            $ref: "#/components/schemas/QuoteLineResponse"
+            $ref: "#/components/schemas/SupplierQuoteLineResponse"
         moduleType:
           type: string
           description: Module Type
@@ -57340,6 +57500,21 @@ components:
           type: string
           format: date
           description: Valid Until Date
+    SupplierQuoteSpecs:
+      description: "Module-specific quote specs, discriminated by specType"
+      discriminator:
+        propertyName: specType
+      oneOf:
+      - $ref: "#/components/schemas/FiberQuoteSpecs"
+      - $ref: "#/components/schemas/YarnQuoteSpecs"
+      - $ref: "#/components/schemas/FabricQuoteSpecs"
+      - $ref: "#/components/schemas/DyeQuoteSpecs"
+      - $ref: "#/components/schemas/GenericQuoteSpecs"
+      properties:
+        specType:
+          type: string
+      required:
+      - specType
     SupplierRFQResponse:
       type: object
       properties:
@@ -60083,6 +60258,27 @@ components:
             description: Yarn count (Ne)
             example: 30/1
       description: Yarn-specific purchase order specifications
+    YarnQuoteSpecs:
+      allOf:
+      - $ref: "#/components/schemas/SupplierQuoteSpecs"
+      - type: object
+        properties:
+          blend:
+            type: string
+            description: "Blend composition (e.g., 100% Cotton)"
+          strength:
+            type: number
+            description: Strength (RKM)
+          twist:
+            type: number
+            description: Twist level (TPM or TPI)
+          yarnCount:
+            type: string
+            description: "Yarn count (e.g., Ne 30/1)"
+          yarnNotes:
+            type: string
+            description: Additional yarn notes
+      description: Yarn-specific quote specifications
     YarnRFQSpecs:
       allOf:
       - $ref: "#/components/schemas/SupplierRFQSpecs"

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
@@ -21,6 +21,7 @@ import com.fabricmanagement.procurement.quote.dto.SupplierQuoteResponse;
 import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepository;
 import com.fabricmanagement.procurement.quote.mapper.SupplierQuoteMapper;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -28,7 +29,10 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -53,7 +57,7 @@ public class SupplierQuoteService {
   private final TenantReportingCurrencyPort tenantReportingCurrencyPort;
 
   public SupplierQuoteResponse getQuoteById(UUID quoteId) {
-    return quoteMapper.toResponse(getActiveQuote(quoteId));
+    return toResponse(getActiveQuote(quoteId));
   }
 
   public PagedResponse<SupplierQuoteResponse> listQuotes(
@@ -77,16 +81,16 @@ public class SupplierQuoteService {
     }
 
     Page<SupplierQuote> page = quoteRepository.findAll(spec, pageable);
-    return PagedResponse.from(page, quoteMapper::toResponse);
+    Map<UUID, SupplierRFQLine> rfqLinesById = loadRfqLines(page.getContent());
+    return PagedResponse.from(page, quote -> quoteMapper.toResponse(quote, rfqLinesById));
   }
 
   public List<SupplierQuoteResponse> getQuotesByRfq(UUID rfqId) {
     UUID tenantId = TenantContext.requireTenantId();
-    return quoteRepository
-        .findByTenantIdAndRfqIdAndIsActiveTrueOrderByCreatedAtDesc(tenantId, rfqId)
-        .stream()
-        .map(quoteMapper::toResponse)
-        .toList();
+    List<SupplierQuote> quotes =
+        quoteRepository.findByTenantIdAndRfqIdAndIsActiveTrueOrderByCreatedAtDesc(tenantId, rfqId);
+    Map<UUID, SupplierRFQLine> rfqLinesById = loadRfqLines(quotes);
+    return quotes.stream().map(quote -> quoteMapper.toResponse(quote, rfqLinesById)).toList();
   }
 
   @Transactional
@@ -130,7 +134,7 @@ public class SupplierQuoteService {
 
     publishReceivedEvent(saved);
 
-    return quoteMapper.toResponse(saved);
+    return quoteMapper.toResponse(saved, indexRfqLines(parentRfq));
   }
 
   @Transactional
@@ -154,7 +158,7 @@ public class SupplierQuoteService {
 
     quote.addLine(line);
     recomputeTotals(quote);
-    return quoteMapper.toResponse(quoteRepository.save(quote));
+    return toResponse(quoteRepository.save(quote));
   }
 
   @Transactional
@@ -163,7 +167,7 @@ public class SupplierQuoteService {
     quote.startReview();
     SupplierQuote saved = quoteRepository.save(quote);
     log.info("SupplierQuote review started: {}", saved.getQuoteNumber());
-    return quoteMapper.toResponse(saved);
+    return toResponse(saved);
   }
 
   @Transactional
@@ -199,7 +203,7 @@ public class SupplierQuoteService {
     eventPublisher.publish(
         new SupplierQuoteAcceptedEvent(saved.getTenantId(), saved.getId(), saved.getRfqId()));
 
-    return quoteMapper.toResponse(saved);
+    return toResponse(saved);
   }
 
   @Transactional
@@ -208,10 +212,35 @@ public class SupplierQuoteService {
     quote.reject();
     SupplierQuote saved = quoteRepository.save(quote);
     log.info("SupplierQuote rejected: {}", saved.getQuoteNumber());
-    return quoteMapper.toResponse(saved);
+    return toResponse(saved);
   }
 
   // ── Private Helpers ────────────────────────────────────────────────────────
+
+  private SupplierQuoteResponse toResponse(SupplierQuote quote) {
+    return quoteMapper.toResponse(quote, loadRfqLines(List.of(quote)));
+  }
+
+  private Map<UUID, SupplierRFQLine> loadRfqLines(List<SupplierQuote> quotes) {
+    if (quotes.isEmpty()) {
+      return Map.of();
+    }
+
+    UUID tenantId = TenantContext.requireTenantId();
+    List<UUID> rfqIds = quotes.stream().map(SupplierQuote::getRfqId).distinct().toList();
+    return rfqRepository.findAllByTenantIdAndIdInAndIsActiveTrue(tenantId, rfqIds).stream()
+        .flatMap(rfq -> rfq.getLines().stream())
+        .collect(
+            Collectors.toMap(
+                SupplierRFQLine::getId, Function.identity(), (first, duplicate) -> first));
+  }
+
+  private Map<UUID, SupplierRFQLine> indexRfqLines(SupplierRFQ rfq) {
+    return rfq.getLines().stream()
+        .collect(
+            Collectors.toMap(
+                SupplierRFQLine::getId, Function.identity(), (first, duplicate) -> first));
+  }
 
   private SupplierQuote getActiveQuote(UUID quoteId) {
     UUID tenantId = TenantContext.requireTenantId();

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteService.java
@@ -164,6 +164,11 @@ public class SupplierQuoteService {
   @Transactional
   public SupplierQuoteResponse startReview(UUID quoteId) {
     SupplierQuote quote = getActiveQuote(quoteId);
+    if (!hasActiveLines(quote)) {
+      throw new ProcurementDomainException(
+          "Quote has no lines; add at least one line before review.");
+    }
+
     quote.startReview();
     SupplierQuote saved = quoteRepository.save(quote);
     log.info("SupplierQuote review started: {}", saved.getQuoteNumber());
@@ -173,6 +178,10 @@ public class SupplierQuoteService {
   @Transactional
   public SupplierQuoteResponse markAsAccepted(UUID quoteId) {
     SupplierQuote quote = getActiveQuote(quoteId);
+    if (!hasActiveLines(quote)) {
+      throw new ProcurementDomainException(
+          "Quote has no lines; add at least one line before acceptance.");
+    }
 
     // Auto-reject siblings — tek query ile RECEIVED + UNDER_REVIEW çek
     List<SupplierQuote> receivedSiblings =
@@ -216,6 +225,10 @@ public class SupplierQuoteService {
   }
 
   // ── Private Helpers ────────────────────────────────────────────────────────
+
+  private boolean hasActiveLines(SupplierQuote quote) {
+    return quote.getLines().stream().anyMatch(line -> Boolean.TRUE.equals(line.getIsActive()));
+  }
 
   private SupplierQuoteResponse toResponse(SupplierQuote quote) {
     return quoteMapper.toResponse(quote, loadRfqLines(List.of(quote)));

--- a/src/main/java/com/fabricmanagement/procurement/quote/dto/AddQuoteLineRequest.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/dto/AddQuoteLineRequest.java
@@ -9,7 +9,9 @@ import java.math.BigDecimal;
 import java.util.Map;
 import java.util.UUID;
 
-@Schema(description = "Request to add a line to a supplier quote")
+@Schema(
+    name = "SupplierQuoteAddLineRequest",
+    description = "Request to add a line to a supplier quote")
 public record AddQuoteLineRequest(
     @NotNull(message = "RFQ line ID is required")
         @Schema(description = "RFQ Line ID", requiredMode = Schema.RequiredMode.REQUIRED)

--- a/src/main/java/com/fabricmanagement/procurement/quote/dto/SupplierQuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/dto/SupplierQuoteResponse.java
@@ -74,13 +74,19 @@ public class SupplierQuoteResponse {
 
   @Value
   @Builder
-  @Schema(description = "Supplier Quote Line Response")
+  @Schema(name = "SupplierQuoteLineResponse", description = "Supplier Quote Line Response")
   public static class QuoteLineResponse {
     @Schema(description = "Line ID")
     UUID id;
 
     @Schema(description = "RFQ Line ID")
     UUID rfqLineId;
+
+    @Schema(description = "Product ID resolved from the RFQ line")
+    UUID productId;
+
+    @Schema(description = "Product description resolved from the RFQ line")
+    String productDesc;
 
     @Schema(description = "Unit Price")
     BigDecimal unitPrice;

--- a/src/main/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapper.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapper.java
@@ -6,6 +6,10 @@ import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
 import com.fabricmanagement.procurement.quote.dto.SupplierQuoteResponse;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
+import java.util.Map;
+import java.util.UUID;
+import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -13,10 +17,26 @@ import org.mapstruct.Mapping;
 public interface SupplierQuoteMapper {
 
   @Mapping(target = "totalAmount", expression = "java(entity.computeTotalAmount())")
-  SupplierQuoteResponse toResponse(SupplierQuote entity);
+  SupplierQuoteResponse toResponse(
+      SupplierQuote entity, @Context Map<UUID, SupplierRFQLine> rfqLinesById);
 
   @Mapping(target = "lineTotal", expression = "java(line.lineTotal())")
-  SupplierQuoteResponse.QuoteLineResponse toLineResponse(SupplierQuoteLine line);
+  @Mapping(target = "productId", expression = "java(productId(line.getRfqLineId(), rfqLinesById))")
+  @Mapping(
+      target = "productDesc",
+      expression = "java(productDesc(line.getRfqLineId(), rfqLinesById))")
+  SupplierQuoteResponse.QuoteLineResponse toLineResponse(
+      SupplierQuoteLine line, @Context Map<UUID, SupplierRFQLine> rfqLinesById);
+
+  default UUID productId(UUID rfqLineId, Map<UUID, SupplierRFQLine> rfqLinesById) {
+    SupplierRFQLine rfqLine = rfqLinesById.get(rfqLineId);
+    return rfqLine != null ? rfqLine.getProductId() : null;
+  }
+
+  default String productDesc(UUID rfqLineId, Map<UUID, SupplierRFQLine> rfqLinesById) {
+    SupplierRFQLine rfqLine = rfqLinesById.get(rfqLineId);
+    return rfqLine != null ? rfqLine.getProductDesc() : null;
+  }
 
   default ConvertedMoneyDto toDto(ConvertedMoney money) {
     if (money == null) {

--- a/src/main/java/com/fabricmanagement/procurement/rfq/infra/repository/SupplierRFQRepository.java
+++ b/src/main/java/com/fabricmanagement/procurement/rfq/infra/repository/SupplierRFQRepository.java
@@ -1,8 +1,11 @@
 package com.fabricmanagement.procurement.rfq.infra.repository;
 
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -11,4 +14,7 @@ import org.springframework.stereotype.Repository;
 public interface SupplierRFQRepository
     extends JpaRepository<SupplierRFQ, UUID>, JpaSpecificationExecutor<SupplierRFQ> {
   Optional<SupplierRFQ> findByTenantIdAndIdAndIsActiveTrue(UUID tenantId, UUID id);
+
+  @EntityGraph(attributePaths = "lines")
+  List<SupplierRFQ> findAllByTenantIdAndIdInAndIsActiveTrue(UUID tenantId, Collection<UUID> ids);
 }

--- a/src/test/java/com/fabricmanagement/architecture/OpenApiExportIT.java
+++ b/src/test/java/com/fabricmanagement/architecture/OpenApiExportIT.java
@@ -60,6 +60,7 @@ public class OpenApiExportIT {
     String generatedSpec = response.getBody();
     assertThat(generatedSpec).isNotNull();
     assertThat(generatedSpec).contains("openapi: 3.");
+    assertThat(generatedSpec).doesNotContainPattern("(?m)^    [A-Za-z][A-Za-z0-9]*_1:$");
 
     // 2. Define the target spec file location
     File specFile = new File("api/openapi.yaml");

--- a/src/test/java/com/fabricmanagement/architecture/OpenApiSchemaNameCollisionTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/OpenApiSchemaNameCollisionTest.java
@@ -1,0 +1,167 @@
+package com.fabricmanagement.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaModifier;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Protects component schema names before springdoc can collapse two Java DTO types into one.
+ *
+ * <p>This guard intentionally follows the codebase convention that API types live in {@code dto}
+ * packages. It includes public top-level and nested types in those packages, but it does not
+ * attempt to discover controller reachability or API types outside the convention. Lombok-generated
+ * builder implementation classes are excluded because they are not DTO declarations or schema
+ * candidates.
+ */
+class OpenApiSchemaNameCollisionTest {
+
+  private static final Pattern DTO_PACKAGE = Pattern.compile("(^|\\.)dto($|\\.)");
+  private static final Pattern SPRINGDOC_SUFFIXED_SCHEMA =
+      Pattern.compile("(?m)^    [A-Za-z][A-Za-z0-9]*_1:$");
+  private static final Pattern COMPONENT_SCHEMA =
+      Pattern.compile("(?m)^    ([A-Za-z][A-Za-z0-9._-]*):(?:\\s.*)?$");
+  private static final Pattern COMPONENT_SCHEMA_REF =
+      Pattern.compile("#/components/schemas/([A-Za-z][A-Za-z0-9._-]*)");
+
+  private static final Map<String, Set<String>> ALLOWED_COLLISIONS =
+      Map.of(
+          // QUOTE-CONTRACT-2: give batch and stock-unit requests unique schema names.
+          "ConsumeRequest",
+              Set.of(
+                  "com.fabricmanagement.production.execution.batch.dto.ConsumeRequest",
+                  "com.fabricmanagement.production.execution.stockunit.dto.ConsumeRequest"),
+          // QUOTE-CONTRACT-2: separate approval policy and platform policy contracts.
+          "CreatePolicyRequest",
+              Set.of(
+                  "com.fabricmanagement.approval.dto.CreatePolicyRequest",
+                  "com.fabricmanagement.platform.policy.dto.CreatePolicyRequest"),
+          // QUOTE-CONTRACT-2: separate batch and work-order production requests.
+          "StartProductionRequest",
+              Set.of(
+                  "com.fabricmanagement.production.execution.batch.dto.StartProductionRequest",
+                  "com.fabricmanagement.production.execution.workorder.dto.StartProductionRequest"),
+          // QUOTE-CONTRACT-2: separate approval policy and platform policy contracts.
+          "UpdatePolicyRequest",
+              Set.of(
+                  "com.fabricmanagement.approval.dto.UpdatePolicyRequest",
+                  "com.fabricmanagement.platform.policy.dto.UpdatePolicyRequest"),
+          // QUOTE-CONTRACT-2: disambiguate organization and user address payloads.
+          "AddressData",
+              Set.of(
+                  "com.fabricmanagement.platform.organization.dto.OrganizationAddressDto$AddressData",
+                  "com.fabricmanagement.platform.user.dto.AddressData",
+                  "com.fabricmanagement.platform.user.dto.UpdateUserProfileRequest$AddressData"),
+          // QUOTE-CONTRACT-2: disambiguate organization and user contact payloads.
+          "ContactData",
+              Set.of(
+                  "com.fabricmanagement.platform.organization.dto.OrganizationContactDto$ContactData",
+                  "com.fabricmanagement.platform.user.dto.ContactData"),
+          // QUOTE-CONTRACT-2: disambiguate user creation and profile-update emergency contacts.
+          "EmergencyContactData",
+              Set.of(
+                  "com.fabricmanagement.platform.user.dto.CreateInternalUserRequest$EmergencyContactData",
+                  "com.fabricmanagement.platform.user.dto.UpdateUserProfileRequest$EmergencyContactData"),
+          // QUOTE-CONTRACT-2: disambiguate production and consumption summary breakdowns.
+          "ProductBreakdown",
+              Set.of(
+                  "com.fabricmanagement.production.execution.workorder.dto.ProductionSummaryResponse$ProductBreakdown",
+                  "com.fabricmanagement.production.execution.workorder.dto.WorkOrderConsumptionSummaryResponse$ProductBreakdown"));
+
+  @Test
+  void publicDtoTypesShouldHaveUniqueEffectiveSchemaNamesExceptForExplicitAllowlist() {
+    Map<String, Set<String>> actualCollisions =
+        new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("com.fabricmanagement")
+                .stream()
+                .filter(javaClass -> DTO_PACKAGE.matcher(javaClass.getPackageName()).find())
+                .filter(javaClass -> javaClass.getModifiers().contains(JavaModifier.PUBLIC))
+                .filter(javaClass -> !sourceSimpleName(javaClass).endsWith("Builder"))
+                .collect(
+                    Collectors.groupingBy(
+                        OpenApiSchemaNameCollisionTest::effectiveSchemaName,
+                        TreeMap::new,
+                        Collectors.mapping(
+                            JavaClass::getName, Collectors.toCollection(TreeSet::new))))
+                .entrySet()
+                .stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (first, duplicate) -> first,
+                        TreeMap::new));
+
+    assertThat(actualCollisions)
+        .as(
+            "Public DTO types must have unique effective OpenAPI schema names. "
+                + "Rename new collisions with @Schema(name = ...); keep only QUOTE-CONTRACT-2 "
+                + "debt in the explicit allowlist. Actual collisions name every Java class.")
+        .isEqualTo(ALLOWED_COLLISIONS);
+  }
+
+  @Test
+  void committedOpenApiShouldNotContainSpringdocNumericSchemaSuffixes() throws IOException {
+    String openApi = Files.readString(Path.of("api/openapi.yaml"));
+
+    assertThat(openApi).doesNotContainPattern(SPRINGDOC_SUFFIXED_SCHEMA);
+  }
+
+  @Test
+  void committedOpenApiShouldNotContainDanglingComponentSchemaReferences() throws IOException {
+    String openApi = Files.readString(Path.of("api/openapi.yaml"));
+    String componentsMarker = "components:\n  schemas:\n";
+    int componentsStart = openApi.indexOf(componentsMarker);
+    assertThat(componentsStart)
+        .as("OpenAPI must define components.schemas")
+        .isGreaterThanOrEqualTo(0);
+    String schemasSection = openApi.substring(componentsStart + componentsMarker.length());
+
+    Set<String> definedSchemas =
+        COMPONENT_SCHEMA
+            .matcher(schemasSection)
+            .results()
+            .map(match -> match.group(1))
+            .collect(Collectors.toSet());
+    Set<String> referencedSchemas =
+        COMPONENT_SCHEMA_REF
+            .matcher(openApi)
+            .results()
+            .map(match -> match.group(1))
+            .collect(Collectors.toSet());
+
+    assertThat(definedSchemas)
+        .as("Every OpenAPI component schema reference must resolve to a defined component")
+        .containsAll(referencedSchemas);
+  }
+
+  private static String effectiveSchemaName(JavaClass javaClass) {
+    if (!javaClass.isAnnotatedWith(Schema.class)) {
+      return sourceSimpleName(javaClass);
+    }
+
+    String explicitName = javaClass.getAnnotationOfType(Schema.class).name();
+    return explicitName.isBlank() ? sourceSimpleName(javaClass) : explicitName;
+  }
+
+  private static String sourceSimpleName(JavaClass javaClass) {
+    String className = javaClass.getName();
+    int separator = Math.max(className.lastIndexOf('.'), className.lastIndexOf('$'));
+    return className.substring(separator + 1);
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +26,7 @@ import com.fabricmanagement.procurement.quote.dto.SupplierQuoteResponse;
 import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepository;
 import com.fabricmanagement.procurement.quote.mapper.SupplierQuoteMapper;
 import com.fabricmanagement.procurement.rfq.domain.SupplierRFQ;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
 import com.fabricmanagement.procurement.rfq.infra.repository.SupplierRFQRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -99,7 +102,7 @@ class SupplierQuoteServiceTest {
             null);
 
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
-    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
     when(partnerResolver.resolvePartner(tenantId, partnerId)).thenReturn(Optional.empty());
     SupplierRFQ mockRfq = new SupplierRFQ();
     mockRfq.setModuleType(
@@ -115,12 +118,35 @@ class SupplierQuoteServiceTest {
   }
 
   @Test
+  @DisplayName("Should resolve RFQ lines before mapping a Supplier Quote response")
+  void shouldResolveRfqLinesBeforeMappingResponse() {
+    UUID rfqLineId = UUID.randomUUID();
+    SupplierRFQLine rfqLine = new SupplierRFQLine();
+    rfqLine.setId(rfqLineId);
+    SupplierRFQ rfq = new SupplierRFQ();
+    rfq.addLine(rfqLine);
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+    when(rfqRepository.findAllByTenantIdAndIdInAndIsActiveTrue(
+            eq(tenantId), argThat(ids -> ids.contains(rfqId))))
+        .thenReturn(List.of(rfq));
+    when(quoteMapper.toResponse(eq(mockQuote), anyMap())).thenReturn(mockResponse);
+
+    SupplierQuoteResponse response = quoteService.getQuoteById(quoteId);
+
+    assertEquals(mockResponse, response);
+    verify(quoteMapper)
+        .toResponse(eq(mockQuote), argThat(rfqLines -> rfqLines.get(rfqLineId) == rfqLine));
+  }
+
+  @Test
   @DisplayName("Should successfully add line when Quote is in RECEIVED status")
   void shouldAddLineToReceivedQuote() {
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(mockQuote));
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
-    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
     when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("USD");
 
     AddQuoteLineRequest req =
@@ -155,7 +181,7 @@ class SupplierQuoteServiceTest {
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(mockQuote));
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
-    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
     when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("GBP");
     when(exchangeRateService.convert(
             eq(tenantId), any(BigDecimal.class), eq("USD"), eq("TRY"), eq(docDate)))
@@ -268,7 +294,7 @@ class SupplierQuoteServiceTest {
         .thenReturn(new ArrayList<>());
 
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
-    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
 
     SupplierQuoteResponse updated = quoteService.markAsAccepted(quoteId);
 
@@ -297,7 +323,7 @@ class SupplierQuoteServiceTest {
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
         .thenReturn(Optional.of(mockQuote));
     when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
-    when(quoteMapper.toResponse(any(SupplierQuote.class))).thenReturn(mockResponse);
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
 
     SupplierQuoteResponse updated = quoteService.markAsRejected(quoteId);
 

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteServiceTest.java
@@ -8,6 +8,8 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.domain.vo.ConvertedMoney;
@@ -16,6 +18,7 @@ import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
+import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.quote.domain.QuoteEntryMethod;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
@@ -267,8 +270,84 @@ class SupplierQuoteServiceTest {
   }
 
   @Test
+  @DisplayName("Should reject review when Supplier Quote has no active lines")
+  void shouldRejectReviewWithoutLines() {
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+
+    ProcurementDomainException ex =
+        assertThrows(ProcurementDomainException.class, () -> quoteService.startReview(quoteId));
+
+    assertEquals("Quote has no lines; add at least one line before review.", ex.getMessage());
+    verify(quoteRepository).findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId);
+    verifyNoMoreInteractions(quoteRepository);
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("Should reject review when Supplier Quote has only an inactive line")
+  void shouldRejectReviewWithOnlyInactiveLine() {
+    SupplierQuoteLine inactiveLine = quoteLine("USD", "1.00", "1.000");
+    inactiveLine.setIsActive(false);
+    mockQuote.addLine(inactiveLine);
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+
+    ProcurementDomainException ex =
+        assertThrows(ProcurementDomainException.class, () -> quoteService.startReview(quoteId));
+
+    assertEquals("Quote has no lines; add at least one line before review.", ex.getMessage());
+  }
+
+  @Test
+  @DisplayName("Should start review when Supplier Quote has an active line")
+  void shouldStartReviewWithActiveLine() {
+    mockQuote.addLine(quoteLine("USD", "1.00", "1.000"));
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+    when(quoteRepository.save(any(SupplierQuote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(quoteMapper.toResponse(any(SupplierQuote.class), anyMap())).thenReturn(mockResponse);
+
+    SupplierQuoteResponse updated = quoteService.startReview(quoteId);
+
+    assertNotNull(updated);
+    assertEquals(SupplierQuoteStatus.UNDER_REVIEW, mockQuote.getStatus());
+  }
+
+  @Test
+  @DisplayName("Should reject acceptance without lines and perform no side effects")
+  void shouldRejectAcceptanceWithoutLinesAndPerformNoSideEffects() {
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+
+    ProcurementDomainException ex =
+        assertThrows(ProcurementDomainException.class, () -> quoteService.markAsAccepted(quoteId));
+
+    assertEquals("Quote has no lines; add at least one line before acceptance.", ex.getMessage());
+    verify(quoteRepository).findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId);
+    verifyNoMoreInteractions(quoteRepository);
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("Should reject acceptance when Supplier Quote has only an inactive line")
+  void shouldRejectAcceptanceWithOnlyInactiveLine() {
+    SupplierQuoteLine inactiveLine = quoteLine("USD", "1.00", "1.000");
+    inactiveLine.setIsActive(false);
+    mockQuote.addLine(inactiveLine);
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(mockQuote));
+
+    ProcurementDomainException ex =
+        assertThrows(ProcurementDomainException.class, () -> quoteService.markAsAccepted(quoteId));
+
+    assertEquals("Quote has no lines; add at least one line before acceptance.", ex.getMessage());
+  }
+
+  @Test
   @DisplayName("Should mark quote as ACCEPTED and auto-reject siblings")
   void shouldMarkQuoteAsAcceptedAndRejectSiblings() {
+    mockQuote.addLine(quoteLine("USD", "1.00", "1.000"));
     UUID siblingId = UUID.randomUUID();
     SupplierQuote sibling = new SupplierQuote();
     sibling.setId(siblingId);
@@ -306,6 +385,7 @@ class SupplierQuoteServiceTest {
   @Test
   @DisplayName("Should throw when accepting already REJECTED quote")
   void shouldThrowWhenAcceptingRejectedQuote() {
+    mockQuote.addLine(quoteLine("USD", "1.00", "1.000"));
     mockQuote.setStatus(SupplierQuoteStatus.REJECTED);
 
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))

--- a/src/test/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapperTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/mapper/SupplierQuoteMapperTest.java
@@ -1,0 +1,47 @@
+package com.fabricmanagement.procurement.quote.mapper;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
+import com.fabricmanagement.procurement.quote.dto.SupplierQuoteResponse;
+import com.fabricmanagement.procurement.rfq.domain.SupplierRFQLine;
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class SupplierQuoteMapperTest {
+
+  private final SupplierQuoteMapper mapper = Mappers.getMapper(SupplierQuoteMapper.class);
+
+  @Test
+  void shouldEnrichQuoteLineWithProductFieldsFromMatchingRfqLine() {
+    UUID rfqLineId = UUID.randomUUID();
+    UUID productId = UUID.randomUUID();
+
+    SupplierQuoteLine quoteLine = new SupplierQuoteLine();
+    quoteLine.setRfqLineId(rfqLineId);
+    quoteLine.setUnitPrice(new BigDecimal("12.50"));
+    quoteLine.setCurrency("GBP");
+    quoteLine.setQty(new BigDecimal("4.000"));
+    quoteLine.setUnit("kg");
+
+    SupplierQuote quote = new SupplierQuote();
+    quote.addLine(quoteLine);
+
+    SupplierRFQLine rfqLine = new SupplierRFQLine();
+    rfqLine.setId(rfqLineId);
+    rfqLine.setProductId(productId);
+    rfqLine.setProductDesc("Combed cotton yarn");
+
+    SupplierQuoteResponse response = mapper.toResponse(quote, Map.of(rfqLineId, rfqLine));
+    SupplierQuoteResponse.QuoteLineResponse mappedLine = response.getLines().getFirst();
+
+    assertEquals(productId, mappedLine.getProductId());
+    assertEquals("Combed cotton yarn", mappedLine.getProductDesc());
+    assertEquals(new BigDecimal("12.50"), mappedLine.getUnitPrice());
+    assertEquals(new BigDecimal("4.000"), mappedLine.getQty());
+  }
+}


### PR DESCRIPTION
…CONTRACT-1)

springdoc keys component schemas by Java simple name. Sales and procurement both declare AddQuoteLineRequest, and procurement's line response (nested in SupplierQuoteResponse) collides with sales' QuoteLineResponse - so the committed export carried only the sales shapes and every consumer generated from it compiled against the wrong contract. Concretely: the frontend sent productId/offeredPrice/requestedQty to an endpoint requiring rfqLineId/unitPrice/currency/qty/unit; every supplier-quote add-line POST returned 400, quotes saved header-only, and the detail screen rendered lines as dashes.

- @Schema(name = "SupplierQuoteAddLineRequest") on procurement's AddQuoteLineRequest; @Schema(name = "SupplierQuoteLineResponse") on the nested line record. Sales API names untouched (external quote-approval consumers see them).
- SupplierQuoteLineResponse enriched with productId/productDesc resolved from the RFQ line server-side (SupplierQuoteMapper), so the detail screen needs no second fetch.
- OpenApiSchemaNameCollisionTest: scans public top-level and nested types in dto packages, computes the effective schema name (@Schema(name) else simple name), fails naming both classes on any collision outside the explicit allowlist (8 known groups, all tagged QUOTE-CONTRACT-2); also asserts the regenerated export contains no springdoc _1 suffixes.
- Regenerated api/openapi.yaml.

Ticket: docs/platform/tickets/QUOTE-CONTRACT-1-openapi-schema-name-collision.md
Follow-up: QUOTE-CONTRACT-2 empties the allowlist.