### PR TITLE
fix(procurement): the database decides the seeder/orchestrator PO rac…

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
@@ -7,6 +7,7 @@ import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequ
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
 import com.fabricmanagement.platform.user.domain.SystemUser;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderConstraintViolationMatcher;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
@@ -54,12 +55,17 @@ import java.util.UUID;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
  * Seeds a coherent procurement demo dataset for master and playground tenants: suppliers,
  * PURCHASE/SUBCONTRACT work orders, an RFQ -> quote -> PO -> receipt chain, and an in-progress
  * subcontract order. It is best-effort and must never break playground initialization.
+ *
+ * <p>Quote acceptance also wakes the asynchronous quote-to-order orchestrator. If that writer wins
+ * the purchase-order race, this seeder resolves the named unique-constraint violation, fetches the
+ * winning order by tenant and quote, and continues the confirmation and receipt chain on it.
  */
 @Component
 @RequiredArgsConstructor
@@ -214,14 +220,12 @@ public class ProcurementDemoSeeder {
       SupplierQuoteResponse acceptedQuote =
           supplierQuoteService.markAsAccepted(anatoliaQuote.getId());
 
-      PurchaseOrderResponse po =
-          createConfirmedPurchaseOrder(
-              chainPurchaseWo.id(),
-              anatolia.getId(),
-              acceptedQuote.getId(),
-              rfqLines,
-              procurementPersonaUserId);
-      createConfirmedGoodsReceipt(po.getId());
+      createConfirmedPurchaseOrderAndReceipt(
+          chainPurchaseWo.id(),
+          anatolia.getId(),
+          acceptedQuote.getId(),
+          rfqLines,
+          procurementPersonaUserId);
 
       createInProgressSubcontract(chainSubcontractWo.id(), marmara.getId(), cotton, blend, today);
 
@@ -381,50 +385,76 @@ public class ProcurementDemoSeeder {
         notes);
   }
 
-  private PurchaseOrderResponse createConfirmedPurchaseOrder(
+  PurchaseOrderResponse createConfirmedPurchaseOrder(
       UUID workOrderId,
       UUID supplierId,
       UUID quoteId,
       List<SupplierRFQResponse.RfqLineResponse> rfqLines,
       UUID ownerUserId) {
-    PurchaseOrderResponse po =
-        executeAsUser(
-            ownerUserId,
-            () ->
-                purchaseOrderService.createPurchaseOrder(
-                    CreatePurchaseOrderRequest.builder()
-                        .workOrderId(workOrderId)
-                        .tradingPartnerId(supplierId)
-                        .supplierQuoteId(quoteId)
-                        .currency("USD")
-                        .paymentTerms("NET30")
-                        .expectedDelivery(LocalDate.now(clock).plusDays(16))
-                        .notes("Demo PO generated from accepted supplier quote")
-                        .moduleType(PurchaseOrderModuleType.FIBER)
-                        .moduleSpecs(fiberPurchaseSpecs())
-                        .lines(
-                            rfqLines.stream()
-                                .map(
-                                    line ->
-                                        CreatePurchaseOrderRequest.PurchaseOrderLineRequest
-                                            .builder()
-                                            .rfqLineId(line.getId())
-                                            .productId(line.getProductId())
-                                            .productDesc(line.getProductDesc())
-                                            .qty(line.getRequestedQty())
-                                            .unit(line.getUnit())
-                                            .unitPrice(new BigDecimal("3.78"))
-                                            .currency("USD")
-                                            .moduleSpecs(fiberPurchaseSpecs())
-                                            .build())
-                                .toList())
-                        .build()));
+    PurchaseOrderResponse po;
+    try {
+      po =
+          executeAsUser(
+              ownerUserId,
+              () ->
+                  purchaseOrderService.createPurchaseOrder(
+                      CreatePurchaseOrderRequest.builder()
+                          .workOrderId(workOrderId)
+                          .tradingPartnerId(supplierId)
+                          .supplierQuoteId(quoteId)
+                          .currency("USD")
+                          .paymentTerms("NET30")
+                          .expectedDelivery(LocalDate.now(clock).plusDays(16))
+                          .notes("Demo PO generated from accepted supplier quote")
+                          .moduleType(PurchaseOrderModuleType.FIBER)
+                          .moduleSpecs(fiberPurchaseSpecs())
+                          .lines(
+                              rfqLines.stream()
+                                  .map(
+                                      line ->
+                                          CreatePurchaseOrderRequest.PurchaseOrderLineRequest
+                                              .builder()
+                                              .rfqLineId(line.getId())
+                                              .productId(line.getProductId())
+                                              .productDesc(line.getProductDesc())
+                                              .qty(line.getRequestedQty())
+                                              .unit(line.getUnit())
+                                              .unitPrice(new BigDecimal("3.78"))
+                                              .currency("USD")
+                                              .moduleSpecs(fiberPurchaseSpecs())
+                                              .build())
+                                  .toList())
+                          .build()));
+    } catch (DataIntegrityViolationException exception) {
+      if (!PurchaseOrderConstraintViolationMatcher.isActiveSupplierQuoteViolation(exception)) {
+        throw exception;
+      }
+
+      UUID tenantId = TenantContext.requireTenantId();
+      po = purchaseOrderService.getActivePurchaseOrderBySupplierQuote(tenantId, quoteId);
+      log.info(
+          "Procurement demo PO creation lost the race for quote {}; continuing with PO {}",
+          quoteId,
+          po.getId());
+    }
 
     po = purchaseOrderService.changeStatus(po.getId(), PurchaseOrderStatus.SENT);
     if (po.getStatus() == PurchaseOrderStatus.PENDING_APPROVAL) {
       po = purchaseOrderService.changeStatusAsSystem(po.getId(), PurchaseOrderStatus.SENT);
     }
     return purchaseOrderService.changeStatus(po.getId(), PurchaseOrderStatus.CONFIRMED);
+  }
+
+  PurchaseOrderResponse createConfirmedPurchaseOrderAndReceipt(
+      UUID workOrderId,
+      UUID supplierId,
+      UUID quoteId,
+      List<SupplierRFQResponse.RfqLineResponse> rfqLines,
+      UUID ownerUserId) {
+    PurchaseOrderResponse po =
+        createConfirmedPurchaseOrder(workOrderId, supplierId, quoteId, rfqLines, ownerUserId);
+    createConfirmedGoodsReceipt(po.getId());
+    return po;
   }
 
   private UUID resolveProcurementPersonaUserId(UUID tenantId) {

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderConstraintViolationMatcher.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderConstraintViolationMatcher.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.procurement.purchaseorder.app;
+
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/** Identifies database constraints shared by purchase-order race handlers. */
+public final class PurchaseOrderConstraintViolationMatcher {
+
+  public static final String ACTIVE_SUPPLIER_QUOTE_CONSTRAINT =
+      "uq_purchase_order_tenant_supplier_quote_active";
+
+  private PurchaseOrderConstraintViolationMatcher() {}
+
+  public static boolean isActiveSupplierQuoteViolation(DataIntegrityViolationException exception) {
+    Throwable current = exception;
+    while (current != null) {
+      if (current instanceof ConstraintViolationException constraintViolation
+          && ACTIVE_SUPPLIER_QUOTE_CONSTRAINT.equals(constraintViolation.getConstraintName())) {
+        return true;
+      }
+
+      String message = current.getMessage();
+      if (message != null && message.contains(ACTIVE_SUPPLIER_QUOTE_CONSTRAINT)) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
@@ -62,6 +62,24 @@ public class PurchaseOrderService {
     return mapToResponse(po, lines);
   }
 
+  /**
+   * Resolves the active purchase order that won concurrent creation for a supplier quote. Tenant ID
+   * is explicit because callers must not rely on RLS as a query filter.
+   */
+  public PurchaseOrderResponse getActivePurchaseOrderBySupplierQuote(
+      UUID tenantId, UUID supplierQuoteId) {
+    PurchaseOrder po =
+        poRepository
+            .findByTenantIdAndSupplierQuoteIdAndIsActiveTrue(tenantId, supplierQuoteId)
+            .orElseThrow(
+                () ->
+                    new ProcurementDomainException(
+                        "Active PurchaseOrder not found for supplier quote: " + supplierQuoteId));
+    List<PurchaseOrderLine> lines =
+        lineRepository.findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(po.getId());
+    return mapToResponse(po, lines);
+  }
+
   public PagedResponse<PurchaseOrderResponse> listPurchaseOrders(
       PurchaseOrderModuleType moduleType, PurchaseOrderStatus status, Pageable pageable) {
 

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepository.java
@@ -22,4 +22,7 @@ public interface PurchaseOrderRepository
   boolean existsByPoNumberAndIsActiveTrue(String poNumber);
 
   boolean existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(UUID tenantId, UUID supplierQuoteId);
+
+  Optional<PurchaseOrder> findByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+      UUID tenantId, UUID supplierQuoteId);
 }

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/listener/PurchaseOrderCreationTransaction.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/listener/PurchaseOrderCreationTransaction.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.procurement.quote.app.listener;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
+import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
+import com.fabricmanagement.procurement.purchaseorder.dto.PurchaseOrderResponse;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Isolates automatic purchase-order creation so a race rollback cannot poison the listener. */
+@Component
+@RequiredArgsConstructor
+public class PurchaseOrderCreationTransaction {
+
+  private final PurchaseOrderService purchaseOrderService;
+  private final PurchaseOrderRepository purchaseOrderRepository;
+  private final TenantSessionBinder tenantSessionBinder;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public PurchaseOrderResponse createAndFlush(CreatePurchaseOrderRequest request) {
+    tenantSessionBinder.bindToCurrentSession(TenantContext.requireTenantId());
+    PurchaseOrderResponse response = purchaseOrderService.createPurchaseOrder(request);
+    purchaseOrderRepository.flush();
+    return response;
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestrator.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestrator.java
@@ -3,7 +3,7 @@ package com.fabricmanagement.procurement.quote.app.listener;
 import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
-import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderConstraintViolationMatcher;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
@@ -39,7 +40,7 @@ public class QuoteToOrderOrchestrator {
 
   private final SupplierQuoteRepository quoteRepository;
   private final SupplierRFQRepository rfqRepository;
-  private final PurchaseOrderService purchaseOrderService;
+  private final PurchaseOrderCreationTransaction purchaseOrderCreationTransaction;
   private final PurchaseOrderRepository purchaseOrderRepository;
   private final SubcontractOrderService subcontractOrderService;
   private final ObjectMapper objectMapper;
@@ -164,8 +165,17 @@ public class QuoteToOrderOrchestrator {
             .lines(lines)
             .build();
 
-    purchaseOrderService.createPurchaseOrder(poRequest);
-    log.info("Successfully created PurchaseOrder for quote {}", quote.getQuoteNumber());
+    try {
+      purchaseOrderCreationTransaction.createAndFlush(poRequest);
+      log.info("Successfully created PurchaseOrder for quote {}", quote.getQuoteNumber());
+    } catch (DataIntegrityViolationException exception) {
+      if (!PurchaseOrderConstraintViolationMatcher.isActiveSupplierQuoteViolation(exception)) {
+        throw exception;
+      }
+      log.info(
+          "PurchaseOrder creation lost the race for quote {}; using the existing order",
+          quote.getQuoteNumber());
+    }
   }
 
   private void createSubcontractOrder(SupplierQuote quote, SupplierRFQ rfq) {

--- a/src/main/resources/db/migration/V20260711120000__unique_active_purchase_order_per_supplier_quote.sql
+++ b/src/main/resources/db/migration/V20260711120000__unique_active_purchase_order_per_supplier_quote.sql
@@ -1,0 +1,34 @@
+DO $$
+DECLARE
+    duplicate_pairs TEXT;
+BEGIN
+    SELECT string_agg(
+               format(
+                   '(tenant_id=%s, supplier_quote_id=%s, count=%s)',
+                   tenant_id,
+                   supplier_quote_id,
+                   duplicate_count),
+               E'\n'
+           )
+      INTO duplicate_pairs
+      FROM (
+          SELECT tenant_id, supplier_quote_id, count(*) AS duplicate_count
+            FROM procurement.purchase_order
+           WHERE is_active = true
+             AND supplier_quote_id IS NOT NULL
+           GROUP BY tenant_id, supplier_quote_id
+          HAVING count(*) > 1
+           ORDER BY tenant_id, supplier_quote_id
+      ) duplicates;
+
+    IF duplicate_pairs IS NOT NULL THEN
+        RAISE EXCEPTION
+            'Cannot create uq_purchase_order_tenant_supplier_quote_active; duplicate active purchase orders:%',
+            E'\n' || duplicate_pairs;
+    END IF;
+END
+$$;
+
+CREATE UNIQUE INDEX uq_purchase_order_tenant_supplier_quote_active
+    ON procurement.purchase_order (tenant_id, supplier_quote_id)
+    WHERE is_active = true AND supplier_quote_id IS NOT NULL;

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +16,7 @@ import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequ
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
 import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderConstraintViolationMatcher;
 import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
@@ -64,6 +66,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class ProcurementDemoSeederTest {
@@ -314,6 +317,64 @@ class ProcurementDemoSeederTest {
         .thenThrow(new IllegalStateException("template unavailable"));
 
     assertThatCode(() -> seeder.seedFor(TENANT_ID)).doesNotThrowAnyException();
+  }
+
+  @Test
+  void createConfirmedPurchaseOrder_whenSeederLosesRace_continuesWithWinningOrder() {
+    UUID quoteId = UUID.randomUUID();
+    UUID winningOrderId = UUID.randomUUID();
+    UUID ownerUserId = UUID.randomUUID();
+    SupplierRFQResponse.RfqLineResponse rfqLine =
+        SupplierRFQResponse.RfqLineResponse.builder()
+            .id(UUID.randomUUID())
+            .requestedQty(java.math.BigDecimal.TEN)
+            .unit("KG")
+            .build();
+
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    doThrow(
+            new DataIntegrityViolationException(
+                "duplicate "
+                    + PurchaseOrderConstraintViolationMatcher.ACTIVE_SUPPLIER_QUOTE_CONSTRAINT))
+        .when(purchaseOrderService)
+        .createPurchaseOrder(any(CreatePurchaseOrderRequest.class));
+    when(purchaseOrderService.getActivePurchaseOrderBySupplierQuote(TENANT_ID, quoteId))
+        .thenReturn(
+            PurchaseOrderResponse.builder()
+                .id(winningOrderId)
+                .status(PurchaseOrderStatus.DRAFT)
+                .build());
+    when(purchaseOrderService.changeStatus(any(), any()))
+        .thenAnswer(
+            invocation ->
+                PurchaseOrderResponse.builder()
+                    .id(invocation.getArgument(0))
+                    .status(invocation.getArgument(1))
+                    .build());
+    UUID receiptId = UUID.randomUUID();
+    when(goodsReceiptService.createGoodsReceipt(any(CreateGoodsReceiptRequest.class)))
+        .thenReturn(
+            GoodsReceiptResponse.builder().id(receiptId).status(GoodsReceiptStatus.DRAFT).build());
+    when(goodsReceiptService.confirmGoodsReceipt(receiptId))
+        .thenReturn(
+            GoodsReceiptResponse.builder()
+                .id(receiptId)
+                .status(GoodsReceiptStatus.CONFIRMED)
+                .build());
+
+    PurchaseOrderResponse result =
+        seeder.createConfirmedPurchaseOrderAndReceipt(
+            UUID.randomUUID(), UUID.randomUUID(), quoteId, List.of(rfqLine), ownerUserId);
+
+    assertThat(result.getId()).isEqualTo(winningOrderId);
+    assertThat(result.getStatus()).isEqualTo(PurchaseOrderStatus.CONFIRMED);
+    verify(purchaseOrderService).getActivePurchaseOrderBySupplierQuote(TENANT_ID, quoteId);
+    verify(purchaseOrderService).changeStatus(winningOrderId, PurchaseOrderStatus.CONFIRMED);
+    ArgumentCaptor<CreateGoodsReceiptRequest> receiptCaptor =
+        ArgumentCaptor.forClass(CreateGoodsReceiptRequest.class);
+    verify(goodsReceiptService).createGoodsReceipt(receiptCaptor.capture());
+    assertThat(receiptCaptor.getValue().getSourceId()).isEqualTo(winningOrderId);
+    verify(goodsReceiptService).confirmGoodsReceipt(receiptId);
   }
 
   private ProductDto product(String name) {

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepositoryConstraintIT.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderRepositoryConstraintIT.java
@@ -1,0 +1,143 @@
+package com.fabricmanagement.procurement.purchaseorder.infra.repository;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderConstraintViolationMatcher;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class PurchaseOrderRepositoryConstraintIT {
+
+  private static final UUID TENANT_ONE = UUID.fromString("88888888-8888-4888-8888-888888888881");
+  private static final UUID TENANT_TWO = UUID.fromString("88888888-8888-4888-8888-888888888882");
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (Statement stmt = conn.createStatement()) {
+        stmt.execute(
+            "DO $$ BEGIN "
+                + "IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN "
+                + "CREATE ROLE fabric_app LOGIN NOSUPERUSER NOCREATEDB NOBYPASSRLS PASSWORD 'app_test'; "
+                + "END IF; END $$");
+      }
+    } catch (Exception exception) {
+      throw new RuntimeException("Failed to create fabric_app role", exception);
+    }
+
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", () -> "fabric_app");
+    registry.add("spring.datasource.password", () -> "app_test");
+    registry.add("spring.flyway.url", postgres::getJdbcUrl);
+    registry.add("spring.flyway.user", postgres::getUsername);
+    registry.add("spring.flyway.password", postgres::getPassword);
+    registry.add("spring.flyway.enabled", () -> "true");
+  }
+
+  @Autowired private PurchaseOrderRepository purchaseOrderRepository;
+  @Autowired private TenantSessionBinder tenantSessionBinder;
+  @Autowired private TransactionTemplate transactionTemplate;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void activeSupplierQuoteConstraint_isTenantScopedAndIgnoresInactiveRows() throws Exception {
+    seedTenantAsOwner(TENANT_ONE, "PO-CONSTRAINT-ONE", "po-constraint-one");
+    seedTenantAsOwner(TENANT_TWO, "PO-CONSTRAINT-TWO", "po-constraint-two");
+    UUID supplierQuoteId = UUID.randomUUID();
+
+    savePurchaseOrder(TENANT_ONE, supplierQuoteId, true);
+
+    assertThatThrownBy(() -> savePurchaseOrder(TENANT_ONE, supplierQuoteId, true))
+        .isInstanceOfSatisfying(
+            DataIntegrityViolationException.class,
+            exception ->
+                org.assertj.core.api.Assertions.assertThat(
+                        PurchaseOrderConstraintViolationMatcher.isActiveSupplierQuoteViolation(
+                            exception))
+                    .isTrue());
+
+    assertThatCode(() -> savePurchaseOrder(TENANT_TWO, supplierQuoteId, true))
+        .doesNotThrowAnyException();
+    assertThatCode(() -> savePurchaseOrder(TENANT_ONE, supplierQuoteId, false))
+        .doesNotThrowAnyException();
+  }
+
+  private void savePurchaseOrder(UUID tenantId, UUID supplierQuoteId, boolean active) {
+    TenantContext.setCurrentTenantId(tenantId);
+    TenantContext.setCurrentTenantUid("PO-CONSTRAINT");
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          tenantSessionBinder.bindToCurrentSession(tenantId);
+          PurchaseOrder purchaseOrder =
+              PurchaseOrder.builder()
+                  .poNumber("PO-CONSTRAINT-" + UUID.randomUUID())
+                  .workOrderId(UUID.randomUUID())
+                  .tradingPartnerId(UUID.randomUUID())
+                  .supplierQuoteId(supplierQuoteId)
+                  .status(PurchaseOrderStatus.DRAFT)
+                  .totalAmount(Money.zero("USD"))
+                  .build();
+          purchaseOrder.setIsActive(active);
+          purchaseOrderRepository.saveAndFlush(purchaseOrder);
+        });
+  }
+
+  private void seedTenantAsOwner(UUID tenantId, String uid, String slug) throws Exception {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (var ps =
+          conn.prepareStatement(
+              "INSERT INTO common_tenant.common_tenant "
+                  + "(id, uid, slug, name, status, settings, is_active, created_at, updated_at, version) "
+                  + "VALUES (?, ?, ?, ?, 'ACTIVE', '{}'::jsonb, true, now(), now(), 0) "
+                  + "ON CONFLICT (id) DO NOTHING")) {
+        ps.setObject(1, tenantId);
+        ps.setString(2, uid);
+        ps.setString(3, slug);
+        ps.setString(4, uid);
+        ps.executeUpdate();
+      }
+    }
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorAsyncTenantIT.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorAsyncTenantIT.java
@@ -4,16 +4,22 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.approval.ApprovalPort;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
 import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
+import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
 import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
 import com.fabricmanagement.procurement.quote.domain.QuoteEntryMethod;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuoteLine;
@@ -38,9 +44,13 @@ import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
@@ -57,6 +67,7 @@ import org.testcontainers.utility.DockerImageName;
 @ActiveProfiles("test")
 @Testcontainers
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@ExtendWith(OutputCaptureExtension.class)
 class QuoteToOrderOrchestratorAsyncTenantIT {
 
   private static final UUID TENANT_ID = UUID.fromString("77777777-7777-4777-8777-777777777777");
@@ -99,6 +110,8 @@ class QuoteToOrderOrchestratorAsyncTenantIT {
   @Autowired private SupplierQuoteRepository quoteRepository;
   @Autowired private TransactionTemplate transactionTemplate;
   @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private TenantSessionBinder tenantSessionBinder;
+  @SpyBean private PurchaseOrderRepository purchaseOrderRepository;
 
   @MockBean private PurchaseOrderValidationEngine validationEngine;
   @MockBean private ApprovalPort approvalPort;
@@ -145,6 +158,32 @@ class QuoteToOrderOrchestratorAsyncTenantIT {
                 assertThat(countPurchaseOrdersForQuoteAsOwner())
                     .as("purchase_order row for accepted supplier quote")
                     .isEqualTo(1));
+  }
+
+  @Test
+  void duplicateFlushRollsBackInnerTransactionAndCompletesEvent(CapturedOutput output)
+      throws Exception {
+    seedTenantAsOwner();
+    seedAcceptedQuote();
+    seedExistingPurchaseOrder();
+    doReturn(false)
+        .when(purchaseOrderRepository)
+        .existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(TENANT_ID, quoteId);
+    SupplierQuoteAcceptedEvent event = new SupplierQuoteAcceptedEvent(TENANT_ID, quoteId, rfqId);
+    TenantContext.clear();
+
+    transactionTemplate.executeWithoutResult(status -> eventPublisher.publishEvent(event));
+
+    await()
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(
+            () -> {
+              assertThat(countPurchaseOrdersForQuoteAsOwner()).isEqualTo(1);
+              assertThat(countProcessedEvents(event.getEventId())).isEqualTo(1);
+              assertThat(countIncompletePublications(event.getEventId())).isZero();
+              assertThat(output.getOut()).contains("PurchaseOrder creation lost the race");
+              assertThat(output.getAll()).doesNotContain("UnexpectedRollbackException");
+            });
   }
 
   private void seedAcceptedQuote() {
@@ -216,6 +255,57 @@ class QuoteToOrderOrchestratorAsyncTenantIT {
                 + "', 'ASYNC-TENANT', 'async-tenant', 'Async Tenant Test', 'ACTIVE', "
                 + "'{}'::jsonb, true, now(), now(), 0) "
                 + "ON CONFLICT (id) DO NOTHING");
+      }
+    }
+  }
+
+  private void seedExistingPurchaseOrder() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentTenantUid("ASYNC-TENANT");
+    transactionTemplate.executeWithoutResult(
+        status -> {
+          tenantSessionBinder.bindToCurrentSession(TENANT_ID);
+          purchaseOrderRepository.saveAndFlush(
+              PurchaseOrder.builder()
+                  .poNumber("ASYNC-PO-" + UUID.randomUUID())
+                  .workOrderId(UUID.randomUUID())
+                  .tradingPartnerId(UUID.randomUUID())
+                  .supplierQuoteId(quoteId)
+                  .status(PurchaseOrderStatus.DRAFT)
+                  .totalAmount(Money.zero("USD"))
+                  .build());
+        });
+    TenantContext.clear();
+  }
+
+  private int countProcessedEvents(UUID eventId) throws Exception {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (var ps =
+          conn.prepareStatement("SELECT count(*) FROM processed_event WHERE event_id = ?")) {
+        ps.setObject(1, eventId);
+        try (var rs = ps.executeQuery()) {
+          rs.next();
+          return rs.getInt(1);
+        }
+      }
+    }
+  }
+
+  private int countIncompletePublications(UUID eventId) throws Exception {
+    try (Connection conn =
+        DriverManager.getConnection(
+            postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())) {
+      try (var ps =
+          conn.prepareStatement(
+              "SELECT count(*) FROM event_publication "
+                  + "WHERE serialized_event LIKE ? AND completion_date IS NULL")) {
+        ps.setString(1, "%" + eventId + "%");
+        try (var rs = ps.executeQuery()) {
+          rs.next();
+          return rs.getInt(1);
+        }
       }
     }
   }

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/listener/QuoteToOrderOrchestratorTest.java
@@ -1,11 +1,12 @@
 package com.fabricmanagement.procurement.quote.app.listener;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
-import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderService;
+import com.fabricmanagement.procurement.purchaseorder.app.PurchaseOrderConstraintViolationMatcher;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
 import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
 import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
@@ -30,13 +31,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class QuoteToOrderOrchestratorTest {
 
   @Mock private SupplierQuoteRepository quoteRepository;
   @Mock private SupplierRFQRepository rfqRepository;
-  @Mock private PurchaseOrderService purchaseOrderService;
+  @Mock private PurchaseOrderCreationTransaction purchaseOrderCreationTransaction;
   @Mock private PurchaseOrderRepository purchaseOrderRepository;
   @Mock private SubcontractOrderService subcontractOrderService;
   @Mock private TenantSessionBinder tenantSessionBinder;
@@ -117,7 +119,7 @@ class QuoteToOrderOrchestratorTest {
     orchestrator.onQuoteAccepted(event);
 
     // Assert
-    verify(purchaseOrderService).createPurchaseOrder(any(CreatePurchaseOrderRequest.class));
+    verify(purchaseOrderCreationTransaction).createAndFlush(any(CreatePurchaseOrderRequest.class));
     verifyNoInteractions(subcontractOrderService);
   }
 
@@ -150,7 +152,7 @@ class QuoteToOrderOrchestratorTest {
     // Assert
     verify(subcontractOrderService)
         .createSubcontractOrder(any(CreateSubcontractOrderRequest.class));
-    verifyNoInteractions(purchaseOrderService);
+    verifyNoInteractions(purchaseOrderCreationTransaction);
   }
 
   @Test
@@ -170,7 +172,7 @@ class QuoteToOrderOrchestratorTest {
     orchestrator.onQuoteAccepted(event);
 
     // Assert
-    verify(purchaseOrderService, never()).createPurchaseOrder(any());
+    verify(purchaseOrderCreationTransaction, never()).createAndFlush(any());
   }
 
   @Test
@@ -185,7 +187,7 @@ class QuoteToOrderOrchestratorTest {
         .hasMessageContaining("Quote not found");
 
     verifyNoInteractions(rfqRepository);
-    verifyNoInteractions(purchaseOrderService);
+    verifyNoInteractions(purchaseOrderCreationTransaction);
     verifyNoInteractions(subcontractOrderService);
   }
 
@@ -202,7 +204,7 @@ class QuoteToOrderOrchestratorTest {
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("RFQ not found");
 
-    verifyNoInteractions(purchaseOrderService);
+    verifyNoInteractions(purchaseOrderCreationTransaction);
     verifyNoInteractions(subcontractOrderService);
   }
 
@@ -220,13 +222,56 @@ class QuoteToOrderOrchestratorTest {
             tenantId, quoteId))
         .thenReturn(false);
 
-    doThrow(new RuntimeException("DB down")).when(purchaseOrderService).createPurchaseOrder(any());
+    doThrow(new RuntimeException("DB down"))
+        .when(purchaseOrderCreationTransaction)
+        .createAndFlush(any());
 
     // Act / Assert
     assertThatThrownBy(() -> orchestrator.onQuoteAccepted(event))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("DB down");
 
-    verify(purchaseOrderService).createPurchaseOrder(any(CreatePurchaseOrderRequest.class));
+    verify(purchaseOrderCreationTransaction).createAndFlush(any(CreatePurchaseOrderRequest.class));
+  }
+
+  @Test
+  void onQuoteAccepted_PurchaseOrderConstraintRace_CompletesWithoutRetry() {
+    rfq.setRfqType(SupplierRFQType.PURCHASE);
+    quote.setLines(List.of());
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
+        .thenReturn(Optional.of(rfq));
+    when(purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+            tenantId, quoteId))
+        .thenReturn(false);
+    doThrow(
+            new DataIntegrityViolationException(
+                "duplicate "
+                    + PurchaseOrderConstraintViolationMatcher.ACTIVE_SUPPLIER_QUOTE_CONSTRAINT))
+        .when(purchaseOrderCreationTransaction)
+        .createAndFlush(any());
+
+    assertThatCode(() -> orchestrator.onQuoteAccepted(event)).doesNotThrowAnyException();
+
+    verify(purchaseOrderCreationTransaction).createAndFlush(any());
+  }
+
+  @Test
+  void onQuoteAccepted_UnrelatedIntegrityViolation_PropagatesForRetry() {
+    rfq.setRfqType(SupplierRFQType.PURCHASE);
+    quote.setLines(List.of());
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(rfqRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, rfqId))
+        .thenReturn(Optional.of(rfq));
+    when(purchaseOrderRepository.existsByTenantIdAndSupplierQuoteIdAndIsActiveTrue(
+            tenantId, quoteId))
+        .thenReturn(false);
+    DataIntegrityViolationException unrelated =
+        new DataIntegrityViolationException("ck_purchase_order_status");
+    doThrow(unrelated).when(purchaseOrderCreationTransaction).createAndFlush(any());
+
+    assertThatThrownBy(() -> orchestrator.onQuoteAccepted(event)).isSameAs(unrelated);
   }
 }


### PR DESCRIPTION
…e (DEMO-RACE-1)

ProcurementDemoSeeder accepts a supplier quote (publishing the event the orchestrator acts on) and then builds a confirmed PO for the same quote itself. Two writers, one quote, and the only protection was a check-then-act exists query - correct by lucky timing, observed holding by luck in live logs after ASYNC-TENANT-1 made both writers healthy.

- Migration V20260711120000: unique partial index uq_purchase_order_tenant_supplier_quote_active on (tenant_id, supplier_quote_id) WHERE is_active AND supplier_quote_id IS NOT NULL. Preflight DO block fails loud listing duplicate pairs if any exist - no silent survivor-picking.
- PurchaseOrderCreationTransaction: create + explicit flush in REQUIRES_NEW, so the violation surfaces inside an isolated transaction instead of at listener-commit where no catch can reach it (and where an in-transaction catch would end in UnexpectedRollbackException). PurchaseOrderService's own propagation untouched.
- PurchaseOrderConstraintViolationMatcher: one shared cause-chain matcher on the canonical constraint name, used by both the orchestrator and the seeder; unrelated DataIntegrityViolationExceptions propagate (legitimate retry).
- Orchestrator: matched violation = idempotent skip - INFO log, event completes. Seeder: on losing, fetches the winning PO by explicit tenantId + supplierQuoteId and continues the demo chain (confirm + goods receipt) on it; race documented in the javadoc.
- Tests: repository duplicate-insert (named constraint; different tenant and inactive rows still insert), orchestrator matched/unmatched paths, seeder loses-and-continues, and the transaction-boundary IT: pre-inserted PO + published event -> event completes, exactly one PO, no UnexpectedRollbackException.

Ticket: docs/procurement/tickets/DEMO-RACE-1-seeder-orchestrator-po-race.md