### PR TITLE
feat(events): surface stuck event publications (EVENT-VISIBILITY-1 Sl…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -74,6 +74,8 @@ tags:
   name: Sales Lot
 - description: Contact operations
   name: Contact
+- description: Incomplete background follow-up flags
+  name: Follow-up flags
 - description: Platform Notification operations
   name: Platform Notification
 - description: Task management and status updates
@@ -21723,6 +21725,146 @@ paths:
       summary: Get user's current workload
       tags:
       - FlowBoard — Workload
+  /api/v1/follow-up-flags:
+    get:
+      operationId: findForRecord
+      parameters:
+      - in: query
+        name: entityType
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: entityId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseListFollowUpFlagDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List active follow-up flags for a record
+      tags:
+      - Follow-up flags
+  /api/v1/follow-up-flags/active:
+    get:
+      operationId: findActive
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseListFollowUpFlagDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List active follow-up flags for the current tenant
+      tags:
+      - Follow-up flags
   /api/v1/health:
     get:
       operationId: health
@@ -44387,6 +44529,26 @@ components:
           type: array
           items:
             type: string
+    ApiResponseListFollowUpFlagDto:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/FollowUpFlagDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseListFxRevaluationDto:
       type: object
       properties:
@@ -52003,6 +52165,34 @@ components:
             format: double
             description: Target fabric width in cm
             example: 155.0
+    FollowUpFlagDto:
+      type: object
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+        entityId:
+          type: string
+          format: uuid
+        entityRef:
+          type: string
+        entityType:
+          type: string
+        id:
+          type: string
+          format: uuid
+        referenceId:
+          type: string
+          format: uuid
+        referenceType:
+          type: string
+        status:
+          type: string
+          enum:
+          - ACTIVE
+          - RESOLVED
+        summary:
+          type: string
     FxExposureCurrencyDto:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandler.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandler.java
@@ -1,0 +1,98 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FlagWritingStuckEventHandler implements StuckEventHandler {
+
+  private final IncompleteFollowUpFlagRepository flagRepository;
+  private final List<StuckEventPresenter> presenters;
+  private final ObjectMapper objectMapper;
+  private final TenantSessionBinder tenantSessionBinder;
+
+  @Override
+  @Transactional
+  public void onNewlyStuck(StuckEventContext context) {
+    if (context.tenantId() == null) {
+      log.warn("Skipping follow-up flag without tenant: publicationId={}", context.publicationId());
+      return;
+    }
+
+    TenantContext.executeInTenantContext(
+        context.tenantId(),
+        () -> {
+          tenantSessionBinder.bindToCurrentSession(context.tenantId());
+          StuckEventPresentation presentation =
+              presenterFor(context.eventType())
+                  .present(context.tenantId(), readPayload(context.payload()));
+          flagRepository
+              .findByTenantIdAndPublicationId(context.tenantId(), context.publicationId())
+              .ifPresentOrElse(
+                  existing -> {
+                    if (existing.getStatus() != FollowUpFlagStatus.ACTIVE) {
+                      existing.raiseAgain(presentation);
+                      flagRepository.save(existing);
+                    }
+                  },
+                  () ->
+                      flagRepository.save(
+                          IncompleteFollowUpFlag.raise(
+                              context.tenantId(),
+                              context.publicationId(),
+                              context.eventType(),
+                              presentation)));
+        });
+  }
+
+  @Override
+  @Transactional
+  public void onResolved(StuckEventContext context) {
+    if (context.tenantId() == null) {
+      log.warn(
+          "Skipping follow-up flag resolution without tenant: publicationId={}",
+          context.publicationId());
+      return;
+    }
+
+    TenantContext.executeInTenantContext(
+        context.tenantId(),
+        () -> {
+          tenantSessionBinder.bindToCurrentSession(context.tenantId());
+          flagRepository
+              .findByTenantIdAndPublicationId(context.tenantId(), context.publicationId())
+              .filter(flag -> flag.getStatus() == FollowUpFlagStatus.ACTIVE)
+              .ifPresent(
+                  flag -> {
+                    flag.resolve(Instant.now());
+                    flagRepository.save(flag);
+                  });
+        });
+  }
+
+  private StuckEventPresenter presenterFor(String eventType) {
+    return presenters.stream()
+        .filter(presenter -> presenter.supports(eventType))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No stuck-event presenter registered"));
+  }
+
+  private JsonNode readPayload(String payload) {
+    try {
+      return objectMapper.readTree(payload);
+    } catch (JsonProcessingException | IllegalArgumentException exception) {
+      return objectMapper.createObjectNode();
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagDto.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagDto.java
@@ -1,0 +1,29 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FollowUpFlagDto(
+    UUID id,
+    String entityType,
+    UUID entityId,
+    String entityRef,
+    String summary,
+    String referenceType,
+    UUID referenceId,
+    FollowUpFlagStatus status,
+    Instant createdAt) {
+
+  static FollowUpFlagDto from(IncompleteFollowUpFlag flag) {
+    return new FollowUpFlagDto(
+        flag.getId(),
+        flag.getEntityType(),
+        flag.getEntityId(),
+        flag.getEntityRef(),
+        flag.getSummary(),
+        flag.getReferenceType(),
+        flag.getReferenceId(),
+        flag.getStatus(),
+        flag.getCreatedAt());
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagService.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagService.java
@@ -1,0 +1,33 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FollowUpFlagService {
+
+  private final IncompleteFollowUpFlagRepository flagRepository;
+
+  public List<FollowUpFlagDto> findActiveForRecord(String entityType, UUID entityId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    return flagRepository
+        .findByTenantIdAndEntityTypeAndEntityIdAndStatus(
+            tenantId, entityType, entityId, FollowUpFlagStatus.ACTIVE)
+        .stream()
+        .map(FollowUpFlagDto::from)
+        .toList();
+  }
+
+  public List<FollowUpFlagDto> findActiveForTenant() {
+    UUID tenantId = TenantContext.requireTenantId();
+    return flagRepository.findByTenantIdAndStatus(tenantId, FollowUpFlagStatus.ACTIVE).stream()
+        .map(FollowUpFlagDto::from)
+        .toList();
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagStatus.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFlagStatus.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+public enum FollowUpFlagStatus {
+  ACTIVE,
+  RESOLVED
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/GenericStuckEventPresenter.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/GenericStuckEventPresenter.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.UUID;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class GenericStuckEventPresenter implements StuckEventPresenter {
+
+  @Override
+  public boolean supports(String eventType) {
+    return true;
+  }
+
+  @Override
+  public StuckEventPresentation present(UUID tenantId, JsonNode payload) {
+    return new StuckEventPresentation(
+        "UNKNOWN", null, null, "A background follow-up did not complete.", null, null, null);
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlag.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlag.java
@@ -1,0 +1,93 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(schema = "common_infrastructure", name = "incomplete_follow_up_flag")
+@Getter
+@NoArgsConstructor
+public class IncompleteFollowUpFlag extends BaseEntity {
+
+  @Column(name = "publication_id", nullable = false)
+  private UUID publicationId;
+
+  @Column(name = "event_type", nullable = false, length = 512)
+  private String eventType;
+
+  @Column(name = "entity_type", nullable = false, length = 64)
+  private String entityType;
+
+  @Column(name = "entity_id")
+  private UUID entityId;
+
+  @Column(name = "entity_ref", length = 128)
+  private String entityRef;
+
+  @Column(name = "summary", nullable = false, columnDefinition = "TEXT")
+  private String summary;
+
+  @Column(name = "reference_type", length = 64)
+  private String referenceType;
+
+  @Column(name = "reference_id")
+  private UUID referenceId;
+
+  @Column(name = "affected_user_id")
+  private UUID affectedUserId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "status", nullable = false, length = 20)
+  private FollowUpFlagStatus status;
+
+  @Column(name = "resolved_at")
+  private Instant resolvedAt;
+
+  public static IncompleteFollowUpFlag raise(
+      UUID tenantId, UUID publicationId, String eventType, StuckEventPresentation presentation) {
+    IncompleteFollowUpFlag flag = new IncompleteFollowUpFlag();
+    flag.setTenantId(tenantId);
+    flag.publicationId = publicationId;
+    flag.eventType = eventType;
+    flag.apply(presentation);
+    flag.status = FollowUpFlagStatus.ACTIVE;
+    return flag;
+  }
+
+  public void raiseAgain(StuckEventPresentation presentation) {
+    apply(presentation);
+    status = FollowUpFlagStatus.ACTIVE;
+    resolvedAt = null;
+  }
+
+  public void resolve(Instant resolvedAt) {
+    if (status == FollowUpFlagStatus.RESOLVED) {
+      return;
+    }
+    status = FollowUpFlagStatus.RESOLVED;
+    this.resolvedAt = resolvedAt;
+  }
+
+  private void apply(StuckEventPresentation presentation) {
+    entityType = presentation.entityType();
+    entityId = presentation.entityId();
+    entityRef = presentation.entityRef();
+    summary = presentation.summary();
+    referenceType = presentation.referenceType();
+    referenceId = presentation.referenceId();
+    affectedUserId = presentation.affectedUserId();
+  }
+
+  @Override
+  public String getModuleCode() {
+    return "IFUF";
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlagRepository.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlagRepository.java
@@ -1,0 +1,20 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IncompleteFollowUpFlagRepository
+    extends JpaRepository<IncompleteFollowUpFlag, UUID> {
+
+  Optional<IncompleteFollowUpFlag> findByTenantIdAndPublicationId(
+      UUID tenantId, UUID publicationId);
+
+  List<IncompleteFollowUpFlag> findByTenantIdAndEntityTypeAndEntityIdAndStatus(
+      UUID tenantId, String entityType, UUID entityId, FollowUpFlagStatus status);
+
+  List<IncompleteFollowUpFlag> findByTenantIdAndStatus(UUID tenantId, FollowUpFlagStatus status);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventContext.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventContext.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record StuckEventContext(
+    UUID publicationId,
+    String eventType,
+    String listenerId,
+    UUID tenantId,
+    String payload,
+    Instant firstSeenAt) {}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventHandler.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventHandler.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+public interface StuckEventHandler {
+
+  void onNewlyStuck(StuckEventContext context);
+
+  void onResolved(StuckEventContext context);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitor.java
@@ -1,0 +1,238 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.MultiGauge;
+import io.micrometer.core.instrument.Tags;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class StuckEventMonitor {
+
+  private static final String FIND_STUCK_SQL =
+      """
+      SELECT id, listener_id, event_type, serialized_event, publication_date
+      FROM event_publication
+      WHERE completion_date IS NULL AND publication_date < ?
+      """;
+
+  private static final String FIND_UNRESOLVED_MARKERS_SQL =
+      """
+      SELECT publication_id, event_type, listener_id, tenant_id, first_seen_at, resolved_at
+      FROM public.stuck_event_publication
+      WHERE resolved_at IS NULL
+      """;
+
+  private final JdbcTemplate jdbcTemplate;
+  private final ObjectMapper objectMapper;
+  private final boolean enabled;
+  private final long thresholdMinutes;
+  private final MultiGauge stuckGauge;
+
+  public StuckEventMonitor(
+      JdbcTemplate jdbcTemplate,
+      MeterRegistry meterRegistry,
+      ObjectMapper objectMapper,
+      @Value("${modulith.events.stuck-monitor.enabled:true}") boolean enabled,
+      @Value("${modulith.events.stuck-monitor.threshold-minutes:10}") long thresholdMinutes) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.objectMapper = objectMapper;
+    this.enabled = enabled;
+    this.thresholdMinutes = thresholdMinutes;
+    this.stuckGauge =
+        MultiGauge.builder("events.publication.stuck")
+            .description("Number of stuck event publications grouped by event type")
+            .register(meterRegistry);
+  }
+
+  @Scheduled(fixedDelayString = "${modulith.events.stuck-monitor.interval-ms:60000}")
+  void sweep() {
+    if (!enabled) {
+      return;
+    }
+
+    try {
+      Instant now = Instant.now();
+      List<StuckRow> stuckRows = findStuckRows(now.minus(thresholdMinutes, ChronoUnit.MINUTES));
+      Set<UUID> currentStuckIds = stuckRows.stream().map(StuckRow::id).collect(Collectors.toSet());
+      Set<UUID> markedIds = findMarkedIds(currentStuckIds);
+
+      stuckRows.stream()
+          .filter(row -> !markedIds.contains(row.id()))
+          .forEach(row -> reportNewlyStuck(row, now));
+
+      findUnresolvedMarkers().stream()
+          .filter(marker -> !currentStuckIds.contains(marker.publicationId()))
+          .forEach(marker -> markResolved(marker, now));
+
+      refreshGauge(stuckRows);
+    } catch (Exception e) {
+      log.warn("Failed to sweep stuck event publications", e);
+    }
+  }
+
+  private List<StuckRow> findStuckRows(Instant threshold) {
+    return jdbcTemplate.query(
+        FIND_STUCK_SQL,
+        (rs, rowNum) ->
+            new StuckRow(
+                rs.getObject("id", UUID.class),
+                rs.getString("listener_id"),
+                rs.getString("event_type"),
+                rs.getString("serialized_event"),
+                rs.getTimestamp("publication_date").toInstant()),
+        Timestamp.from(threshold));
+  }
+
+  private Set<UUID> findMarkedIds(Set<UUID> publicationIds) {
+    if (publicationIds.isEmpty()) {
+      return Set.of();
+    }
+
+    String placeholders =
+        publicationIds.stream().map(ignored -> "?").collect(Collectors.joining(","));
+    String sql =
+        "SELECT publication_id FROM public.stuck_event_publication WHERE publication_id IN ("
+            + placeholders
+            + ")";
+    List<UUID> ids =
+        jdbcTemplate.query(
+            sql,
+            (rs, rowNum) -> rs.getObject("publication_id", UUID.class),
+            publicationIds.toArray());
+    return new HashSet<>(ids);
+  }
+
+  private List<StuckMarker> findUnresolvedMarkers() {
+    return jdbcTemplate.query(
+        FIND_UNRESOLVED_MARKERS_SQL,
+        (rs, rowNum) ->
+            new StuckMarker(
+                rs.getObject("publication_id", UUID.class),
+                rs.getString("event_type"),
+                rs.getString("listener_id"),
+                rs.getObject("tenant_id", UUID.class),
+                rs.getTimestamp("first_seen_at").toInstant(),
+                toInstant(rs.getTimestamp("resolved_at"))));
+  }
+
+  private void reportNewlyStuck(StuckRow row, Instant now) {
+    UUID tenantId = parseTenantId(row.payload());
+    int inserted =
+        jdbcTemplate.update(
+            """
+            INSERT INTO public.stuck_event_publication
+                (publication_id, event_type, listener_id, tenant_id, first_seen_at, resolved_at)
+            VALUES (?, ?, ?, ?, ?, NULL)
+            ON CONFLICT (publication_id) DO NOTHING
+            """,
+            row.id(),
+            row.eventType(),
+            row.listenerId(),
+            tenantId,
+            Timestamp.from(now));
+
+    if (inserted == 0) {
+      return;
+    }
+
+    StuckMarker marker =
+        new StuckMarker(row.id(), row.eventType(), row.listenerId(), tenantId, now, null);
+    log.error(
+        "Stuck event publication: eventType={} tenantId={} ageMinutes={} listenerId={} publicationId={}",
+        row.eventType(),
+        tenantId,
+        Math.max(0, Duration.between(row.publicationDate(), now).toMinutes()),
+        row.listenerId(),
+        row.id());
+    onNewlyStuck(marker);
+  }
+
+  private void markResolved(StuckMarker marker, Instant now) {
+    int updated =
+        jdbcTemplate.update(
+            """
+            UPDATE public.stuck_event_publication
+            SET resolved_at = ?
+            WHERE publication_id = ? AND resolved_at IS NULL
+            """,
+            Timestamp.from(now),
+            marker.publicationId());
+
+    if (updated == 0) {
+      return;
+    }
+
+    log.info(
+        "Stuck event publication resolved: eventType={} tenantId={} listenerId={} publicationId={}",
+        marker.eventType(),
+        marker.tenantId(),
+        marker.listenerId(),
+        marker.publicationId());
+    onResolved(marker);
+  }
+
+  private void refreshGauge(List<StuckRow> stuckRows) {
+    Map<String, Long> countsByEventType =
+        stuckRows.stream()
+            .collect(Collectors.groupingBy(StuckRow::eventType, Collectors.counting()));
+    stuckGauge.register(
+        countsByEventType.entrySet().stream()
+            .map(entry -> MultiGauge.Row.of(Tags.of("eventType", entry.getKey()), entry.getValue()))
+            .toList(),
+        true);
+  }
+
+  private UUID parseTenantId(String payload) {
+    try {
+      JsonNode root = objectMapper.readTree(payload);
+      JsonNode tenantId = root == null ? null : root.get("tenantId");
+      if (tenantId == null || tenantId.isNull()) {
+        return null;
+      }
+      return UUID.fromString(tenantId.asText());
+    } catch (JsonProcessingException | IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  private Instant toInstant(Timestamp timestamp) {
+    return timestamp == null ? null : timestamp.toInstant();
+  }
+
+  protected void onNewlyStuck(StuckMarker marker) {
+    // TODO(EVENT-VISIBILITY-1 Slice B): write the tenant-scoped user-facing stuck marker here.
+  }
+
+  protected void onResolved(StuckMarker marker) {
+    // TODO(EVENT-VISIBILITY-1 Slice B): fire the user-facing resolved notification here.
+  }
+
+  record StuckRow(
+      UUID id, String listenerId, String eventType, String payload, Instant publicationDate) {}
+
+  protected record StuckMarker(
+      UUID publicationId,
+      String eventType,
+      String listenerId,
+      UUID tenantId,
+      Instant firstSeenAt,
+      Instant resolvedAt) {}
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitor.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitor.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -45,15 +46,18 @@ public class StuckEventMonitor {
   private final boolean enabled;
   private final long thresholdMinutes;
   private final MultiGauge stuckGauge;
+  private final ObjectProvider<StuckEventHandler> handlerProvider;
 
   public StuckEventMonitor(
       JdbcTemplate jdbcTemplate,
       MeterRegistry meterRegistry,
       ObjectMapper objectMapper,
+      ObjectProvider<StuckEventHandler> handlerProvider,
       @Value("${modulith.events.stuck-monitor.enabled:true}") boolean enabled,
       @Value("${modulith.events.stuck-monitor.threshold-minutes:10}") long thresholdMinutes) {
     this.jdbcTemplate = jdbcTemplate;
     this.objectMapper = objectMapper;
+    this.handlerProvider = handlerProvider;
     this.enabled = enabled;
     this.thresholdMinutes = thresholdMinutes;
     this.stuckGauge =
@@ -153,8 +157,6 @@ public class StuckEventMonitor {
       return;
     }
 
-    StuckMarker marker =
-        new StuckMarker(row.id(), row.eventType(), row.listenerId(), tenantId, now, null);
     log.error(
         "Stuck event publication: eventType={} tenantId={} ageMinutes={} listenerId={} publicationId={}",
         row.eventType(),
@@ -162,7 +164,9 @@ public class StuckEventMonitor {
         Math.max(0, Duration.between(row.publicationDate(), now).toMinutes()),
         row.listenerId(),
         row.id());
-    onNewlyStuck(marker);
+    notifyNewlyStuckHandler(
+        new StuckEventContext(
+            row.id(), row.eventType(), row.listenerId(), tenantId, row.payload(), now));
   }
 
   private void markResolved(StuckMarker marker, Instant now) {
@@ -186,7 +190,14 @@ public class StuckEventMonitor {
         marker.tenantId(),
         marker.listenerId(),
         marker.publicationId());
-    onResolved(marker);
+    notifyResolvedHandler(
+        new StuckEventContext(
+            marker.publicationId(),
+            marker.eventType(),
+            marker.listenerId(),
+            marker.tenantId(),
+            null,
+            marker.firstSeenAt()));
   }
 
   private void refreshGauge(List<StuckRow> stuckRows) {
@@ -217,12 +228,26 @@ public class StuckEventMonitor {
     return timestamp == null ? null : timestamp.toInstant();
   }
 
-  protected void onNewlyStuck(StuckMarker marker) {
-    // TODO(EVENT-VISIBILITY-1 Slice B): write the tenant-scoped user-facing stuck marker here.
+  private void notifyNewlyStuckHandler(StuckEventContext context) {
+    try {
+      handlerProvider.ifAvailable(handler -> handler.onNewlyStuck(context));
+    } catch (Exception exception) {
+      log.warn(
+          "Failed to handle newly stuck event publication: publicationId={}",
+          context.publicationId(),
+          exception);
+    }
   }
 
-  protected void onResolved(StuckMarker marker) {
-    // TODO(EVENT-VISIBILITY-1 Slice B): fire the user-facing resolved notification here.
+  private void notifyResolvedHandler(StuckEventContext context) {
+    try {
+      handlerProvider.ifAvailable(handler -> handler.onResolved(context));
+    } catch (Exception exception) {
+      log.warn(
+          "Failed to handle resolved event publication: publicationId={}",
+          context.publicationId(),
+          exception);
+    }
   }
 
   record StuckRow(

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventPresentation.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventPresentation.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.util.UUID;
+
+public record StuckEventPresentation(
+    String entityType,
+    UUID entityId,
+    String entityRef,
+    String summary,
+    String referenceType,
+    UUID referenceId,
+    UUID affectedUserId) {}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventPresenter.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventPresenter.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.UUID;
+
+public interface StuckEventPresenter {
+
+  boolean supports(String eventType);
+
+  /** Called inside an active tenant context with the database session already bound. */
+  StuckEventPresentation present(UUID tenantId, JsonNode payload);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/api/FollowUpFlagController.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/api/FollowUpFlagController.java
@@ -1,0 +1,41 @@
+package com.fabricmanagement.common.infrastructure.events.api;
+
+import com.fabricmanagement.common.infrastructure.events.FollowUpFlagDto;
+import com.fabricmanagement.common.infrastructure.events.FollowUpFlagService;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/follow-up-flags")
+@RequiredArgsConstructor
+@Tag(name = "Follow-up flags", description = "Incomplete background follow-up flags")
+public class FollowUpFlagController {
+
+  private final FollowUpFlagService flagService;
+
+  @GetMapping
+  @PreAuthorize("isAuthenticated()")
+  @Operation(summary = "List active follow-up flags for a record")
+  public ResponseEntity<ApiResponse<List<FollowUpFlagDto>>> findForRecord(
+      @RequestParam String entityType, @RequestParam UUID entityId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(flagService.findActiveForRecord(entityType, entityId)));
+  }
+
+  @GetMapping("/active")
+  @PreAuthorize("isAuthenticated()")
+  @Operation(summary = "List active follow-up flags for the current tenant")
+  public ResponseEntity<ApiResponse<List<FollowUpFlagDto>>> findActive() {
+    return ResponseEntity.ok(ApiResponse.success(flagService.findActiveForTenant()));
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -149,6 +149,7 @@ public class TenantTransactionalPurgeService {
           "human.human_leave_balance",
           "human.human_employee_number_sequence",
           "common_user.profile_update_request",
+          "common_infrastructure.incomplete_follow_up_flag",
           "common_infrastructure.document_sequence");
 
   static List<String> tenantScopedDeleteTables() {

--- a/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteStuckPresenter.java
+++ b/src/main/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteStuckPresenter.java
@@ -1,0 +1,74 @@
+package com.fabricmanagement.procurement.quote.app;
+
+import com.fabricmanagement.common.infrastructure.events.StuckEventPresentation;
+import com.fabricmanagement.common.infrastructure.events.StuckEventPresenter;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
+import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RequiredArgsConstructor
+public class SupplierQuoteStuckPresenter implements StuckEventPresenter {
+
+  private static final String EVENT_TYPE = "SUPPLIER_QUOTE_ACCEPTED";
+  private static final String ENTITY_TYPE = "SUPPLIER_QUOTE";
+
+  private final SupplierQuoteRepository quoteRepository;
+
+  @Override
+  public boolean supports(String eventType) {
+    return EVENT_TYPE.equals(eventType);
+  }
+
+  @Override
+  public StuckEventPresentation present(UUID tenantId, JsonNode payload) {
+    UUID quoteId = parseQuoteId(payload);
+    if (quoteId == null) {
+      return fallback(null);
+    }
+
+    return quoteRepository
+        .findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId)
+        .map(quote -> presentation(quoteId, quote))
+        .orElseGet(() -> fallback(quoteId));
+  }
+
+  private StuckEventPresentation presentation(UUID quoteId, SupplierQuote quote) {
+    UUID affectedUserId = SystemUser.ID.equals(quote.getCreatedBy()) ? null : quote.getCreatedBy();
+    return new StuckEventPresentation(
+        ENTITY_TYPE,
+        quoteId,
+        quote.getQuoteNumber(),
+        "Purchase order creation for quote " + quote.getQuoteNumber() + " did not complete.",
+        ENTITY_TYPE,
+        quoteId,
+        affectedUserId);
+  }
+
+  private StuckEventPresentation fallback(UUID quoteId) {
+    return new StuckEventPresentation(
+        ENTITY_TYPE,
+        quoteId,
+        null,
+        "Purchase order creation for a supplier quote did not complete.",
+        quoteId == null ? null : ENTITY_TYPE,
+        quoteId,
+        null);
+  }
+
+  private UUID parseQuoteId(JsonNode payload) {
+    try {
+      JsonNode quoteId = payload == null ? null : payload.get("quoteId");
+      return quoteId == null || quoteId.isNull() ? null : UUID.fromString(quoteId.asText());
+    } catch (IllegalArgumentException exception) {
+      return null;
+    }
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,10 @@
+modulith:
+  events:
+    stuck-monitor:
+      enabled: true
+      interval-ms: 60000
+      threshold-minutes: 10
+
 spring:
   application:
     name: fabric-management-system

--- a/src/main/resources/db/migration/V20260711130000__create_stuck_event_publication_table.sql
+++ b/src/main/resources/db/migration/V20260711130000__create_stuck_event_publication_table.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS public.stuck_event_publication (
+    publication_id UUID         NOT NULL,
+    event_type     VARCHAR(512) NOT NULL,
+    listener_id    VARCHAR(512),
+    tenant_id      UUID,
+    first_seen_at  TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    resolved_at    TIMESTAMPTZ,
+    CONSTRAINT pk_stuck_event_publication PRIMARY KEY (publication_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_stuck_event_publication_unresolved
+    ON public.stuck_event_publication(resolved_at);
+
+COMMENT ON TABLE public.stuck_event_publication
+    IS 'Dedup + resolution bookkeeping for the stuck-event monitor (EVENT-VISIBILITY-1 Slice A). Non-RLS, scheduler-written.';
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'fabric_app') THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.stuck_event_publication TO fabric_app';
+  END IF;
+  IF EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'fabric_system') THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.stuck_event_publication TO fabric_system';
+  END IF;
+END $$;

--- a/src/main/resources/db/migration/V20260711160000__create_incomplete_follow_up_flag_table.sql
+++ b/src/main/resources/db/migration/V20260711160000__create_incomplete_follow_up_flag_table.sql
@@ -1,0 +1,59 @@
+CREATE TABLE IF NOT EXISTS common_infrastructure.incomplete_follow_up_flag (
+    id               uuid PRIMARY KEY,
+    uid              varchar(100) UNIQUE,
+    created_at       timestamptz NOT NULL,
+    updated_at       timestamptz NOT NULL,
+    created_by       uuid,
+    updated_by       uuid,
+    tenant_id        uuid NOT NULL,
+    is_active        boolean NOT NULL DEFAULT true,
+    deleted_at       timestamptz,
+    version          bigint NOT NULL DEFAULT 0,
+
+    publication_id   uuid NOT NULL,
+    event_type       varchar(512) NOT NULL,
+    entity_type      varchar(64) NOT NULL,
+    entity_id        uuid,
+    entity_ref       varchar(128),
+    summary          text NOT NULL,
+    reference_type   varchar(64),
+    reference_id     uuid,
+    affected_user_id uuid,
+    status           varchar(20) NOT NULL,
+    resolved_at      timestamptz,
+
+    CONSTRAINT uq_ifu_flag_tenant_publication UNIQUE (tenant_id, publication_id),
+    CONSTRAINT chk_ifu_flag_status CHECK (status IN ('ACTIVE', 'RESOLVED'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_ifu_flag_tenant_entity_status
+    ON common_infrastructure.incomplete_follow_up_flag
+        (tenant_id, entity_type, entity_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_ifu_flag_tenant_status
+    ON common_infrastructure.incomplete_follow_up_flag (tenant_id, status);
+
+ALTER TABLE common_infrastructure.incomplete_follow_up_flag ENABLE ROW LEVEL SECURITY;
+ALTER TABLE common_infrastructure.incomplete_follow_up_flag FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rls_tenant_isolation
+    ON common_infrastructure.incomplete_follow_up_flag;
+CREATE POLICY rls_tenant_isolation
+    ON common_infrastructure.incomplete_follow_up_flag
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+DO $$
+BEGIN
+    GRANT SELECT, INSERT, UPDATE, DELETE
+        ON TABLE common_infrastructure.incomplete_follow_up_flag TO fabric_app;
+EXCEPTION WHEN undefined_object THEN
+    NULL;
+END $$;
+
+DO $$
+BEGIN
+    GRANT SELECT, INSERT, UPDATE, DELETE
+        ON TABLE common_infrastructure.incomplete_follow_up_flag TO fabric_system;
+EXCEPTION WHEN undefined_object THEN
+    NULL;
+END $$;

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandlerTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandlerTest.java
@@ -1,0 +1,153 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.persistence.TenantSessionBinder;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class FlagWritingStuckEventHandlerTest {
+
+  private static final String EVENT_TYPE = "SUPPLIER_QUOTE_ACCEPTED";
+
+  @Mock private IncompleteFollowUpFlagRepository flagRepository;
+  @Mock private StuckEventPresenter presenter;
+  @Mock private TenantSessionBinder tenantSessionBinder;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private FlagWritingStuckEventHandler handler;
+  private UUID tenantId;
+  private StuckEventPresentation presentation;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    presentation =
+        new StuckEventPresentation(
+            "SUPPLIER_QUOTE",
+            UUID.randomUUID(),
+            "SQ-1042",
+            "Purchase order creation for quote SQ-1042 did not complete.",
+            "SUPPLIER_QUOTE",
+            UUID.randomUUID(),
+            UUID.randomUUID());
+    handler =
+        new FlagWritingStuckEventHandler(
+            flagRepository,
+            List.of(presenter, new GenericStuckEventPresenter()),
+            objectMapper,
+            tenantSessionBinder);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void newlyStuckWritesOneActiveFlagInsideTenantContext() {
+    StuckEventContext context = context(tenantId, UUID.randomUUID());
+    stubPresentation();
+    when(flagRepository.findByTenantIdAndPublicationId(tenantId, context.publicationId()))
+        .thenReturn(Optional.empty());
+
+    handler.onNewlyStuck(context);
+
+    ArgumentCaptor<IncompleteFollowUpFlag> flagCaptor =
+        ArgumentCaptor.forClass(IncompleteFollowUpFlag.class);
+    verify(flagRepository).save(flagCaptor.capture());
+    IncompleteFollowUpFlag saved = flagCaptor.getValue();
+    assertThat(saved.getTenantId()).isEqualTo(tenantId);
+    assertThat(saved.getPublicationId()).isEqualTo(context.publicationId());
+    assertThat(saved.getStatus()).isEqualTo(FollowUpFlagStatus.ACTIVE);
+    assertThat(saved.getEntityRef()).isEqualTo("SQ-1042");
+    verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+  }
+
+  @Test
+  void secondCallForSameActivePublicationDoesNotCreateDuplicate() {
+    StuckEventContext context = context(tenantId, UUID.randomUUID());
+    IncompleteFollowUpFlag existing =
+        IncompleteFollowUpFlag.raise(
+            tenantId, context.publicationId(), context.eventType(), presentation);
+    stubPresentation();
+    when(flagRepository.findByTenantIdAndPublicationId(tenantId, context.publicationId()))
+        .thenReturn(Optional.empty(), Optional.of(existing));
+
+    handler.onNewlyStuck(context);
+    handler.onNewlyStuck(context);
+
+    verify(flagRepository, times(1)).save(any(IncompleteFollowUpFlag.class));
+  }
+
+  @Test
+  void resolvedPublicationFlipsActiveFlagAndSetsResolvedAt() {
+    StuckEventContext context = context(tenantId, UUID.randomUUID());
+    IncompleteFollowUpFlag existing =
+        IncompleteFollowUpFlag.raise(
+            tenantId, context.publicationId(), context.eventType(), presentation);
+    when(flagRepository.findByTenantIdAndPublicationId(tenantId, context.publicationId()))
+        .thenReturn(Optional.of(existing));
+
+    handler.onResolved(context);
+
+    assertThat(existing.getStatus()).isEqualTo(FollowUpFlagStatus.RESOLVED);
+    assertThat(existing.getResolvedAt()).isNotNull().isBeforeOrEqualTo(Instant.now());
+    verify(flagRepository).save(existing);
+    verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+  }
+
+  @Test
+  void nullTenantIsSkippedWithWarning(CapturedOutput output) {
+    StuckEventContext context = context(null, UUID.randomUUID());
+
+    handler.onNewlyStuck(context);
+
+    verifyNoInteractions(flagRepository, tenantSessionBinder);
+    assertThat(output.getAll()).contains("Skipping follow-up flag without tenant");
+  }
+
+  @Test
+  void genericPresenterMatchesEveryEventType() {
+    GenericStuckEventPresenter generic = new GenericStuckEventPresenter();
+
+    assertThat(generic.supports("UNREGISTERED_EVENT")).isTrue();
+    assertThat(generic.present(tenantId, objectMapper.createObjectNode()).entityType())
+        .isEqualTo("UNKNOWN");
+  }
+
+  private void stubPresentation() {
+    when(presenter.supports(EVENT_TYPE)).thenReturn(true);
+    when(presenter.present(any(UUID.class), any(JsonNode.class))).thenReturn(presentation);
+  }
+
+  private StuckEventContext context(UUID contextTenantId, UUID publicationId) {
+    return new StuckEventContext(
+        publicationId,
+        EVENT_TYPE,
+        "listener",
+        contextTenantId,
+        "{\"quoteId\":\"" + presentation.entityId() + "\"}",
+        Instant.now().minusSeconds(60));
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitorTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +16,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +24,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -30,6 +34,8 @@ import org.springframework.jdbc.core.RowMapper;
 class StuckEventMonitorTest {
 
   @Mock private JdbcTemplate jdbcTemplate;
+  @Mock private ObjectProvider<StuckEventHandler> handlerProvider;
+  @Mock private StuckEventHandler stuckEventHandler;
 
   private SimpleMeterRegistry meterRegistry;
   private StuckEventMonitor monitor;
@@ -37,7 +43,18 @@ class StuckEventMonitorTest {
   @BeforeEach
   void setUp() {
     meterRegistry = new SimpleMeterRegistry();
-    monitor = new StuckEventMonitor(jdbcTemplate, meterRegistry, new ObjectMapper(), true, 10);
+    lenient()
+        .doAnswer(
+            invocation -> {
+              Consumer<StuckEventHandler> consumer = invocation.getArgument(0);
+              consumer.accept(stuckEventHandler);
+              return null;
+            })
+        .when(handlerProvider)
+        .ifAvailable(any());
+    monitor =
+        new StuckEventMonitor(
+            jdbcTemplate, meterRegistry, new ObjectMapper(), handlerProvider, true, 10);
   }
 
   @Test
@@ -135,7 +152,9 @@ class StuckEventMonitorTest {
 
   @Test
   void disabledMonitorDoesNotAccessDatabaseOrRegisterGauge() {
-    monitor = new StuckEventMonitor(jdbcTemplate, meterRegistry, new ObjectMapper(), false, 10);
+    monitor =
+        new StuckEventMonitor(
+            jdbcTemplate, meterRegistry, new ObjectMapper(), handlerProvider, false, 10);
 
     monitor.sweep();
 
@@ -219,6 +238,60 @@ class StuckEventMonitorTest {
 
     assertThat(meterRegistry.find("events.publication.stuck").tag("eventType", "A").gauge())
         .isNull();
+  }
+
+  @Test
+  void handlerIsInvokedOnlyAfterWinningInsertAndResolutionRaces() {
+    UUID tenantId = UUID.randomUUID();
+    StuckEventMonitor.StuckRow insertedRow = stuckRow(UUID.randomUUID(), tenantId.toString());
+    stubSweep(List.of(insertedRow), List.of(), List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+
+    StuckEventMonitor.StuckMarker updatedMarker =
+        new StuckEventMonitor.StuckMarker(
+            insertedRow.id(),
+            insertedRow.eventType(),
+            insertedRow.listenerId(),
+            tenantId,
+            Instant.now().minusSeconds(60),
+            null);
+    stubSweep(List.of(), List.of(), List.of(updatedMarker));
+    when(jdbcTemplate.update(
+            startsWith("UPDATE public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+
+    StuckEventMonitor.StuckRow lostInsertRace = stuckRow(UUID.randomUUID(), tenantId.toString());
+    stubSweep(List.of(lostInsertRace), List.of(), List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(0);
+
+    monitor.sweep();
+
+    StuckEventMonitor.StuckMarker lostUpdateRace =
+        new StuckEventMonitor.StuckMarker(
+            UUID.randomUUID(),
+            insertedRow.eventType(),
+            insertedRow.listenerId(),
+            tenantId,
+            Instant.now().minusSeconds(60),
+            null);
+    stubSweep(List.of(), List.of(), List.of(lostUpdateRace));
+    when(jdbcTemplate.update(
+            startsWith("UPDATE public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(0);
+
+    monitor.sweep();
+
+    verify(stuckEventHandler, times(1)).onNewlyStuck(any(StuckEventContext.class));
+    verify(stuckEventHandler, times(1)).onResolved(any(StuckEventContext.class));
+    verifyNoMoreInteractions(stuckEventHandler);
   }
 
   private void stubSweep(

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitorTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/StuckEventMonitorTest.java
@@ -1,0 +1,267 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class StuckEventMonitorTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  private SimpleMeterRegistry meterRegistry;
+  private StuckEventMonitor monitor;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    monitor = new StuckEventMonitor(jdbcTemplate, meterRegistry, new ObjectMapper(), true, 10);
+  }
+
+  @Test
+  void reportsNewlyStuckPublicationAndRefreshesGauge(CapturedOutput output) {
+    UUID publicationId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    StuckEventMonitor.StuckRow row = stuckRow(publicationId, tenantId.toString());
+    stubSweep(List.of(row), List.of(), List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+
+    verify(jdbcTemplate)
+        .update(startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class));
+    assertThat(output.getAll()).contains("Stuck event publication: eventType=");
+    assertThat(
+            meterRegistry
+                .get("events.publication.stuck")
+                .tag("eventType", row.eventType())
+                .gauge()
+                .value())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  void doesNotInsertOrLogSamePublicationTwice(CapturedOutput output) {
+    UUID publicationId = UUID.randomUUID();
+    StuckEventMonitor.StuckRow row = stuckRow(publicationId, UUID.randomUUID().toString());
+    stubStuckRows(List.of(row));
+    when(jdbcTemplate.query(
+            startsWith("SELECT publication_id FROM public.stuck_event_publication WHERE"),
+            ArgumentMatchers.<RowMapper<UUID>>any(),
+            any(Object[].class)))
+        .thenReturn(List.of(), List.of(publicationId));
+    stubUnresolvedMarkers(List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+    monitor.sweep();
+
+    verify(jdbcTemplate, times(1))
+        .update(startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class));
+    assertThat(occurrences(output.getAll(), "Stuck event publication: eventType=")).isEqualTo(1);
+  }
+
+  @Test
+  void marksPreviouslyStuckPublicationAsResolved(CapturedOutput output) {
+    UUID publicationId = UUID.randomUUID();
+    StuckEventMonitor.StuckMarker marker =
+        new StuckEventMonitor.StuckMarker(
+            publicationId,
+            "com.fabricmanagement.SomeEvent",
+            "listener",
+            UUID.randomUUID(),
+            Instant.now().minusSeconds(900),
+            null);
+    stubSweep(List.of(), List.of(), List.of(marker));
+    when(jdbcTemplate.update(
+            startsWith("UPDATE public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+
+    verify(jdbcTemplate)
+        .update(startsWith("UPDATE public.stuck_event_publication"), any(Object[].class));
+    assertThat(output.getAll()).contains("Stuck event publication resolved: eventType=");
+  }
+
+  @Test
+  void reportsPayloadsWithMissingOrGarbledTenantAsUnknown() {
+    StuckEventMonitor.StuckRow missingTenant = stuckRow(UUID.randomUUID(), null);
+    StuckEventMonitor.StuckRow garbledTenant =
+        new StuckEventMonitor.StuckRow(
+            UUID.randomUUID(),
+            "listener",
+            "com.fabricmanagement.SomeEvent",
+            "{\"tenantId\":\"not-a-uuid\"}",
+            Instant.now().minusSeconds(900));
+    stubSweep(List.of(missingTenant, garbledTenant), List.of(), List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(1);
+
+    monitor.sweep();
+
+    ArgumentCaptor<Object[]> arguments = ArgumentCaptor.forClass(Object[].class);
+    verify(jdbcTemplate, times(2))
+        .update(startsWith("INSERT INTO public.stuck_event_publication"), arguments.capture());
+    assertThat(arguments.getAllValues()).allSatisfy(values -> assertThat(values[3]).isNull());
+  }
+
+  @Test
+  void disabledMonitorDoesNotAccessDatabaseOrRegisterGauge() {
+    monitor = new StuckEventMonitor(jdbcTemplate, meterRegistry, new ObjectMapper(), false, 10);
+
+    monitor.sweep();
+
+    verifyNoInteractions(jdbcTemplate);
+    assertThat(meterRegistry.find("events.publication.stuck").meter()).isNull();
+  }
+
+  @Test
+  void jdbcFailureIsLoggedAndSwallowed(CapturedOutput output) {
+    when(jdbcTemplate.query(
+            startsWith("SELECT id, listener_id, event_type"),
+            ArgumentMatchers.<RowMapper<StuckEventMonitor.StuckRow>>any(),
+            any(Object[].class)))
+        .thenThrow(new RuntimeException("database unavailable"));
+
+    assertThatCode(monitor::sweep).doesNotThrowAnyException();
+
+    assertThat(output.getAll()).contains("Failed to sweep stuck event publications");
+  }
+
+  @Test
+  void insertRaceGuardDoesNotLogDuplicateStuckError(CapturedOutput output) {
+    StuckEventMonitor.StuckRow row = stuckRow(UUID.randomUUID(), UUID.randomUUID().toString());
+    stubSweep(List.of(row), List.of(), List.of());
+    when(jdbcTemplate.update(
+            startsWith("INSERT INTO public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(0);
+
+    monitor.sweep();
+
+    assertThat(output.getAll()).doesNotContain("Stuck event publication: eventType=");
+  }
+
+  @Test
+  void updateRaceGuardDoesNotLogDuplicateResolution(CapturedOutput output) {
+    StuckEventMonitor.StuckMarker marker =
+        new StuckEventMonitor.StuckMarker(
+            UUID.randomUUID(),
+            "com.fabricmanagement.SomeEvent",
+            "listener",
+            UUID.randomUUID(),
+            Instant.now().minusSeconds(900),
+            null);
+    stubSweep(List.of(), List.of(), List.of(marker));
+    when(jdbcTemplate.update(
+            startsWith("UPDATE public.stuck_event_publication"), any(Object[].class)))
+        .thenReturn(0);
+
+    monitor.sweep();
+
+    assertThat(output.getAll()).doesNotContain("Stuck event publication resolved:");
+  }
+
+  @Test
+  void gaugeOverwritesChangedCountAndDropsDisappearedEventType() {
+    StuckEventMonitor.StuckRow first =
+        new StuckEventMonitor.StuckRow(
+            UUID.randomUUID(), "listener-1", "A", "{}", Instant.now().minusSeconds(900));
+    StuckEventMonitor.StuckRow second =
+        new StuckEventMonitor.StuckRow(
+            UUID.randomUUID(), "listener-2", "A", "{}", Instant.now().minusSeconds(900));
+    when(jdbcTemplate.query(
+            startsWith("SELECT id, listener_id, event_type"),
+            ArgumentMatchers.<RowMapper<StuckEventMonitor.StuckRow>>any(),
+            any(Object[].class)))
+        .thenReturn(List.of(first, second), List.of(first), List.of());
+    when(jdbcTemplate.query(
+            startsWith("SELECT publication_id FROM public.stuck_event_publication WHERE"),
+            ArgumentMatchers.<RowMapper<UUID>>any(),
+            any(Object[].class)))
+        .thenReturn(List.of(first.id(), second.id()), List.of(first.id()));
+    stubUnresolvedMarkers(List.of());
+
+    monitor.sweep();
+    monitor.sweep();
+
+    assertThat(meterRegistry.find("events.publication.stuck").tag("eventType", "A").gauge().value())
+        .isEqualTo(1.0);
+
+    monitor.sweep();
+
+    assertThat(meterRegistry.find("events.publication.stuck").tag("eventType", "A").gauge())
+        .isNull();
+  }
+
+  private void stubSweep(
+      List<StuckEventMonitor.StuckRow> stuckRows,
+      List<UUID> markedIds,
+      List<StuckEventMonitor.StuckMarker> unresolvedMarkers) {
+    stubStuckRows(stuckRows);
+    if (!stuckRows.isEmpty()) {
+      when(jdbcTemplate.query(
+              startsWith("SELECT publication_id FROM public.stuck_event_publication WHERE"),
+              ArgumentMatchers.<RowMapper<UUID>>any(),
+              any(Object[].class)))
+          .thenReturn(markedIds);
+    }
+    stubUnresolvedMarkers(unresolvedMarkers);
+  }
+
+  private void stubStuckRows(List<StuckEventMonitor.StuckRow> stuckRows) {
+    when(jdbcTemplate.query(
+            startsWith("SELECT id, listener_id, event_type"),
+            ArgumentMatchers.<RowMapper<StuckEventMonitor.StuckRow>>any(),
+            any(Object[].class)))
+        .thenReturn(stuckRows);
+  }
+
+  private void stubUnresolvedMarkers(List<StuckEventMonitor.StuckMarker> unresolvedMarkers) {
+    when(jdbcTemplate.query(
+            startsWith("SELECT publication_id, event_type"),
+            ArgumentMatchers.<RowMapper<StuckEventMonitor.StuckMarker>>any()))
+        .thenReturn(unresolvedMarkers);
+  }
+
+  private StuckEventMonitor.StuckRow stuckRow(UUID publicationId, String tenantId) {
+    String payload = tenantId == null ? "{}" : "{\"tenantId\":\"" + tenantId + "\"}";
+    return new StuckEventMonitor.StuckRow(
+        publicationId,
+        "listener",
+        "com.fabricmanagement.SomeEvent",
+        payload,
+        Instant.now().minusSeconds(900));
+  }
+
+  private int occurrences(String value, String needle) {
+    return (value.length() - value.replace(needle, "").length()) / needle.length();
+  }
+}

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/RlsPolicyEnforcementIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/RlsPolicyEnforcementIT.java
@@ -60,6 +60,11 @@ class RlsPolicyEnforcementIT {
           -- during pre-auth organization selection. The table is deliberately RLS-free so login
           -- can resolve active memberships before TenantContext exists.
           AND NOT (c.table_schema = 'common_auth' AND c.table_name = 'membership')
+          -- EVENT-VISIBILITY-1: public.stuck_event_publication is scheduler-owned, cross-tenant
+          -- bookkeeping written by StuckEventMonitor with no ambient tenant. RLS would blind the
+          -- sweep (the outbox-worker failure mode); tenant_id is informational for routing
+          -- resolution, not an isolation boundary. Deliberately RLS-free.
+          AND NOT (c.table_schema = 'public' AND c.table_name = 'stuck_event_publication')
           AND (
             pc.relrowsecurity = false
             OR pc.relforcerowsecurity = false

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
@@ -125,6 +125,10 @@ class PurgeSchemaCoverageIT extends AbstractIntegrationTest {
   private static Map<String, String> purgeExemptTables() {
     Map<String, String> tables = new LinkedHashMap<>();
 
+    tables.put(
+        "public.stuck_event_publication",
+        "Scheduler-owned cross-tenant stuck-event bookkeeping (EVENT-VISIBILITY-1); non-RLS, "
+            + "self-purging by resolution/age. tenant_id is informational, not tenant business data.");
     tables.put("common_audit.common_audit_log", "Audit history is retained across demo reset.");
     tables.put("common_auth.common_auth_user", "Seed-user auth rows are deleted by demo_seed CTE.");
     tables.put(

--- a/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteStuckPresenterTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/quote/app/SupplierQuoteStuckPresenterTest.java
@@ -1,0 +1,97 @@
+package com.fabricmanagement.procurement.quote.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.StuckEventPresentation;
+import com.fabricmanagement.platform.user.domain.SystemUser;
+import com.fabricmanagement.procurement.quote.domain.SupplierQuote;
+import com.fabricmanagement.procurement.quote.infra.repository.SupplierQuoteRepository;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SupplierQuoteStuckPresenterTest {
+
+  @Mock private SupplierQuoteRepository quoteRepository;
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private SupplierQuoteStuckPresenter presenter;
+
+  @BeforeEach
+  void setUp() {
+    presenter = new SupplierQuoteStuckPresenter(quoteRepository);
+  }
+
+  @Test
+  void presentsKnownQuoteWithReferenceAndAffectedUser() {
+    UUID tenantId = UUID.randomUUID();
+    UUID quoteId = UUID.randomUUID();
+    UUID createdBy = UUID.randomUUID();
+    SupplierQuote quote = quote(quoteId, "SQ-1042", createdBy);
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+
+    StuckEventPresentation result = presenter.present(tenantId, payload(quoteId));
+
+    assertThat(result.entityType()).isEqualTo("SUPPLIER_QUOTE");
+    assertThat(result.entityId()).isEqualTo(quoteId);
+    assertThat(result.entityRef()).isEqualTo("SQ-1042");
+    assertThat(result.summary())
+        .isEqualTo("Purchase order creation for quote SQ-1042 did not complete.");
+    assertThat(result.referenceType()).isEqualTo("SUPPLIER_QUOTE");
+    assertThat(result.referenceId()).isEqualTo(quoteId);
+    assertThat(result.affectedUserId()).isEqualTo(createdBy);
+  }
+
+  @Test
+  void omitsSystemUserFromAffectedUser() {
+    UUID tenantId = UUID.randomUUID();
+    UUID quoteId = UUID.randomUUID();
+    SupplierQuote quote = quote(quoteId, "SQ-1043", SystemUser.ID);
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+
+    StuckEventPresentation result = presenter.present(tenantId, payload(quoteId));
+
+    assertThat(result.affectedUserId()).isNull();
+  }
+
+  @Test
+  void missingQuoteFallsBackToPayloadOnlyPresentationWithoutThrowing() {
+    UUID tenantId = UUID.randomUUID();
+    UUID quoteId = UUID.randomUUID();
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.empty());
+
+    assertThatCode(() -> presenter.present(tenantId, payload(quoteId))).doesNotThrowAnyException();
+    StuckEventPresentation result = presenter.present(tenantId, payload(quoteId));
+
+    assertThat(result.entityType()).isEqualTo("SUPPLIER_QUOTE");
+    assertThat(result.entityId()).isEqualTo(quoteId);
+    assertThat(result.entityRef()).isNull();
+    assertThat(result.summary())
+        .isEqualTo("Purchase order creation for a supplier quote did not complete.");
+    assertThat(result.affectedUserId()).isNull();
+  }
+
+  private SupplierQuote quote(UUID quoteId, String quoteNumber, UUID createdBy) {
+    SupplierQuote quote = new SupplierQuote();
+    quote.setId(quoteId);
+    quote.setQuoteNumber(quoteNumber);
+    quote.setCreatedBy(createdBy);
+    return quote;
+  }
+
+  private JsonNode payload(UUID quoteId) {
+    return objectMapper.createObjectNode().put("quoteId", quoteId.toString());
+  }
+}


### PR DESCRIPTION
…ice A)

Add a @Scheduled monitor over Modulith's event_publication table that detects publications incomplete for longer than a threshold (default 10 min), reports each newly-stuck one once (ERROR log + per-eventType MultiGauge events.publication.stuck), and tracks resolution. Alerting-only slice; user-facing flags and notifications follow in Slice B/C.

- Flyway migration for non-RLS public.stuck_event_publication marker table (dedup + resolution bookkeeping), with fabric_app/fabric_system grants.
- StuckEventMonitor: atomic ON CONFLICT insert and guarded resolution update (race-safe across instances), fail-open tenant parsing from the event payload, gauge overwrite each sweep, Slice-B seams (onNewlyStuck/onResolved) with no domain-event recursion.
- Config defaults under modulith.events.stuck-monitor.*.
- StuckEventMonitorTest: 9 cases incl. dedup, resolution, disabled no-op, swallowed JDBC failure, insert/update race guards, gauge overwrite/drop.

Origin: ASYNC-TENANT-1 live validation (an accepted quote's follow-up
parked silently). Ticket: docs/platform/tickets/EVENT-VISIBILITY-1-*.md