### PR TITLE
feat(events): resolved-follow-up bell notification (EVENT-VISIBILITY-…

### DIFF
--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandler.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandler.java
@@ -9,6 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +22,7 @@ public class FlagWritingStuckEventHandler implements StuckEventHandler {
   private final List<StuckEventPresenter> presenters;
   private final ObjectMapper objectMapper;
   private final TenantSessionBinder tenantSessionBinder;
+  private final ObjectProvider<FollowUpResolutionNotifier> notifierProvider;
 
   @Override
   @Transactional
@@ -77,8 +79,29 @@ public class FlagWritingStuckEventHandler implements StuckEventHandler {
                   flag -> {
                     flag.resolve(Instant.now());
                     flagRepository.save(flag);
+                    notifyResolved(flag);
                   });
         });
+  }
+
+  private void notifyResolved(IncompleteFollowUpFlag flag) {
+    ResolvedFollowUp resolvedFollowUp =
+        new ResolvedFollowUp(
+            flag.getTenantId(),
+            flag.getAffectedUserId(),
+            flag.getEntityType(),
+            flag.getEntityRef(),
+            flag.getReferenceId(),
+            flag.getReferenceType(),
+            flag.getSummary());
+    try {
+      notifierProvider.ifAvailable(notifier -> notifier.notifyResolved(resolvedFollowUp));
+    } catch (Exception exception) {
+      log.warn(
+          "Failed to notify resolved follow-up: publicationId={}",
+          flag.getPublicationId(),
+          exception);
+    }
   }
 
   private StuckEventPresenter presenterFor(String eventType) {

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpResolutionNotifier.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpResolutionNotifier.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+public interface FollowUpResolutionNotifier {
+
+  void notifyResolved(ResolvedFollowUp event);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/ResolvedFollowUp.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/ResolvedFollowUp.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.util.UUID;
+
+public record ResolvedFollowUp(
+    UUID tenantId,
+    UUID affectedUserId,
+    String entityType,
+    String entityRef,
+    UUID referenceId,
+    String referenceType,
+    String summary) {}

--- a/src/main/java/com/fabricmanagement/notification/hub/app/FollowUpResolutionNotificationAdapter.java
+++ b/src/main/java/com/fabricmanagement/notification/hub/app/FollowUpResolutionNotificationAdapter.java
@@ -1,0 +1,72 @@
+package com.fabricmanagement.notification.hub.app;
+
+import com.fabricmanagement.common.infrastructure.events.FollowUpResolutionNotifier;
+import com.fabricmanagement.common.infrastructure.events.ResolvedFollowUp;
+import com.fabricmanagement.notification.hub.domain.port.DepartmentRecipientPort;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class FollowUpResolutionNotificationAdapter implements FollowUpResolutionNotifier {
+
+  static final String EVENT_TYPE = "STUCK_FOLLOW_UP_RESOLVED";
+
+  private final NotificationHubService notificationHub;
+  private final DepartmentRecipientPort departmentRecipientPort;
+
+  @Override
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void notifyResolved(ResolvedFollowUp event) {
+    List<UUID> recipients = recipientsFor(event);
+    if (recipients.isEmpty()) {
+      log.warn(
+          "No recipients for resolved follow-up notification: tenantId={} entityType={} referenceId={}",
+          event.tenantId(),
+          event.entityType(),
+          event.referenceId());
+      return;
+    }
+
+    Map<String, String> payload =
+        Map.of(
+            "entityRef",
+            event.entityRef() == null ? "your recent request" : event.entityRef(),
+            "summary",
+            event.summary());
+    notificationHub.notifyAll(
+        recipients,
+        event.tenantId(),
+        EVENT_TYPE,
+        payload,
+        event.referenceId(),
+        event.referenceType());
+  }
+
+  private List<UUID> recipientsFor(ResolvedFollowUp event) {
+    if (event.affectedUserId() != null) {
+      return List.of(event.affectedUserId());
+    }
+
+    String departmentKeyword = departmentKeyword(event.entityType());
+    if (departmentKeyword == null) {
+      return List.of();
+    }
+    return departmentRecipientPort.findManagersByDepartmentKeyword(
+        event.tenantId(), departmentKeyword);
+  }
+
+  private String departmentKeyword(String entityType) {
+    if ("SUPPLIER_QUOTE".equals(entityType)) {
+      return "PROCUREMENT";
+    }
+    return null;
+  }
+}

--- a/src/main/resources/db/migration/V20260712100000__seed_stuck_follow_up_resolved_notification.sql
+++ b/src/main/resources/db/migration/V20260712100000__seed_stuck_follow_up_resolved_notification.sql
@@ -1,0 +1,142 @@
+-- Seed future tenants through the golden TEMPLATE tenant.
+INSERT INTO i18n.translation_key
+    (id, tenant_id, key_code, module, default_value, description)
+VALUES
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'notification.stuck_follow_up_resolved.title', 'NOTIFICATION',
+     'Sorted — {entityRef} is fixed', 'Resolved stuck follow-up notification title'),
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'notification.stuck_follow_up_resolved.body', 'NOTIFICATION',
+     'The follow-up for {entityRef} didn''t complete earlier, but it''s now resolved. Please try again.',
+     'Resolved stuck follow-up notification body')
+ON CONFLICT (tenant_id, key_code) DO NOTHING;
+
+INSERT INTO i18n.translation_value
+    (id, tenant_id, translation_key_id, locale, value, is_override)
+SELECT gen_random_uuid(),
+       '00000000-0000-0000-ffff-000000000001',
+       tk.id,
+       'TR',
+       CASE tk.key_code
+         WHEN 'notification.stuck_follow_up_resolved.title'
+           THEN 'Çözüldü — {entityRef} düzeltildi'
+         WHEN 'notification.stuck_follow_up_resolved.body'
+           THEN '{entityRef} için takip işlemi daha önce tamamlanamamıştı, ancak sorun artık çözüldü. Lütfen tekrar deneyin.'
+       END,
+       FALSE
+FROM i18n.translation_key tk
+WHERE tk.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND tk.key_code IN (
+    'notification.stuck_follow_up_resolved.title',
+    'notification.stuck_follow_up_resolved.body'
+  )
+ON CONFLICT (translation_key_id, locale, tenant_id) DO NOTHING;
+
+INSERT INTO notification.notification_template
+    (id, tenant_id, event_type, channel, title_key, body_key, importance, delivery_type)
+VALUES
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'STUCK_FOLLOW_UP_RESOLVED', 'IN_APP',
+     'notification.stuck_follow_up_resolved.title',
+     'notification.stuck_follow_up_resolved.body',
+     'HIGH', 'INSTANT')
+ON CONFLICT (tenant_id, event_type, channel) DO NOTHING;
+
+-- Backfill the two keys into every existing real tenant.
+INSERT INTO i18n.translation_key
+    (id, tenant_id, uid, key_code, module, default_value, description,
+     is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::varchar,
+       source_key.key_code,
+       source_key.module,
+       source_key.default_value,
+       source_key.description,
+       source_key.is_active,
+       now(),
+       now(),
+       0
+FROM common_tenant.common_tenant tenant
+CROSS JOIN i18n.translation_key source_key
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND source_key.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND source_key.key_code IN (
+    'notification.stuck_follow_up_resolved.title',
+    'notification.stuck_follow_up_resolved.body'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM i18n.translation_key destination_key
+    WHERE destination_key.tenant_id = tenant.id
+      AND destination_key.key_code = source_key.key_code
+  );
+
+-- Backfill the IN_APP template into every existing real tenant.
+INSERT INTO notification.notification_template
+    (id, tenant_id, uid, event_type, channel, title_key, body_key, importance,
+     delivery_type, grouping_window_minutes, is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::varchar,
+       source_template.event_type,
+       source_template.channel,
+       source_template.title_key,
+       source_template.body_key,
+       source_template.importance,
+       source_template.delivery_type,
+       source_template.grouping_window_minutes,
+       source_template.is_active,
+       now(),
+       now(),
+       0
+FROM common_tenant.common_tenant tenant
+CROSS JOIN notification.notification_template source_template
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND source_template.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND source_template.event_type = 'STUCK_FOLLOW_UP_RESOLVED'
+  AND source_template.channel = 'IN_APP'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM notification.notification_template destination_template
+    WHERE destination_template.tenant_id = tenant.id
+      AND destination_template.event_type = source_template.event_type
+      AND destination_template.channel = source_template.channel
+  );
+
+-- Backfill TR values, remapping each source key to the destination tenant's key ID.
+INSERT INTO i18n.translation_value
+    (id, tenant_id, uid, translation_key_id, locale, value, is_override,
+     is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::varchar,
+       destination_key.id,
+       source_value.locale,
+       source_value.value,
+       source_value.is_override,
+       source_value.is_active,
+       now(),
+       now(),
+       0
+FROM common_tenant.common_tenant tenant
+JOIN i18n.translation_key source_key
+  ON source_key.tenant_id = '00000000-0000-0000-ffff-000000000001'
+ AND source_key.key_code IN (
+   'notification.stuck_follow_up_resolved.title',
+   'notification.stuck_follow_up_resolved.body'
+ )
+JOIN i18n.translation_value source_value
+  ON source_value.tenant_id = '00000000-0000-0000-ffff-000000000001'
+ AND source_value.translation_key_id = source_key.id
+JOIN i18n.translation_key destination_key
+  ON destination_key.tenant_id = tenant.id
+ AND destination_key.key_code = source_key.key_code
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM i18n.translation_value destination_value
+    WHERE destination_value.tenant_id = tenant.id
+      AND destination_value.translation_key_id = destination_key.id
+      AND destination_value.locale = source_value.locale
+  );

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandlerTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/FlagWritingStuckEventHandlerTest.java
@@ -1,7 +1,11 @@
 package com.fabricmanagement.common.infrastructure.events;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -15,13 +19,16 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 
@@ -33,6 +40,8 @@ class FlagWritingStuckEventHandlerTest {
   @Mock private IncompleteFollowUpFlagRepository flagRepository;
   @Mock private StuckEventPresenter presenter;
   @Mock private TenantSessionBinder tenantSessionBinder;
+  @Mock private ObjectProvider<FollowUpResolutionNotifier> notifierProvider;
+  @Mock private FollowUpResolutionNotifier notifier;
 
   private final ObjectMapper objectMapper = new ObjectMapper();
   private FlagWritingStuckEventHandler handler;
@@ -51,12 +60,22 @@ class FlagWritingStuckEventHandlerTest {
             "SUPPLIER_QUOTE",
             UUID.randomUUID(),
             UUID.randomUUID());
+    lenient()
+        .doAnswer(
+            invocation -> {
+              Consumer<FollowUpResolutionNotifier> consumer = invocation.getArgument(0);
+              consumer.accept(notifier);
+              return null;
+            })
+        .when(notifierProvider)
+        .ifAvailable(any());
     handler =
         new FlagWritingStuckEventHandler(
             flagRepository,
             List.of(presenter, new GenericStuckEventPresenter()),
             objectMapper,
-            tenantSessionBinder);
+            tenantSessionBinder,
+            notifierProvider);
   }
 
   @AfterEach
@@ -113,8 +132,41 @@ class FlagWritingStuckEventHandlerTest {
 
     assertThat(existing.getStatus()).isEqualTo(FollowUpFlagStatus.RESOLVED);
     assertThat(existing.getResolvedAt()).isNotNull().isBeforeOrEqualTo(Instant.now());
-    verify(flagRepository).save(existing);
+    InOrder notificationOrder = inOrder(flagRepository, notifier);
+    notificationOrder.verify(flagRepository).save(existing);
+    notificationOrder.verify(notifier).notifyResolved(any(ResolvedFollowUp.class));
     verify(tenantSessionBinder).bindToCurrentSession(tenantId);
+  }
+
+  @Test
+  void resolvedPublicationWithoutActiveFlagDoesNotNotify() {
+    StuckEventContext context = context(tenantId, UUID.randomUUID());
+    when(flagRepository.findByTenantIdAndPublicationId(tenantId, context.publicationId()))
+        .thenReturn(Optional.empty());
+
+    handler.onResolved(context);
+
+    verifyNoInteractions(notifier);
+  }
+
+  @Test
+  void notifierFailureDoesNotPreventFlagResolution(CapturedOutput output) {
+    StuckEventContext context = context(tenantId, UUID.randomUUID());
+    IncompleteFollowUpFlag existing =
+        IncompleteFollowUpFlag.raise(
+            tenantId, context.publicationId(), context.eventType(), presentation);
+    when(flagRepository.findByTenantIdAndPublicationId(tenantId, context.publicationId()))
+        .thenReturn(Optional.of(existing));
+    doThrow(new RuntimeException("notification unavailable"))
+        .when(notifier)
+        .notifyResolved(any(ResolvedFollowUp.class));
+
+    assertThatCode(() -> handler.onResolved(context)).doesNotThrowAnyException();
+
+    assertThat(existing.getStatus()).isEqualTo(FollowUpFlagStatus.RESOLVED);
+    assertThat(existing.getResolvedAt()).isNotNull();
+    verify(flagRepository).save(existing);
+    assertThat(output.getAll()).contains("Failed to notify resolved follow-up");
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/notification/hub/app/FollowUpResolutionNotificationAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/notification/hub/app/FollowUpResolutionNotificationAdapterTest.java
@@ -1,0 +1,118 @@
+package com.fabricmanagement.notification.hub.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.ResolvedFollowUp;
+import com.fabricmanagement.notification.hub.domain.port.DepartmentRecipientPort;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class FollowUpResolutionNotificationAdapterTest {
+
+  @Mock private NotificationHubService notificationHub;
+  @Mock private DepartmentRecipientPort departmentRecipientPort;
+
+  private FollowUpResolutionNotificationAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    adapter = new FollowUpResolutionNotificationAdapter(notificationHub, departmentRecipientPort);
+  }
+
+  @Test
+  void notifiesAffectedUserWithReferenceAndPayload() {
+    UUID tenantId = UUID.randomUUID();
+    UUID affectedUserId = UUID.randomUUID();
+    UUID referenceId = UUID.randomUUID();
+    ResolvedFollowUp event =
+        event(tenantId, affectedUserId, "SUPPLIER_QUOTE", "SQ-1042", referenceId);
+
+    adapter.notifyResolved(event);
+
+    ArgumentCaptor<Map<String, String>> payloadCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(notificationHub)
+        .notifyAll(
+            eq(List.of(affectedUserId)),
+            eq(tenantId),
+            eq(FollowUpResolutionNotificationAdapter.EVENT_TYPE),
+            payloadCaptor.capture(),
+            eq(referenceId),
+            eq("SUPPLIER_QUOTE"));
+    assertThat(payloadCaptor.getValue()).containsEntry("entityRef", "SQ-1042");
+    verifyNoInteractions(departmentRecipientPort);
+  }
+
+  @Test
+  void resolvesProcurementManagersWhenAffectedUserIsUnknown() {
+    UUID tenantId = UUID.randomUUID();
+    UUID managerId = UUID.randomUUID();
+    UUID referenceId = UUID.randomUUID();
+    when(departmentRecipientPort.findManagersByDepartmentKeyword(tenantId, "PROCUREMENT"))
+        .thenReturn(List.of(managerId));
+
+    adapter.notifyResolved(event(tenantId, null, "SUPPLIER_QUOTE", "SQ-1042", referenceId));
+
+    verify(notificationHub)
+        .notifyAll(
+            eq(List.of(managerId)),
+            eq(tenantId),
+            eq(FollowUpResolutionNotificationAdapter.EVENT_TYPE),
+            anyMap(),
+            eq(referenceId),
+            eq("SUPPLIER_QUOTE"));
+  }
+
+  @Test
+  void emptyRecipientsAreLoggedAndSkipped(CapturedOutput output) {
+    UUID tenantId = UUID.randomUUID();
+    when(departmentRecipientPort.findManagersByDepartmentKeyword(tenantId, "PROCUREMENT"))
+        .thenReturn(List.of());
+
+    adapter.notifyResolved(event(tenantId, null, "SUPPLIER_QUOTE", "SQ-1042", UUID.randomUUID()));
+
+    verifyNoInteractions(notificationHub);
+    assertThat(output.getAll()).contains("No recipients for resolved follow-up notification");
+  }
+
+  @Test
+  void notificationRunsInRequiresNewTransaction() throws NoSuchMethodException {
+    Method method =
+        FollowUpResolutionNotificationAdapter.class.getMethod(
+            "notifyResolved", ResolvedFollowUp.class);
+
+    Transactional transactional = method.getAnnotation(Transactional.class);
+
+    assertThat(transactional).isNotNull();
+    assertThat(transactional.propagation()).isEqualTo(Propagation.REQUIRES_NEW);
+  }
+
+  private ResolvedFollowUp event(
+      UUID tenantId, UUID affectedUserId, String entityType, String entityRef, UUID referenceId) {
+    return new ResolvedFollowUp(
+        tenantId,
+        affectedUserId,
+        entityType,
+        entityRef,
+        referenceId,
+        "SUPPLIER_QUOTE",
+        "Purchase order creation is resolved.");
+  }
+}


### PR DESCRIPTION
…1 Slice B/2)

When a stuck follow-up resolves, notify the affected user via the notification hub. No stuck-bell (the flag already shows the stuck state; the alert to us is Slice A). FE deep-link case follows in Slice C.

- FollowUpResolutionNotifier port + ResolvedFollowUp record in common; adapter in the notification module (common does not import notification). Recipients: the flag's affected_user_id, else the PROCUREMENT department managers for a SUPPLIER_QUOTE; empty → warn and skip.
- Adapter's notifyResolved runs REQUIRES_NEW so a notification failure cannot mark the flag-resolution transaction rollback-only; the handler also guards the call with try/catch. Tenant binding is provided by the surrounding TenantContext + MultiTenantConnectionProvider (no manual re-bind).
- FlagWritingStuckEventHandler.onResolved fires the notifier after the flag is resolved, inside the tenant-bound block.
- Migration seeds the STUCK_FOLLOW_UP_RESOLVED IN_APP template + i18n keys on the golden template tenant (future tenants via TenantClonerService) and backfills existing real tenants, remapping each translation_value FK to the destination tenant's own translation_key id.
- Tests: adapter (recipient fallback, empty-skip, REQUIRES_NEW annotation), handler (notifier fired after resolve, not when absent, failure does not block resolution).