### PR TITLE
feat(events): feedback-to-ops endpoint for stuck follow-ups (EVENT-VI…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -21865,6 +21865,77 @@ paths:
       summary: List active follow-up flags for the current tenant
       tags:
       - Follow-up flags
+  /api/v1/follow-up-flags/{flagId}/feedback:
+    post:
+      operationId: reportFeedback
+      parameters:
+      - in: path
+        name: flagId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVoid"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Report an incomplete follow-up to operations
+      tags:
+      - Follow-up flags
   /api/v1/health:
     get:
       operationId: health

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackReport.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackReport.java
@@ -1,0 +1,16 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record FollowUpFeedbackReport(
+    UUID tenantId,
+    UUID publicationId,
+    String eventType,
+    String entityType,
+    String entityRef,
+    String summary,
+    String referenceType,
+    UUID referenceId,
+    UUID affectedUserId,
+    Instant detectedAt) {}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackService.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackService.java
@@ -1,0 +1,45 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class FollowUpFeedbackService {
+
+  private final IncompleteFollowUpFlagRepository flagRepository;
+  private final StuckEventFeedbackSender feedbackSender;
+
+  @Transactional
+  public void report(UUID flagId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    IncompleteFollowUpFlag flag =
+        flagRepository
+            .findByTenantIdAndIdForUpdate(tenantId, flagId)
+            .orElseThrow(() -> new NotFoundException("Follow-up flag not found: " + flagId));
+
+    if (flag.getFeedbackReportedAt() != null) {
+      return;
+    }
+
+    feedbackSender.sendOpsReport(
+        new FollowUpFeedbackReport(
+            tenantId,
+            flag.getPublicationId(),
+            flag.getEventType(),
+            flag.getEntityType(),
+            flag.getEntityRef(),
+            flag.getSummary(),
+            flag.getReferenceType(),
+            flag.getReferenceId(),
+            flag.getAffectedUserId(),
+            flag.getCreatedAt()));
+    flag.markFeedbackReported(Instant.now());
+    flagRepository.save(flag);
+  }
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlag.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlag.java
@@ -51,6 +51,9 @@ public class IncompleteFollowUpFlag extends BaseEntity {
   @Column(name = "resolved_at")
   private Instant resolvedAt;
 
+  @Column(name = "feedback_reported_at")
+  private Instant feedbackReportedAt;
+
   public static IncompleteFollowUpFlag raise(
       UUID tenantId, UUID publicationId, String eventType, StuckEventPresentation presentation) {
     IncompleteFollowUpFlag flag = new IncompleteFollowUpFlag();
@@ -74,6 +77,10 @@ public class IncompleteFollowUpFlag extends BaseEntity {
     }
     status = FollowUpFlagStatus.RESOLVED;
     this.resolvedAt = resolvedAt;
+  }
+
+  public void markFeedbackReported(Instant feedbackReportedAt) {
+    this.feedbackReportedAt = feedbackReportedAt;
   }
 
   private void apply(StuckEventPresentation presentation) {

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlagRepository.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/IncompleteFollowUpFlagRepository.java
@@ -1,9 +1,13 @@
 package com.fabricmanagement.common.infrastructure.events;
 
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -12,6 +16,11 @@ public interface IncompleteFollowUpFlagRepository
 
   Optional<IncompleteFollowUpFlag> findByTenantIdAndPublicationId(
       UUID tenantId, UUID publicationId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("select f from IncompleteFollowUpFlag f where f.tenantId = :tenantId and f.id = :id")
+  Optional<IncompleteFollowUpFlag> findByTenantIdAndIdForUpdate(
+      @Param("tenantId") UUID tenantId, @Param("id") UUID id);
 
   List<IncompleteFollowUpFlag> findByTenantIdAndEntityTypeAndEntityIdAndStatus(
       UUID tenantId, String entityType, UUID entityId, FollowUpFlagStatus status);

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventFeedbackSender.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/StuckEventFeedbackSender.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+public interface StuckEventFeedbackSender {
+
+  void sendOpsReport(FollowUpFeedbackReport report);
+}

--- a/src/main/java/com/fabricmanagement/common/infrastructure/events/api/FollowUpFlagController.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/events/api/FollowUpFlagController.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.common.infrastructure.events.api;
 
+import com.fabricmanagement.common.infrastructure.events.FollowUpFeedbackService;
 import com.fabricmanagement.common.infrastructure.events.FollowUpFlagDto;
 import com.fabricmanagement.common.infrastructure.events.FollowUpFlagService;
 import com.fabricmanagement.common.infrastructure.web.ApiResponse;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class FollowUpFlagController {
 
   private final FollowUpFlagService flagService;
+  private final FollowUpFeedbackService feedbackService;
 
   @GetMapping
   @PreAuthorize("isAuthenticated()")
@@ -37,5 +41,13 @@ public class FollowUpFlagController {
   @Operation(summary = "List active follow-up flags for the current tenant")
   public ResponseEntity<ApiResponse<List<FollowUpFlagDto>>> findActive() {
     return ResponseEntity.ok(ApiResponse.success(flagService.findActiveForTenant()));
+  }
+
+  @PostMapping("/{flagId}/feedback")
+  @PreAuthorize("isAuthenticated()")
+  @Operation(summary = "Report an incomplete follow-up to operations")
+  public ResponseEntity<ApiResponse<Void>> reportFeedback(@PathVariable UUID flagId) {
+    feedbackService.report(flagId);
+    return ResponseEntity.ok(ApiResponse.success(null));
   }
 }

--- a/src/main/java/com/fabricmanagement/platform/communication/app/EmailOutboxService.java
+++ b/src/main/java/com/fabricmanagement/platform/communication/app/EmailOutboxService.java
@@ -338,6 +338,21 @@ public class EmailOutboxService {
   }
 
   /**
+   * Queue mail to a TRUSTED, FIXED internal recipient (ops), bypassing the tenant email sandbox.
+   * The recipient must be config-supplied and never derived from user input — the sandbox exists to
+   * stop a visitor redirecting our domain's mail to an arbitrary address, which cannot happen for a
+   * fixed ops address. Runs in the caller's tenant context (RLS insert); the outbox worker sends
+   * later.
+   */
+  @Transactional
+  public EmailOutbox queueSystemEmail(
+      UUID tenantId, String recipient, String subject, String htmlBody) {
+    EmailOutbox email = EmailOutbox.create(recipient, subject, htmlBody);
+    email.setTenantId(tenantId);
+    return emailOutboxRepository.save(email);
+  }
+
+  /**
    * Get pending email count (for monitoring).
    *
    * <p>Counted through {@code fabric_system}: these are called from metric gauges and a scheduled

--- a/src/main/java/com/fabricmanagement/platform/communication/app/StuckEventFeedbackEmailAdapter.java
+++ b/src/main/java/com/fabricmanagement/platform/communication/app/StuckEventFeedbackEmailAdapter.java
@@ -1,0 +1,83 @@
+package com.fabricmanagement.platform.communication.app;
+
+import com.fabricmanagement.common.infrastructure.events.FollowUpFeedbackReport;
+import com.fabricmanagement.common.infrastructure.events.StuckEventFeedbackSender;
+import java.time.Duration;
+import java.time.Instant;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
+
+@Component
+public class StuckEventFeedbackEmailAdapter implements StuckEventFeedbackSender {
+
+  private final EmailOutboxService emailOutboxService;
+  private final String opsEmail;
+
+  public StuckEventFeedbackEmailAdapter(
+      EmailOutboxService emailOutboxService,
+      @Value("${application.event-visibility.ops-email:ops@fabric-management.local}")
+          String opsEmail) {
+    this.emailOutboxService = emailOutboxService;
+    this.opsEmail = opsEmail;
+  }
+
+  @Override
+  public void sendOpsReport(FollowUpFeedbackReport report) {
+    String subjectReference = stripHeaderBreaks(value(report.entityRef()));
+    if (subjectReference.isBlank()) {
+      subjectReference = "unknown reference";
+    }
+    String subject = "Stuck follow-up report: " + subjectReference;
+    String html =
+        """
+        <html><body>
+        <h1>Stuck follow-up report</h1>
+        <dl>
+          <dt>Tenant</dt><dd>%s</dd>
+          <dt>Event type</dt><dd>%s</dd>
+          <dt>Publication ID</dt><dd>%s</dd>
+          <dt>Entity</dt><dd>%s — %s</dd>
+          <dt>Summary</dt><dd>%s</dd>
+          <dt>Reference</dt><dd>%s / %s</dd>
+          <dt>Affected user</dt><dd>%s</dd>
+          <dt>Detected at</dt><dd>%s</dd>
+          <dt>Age (minutes)</dt><dd>%s</dd>
+        </dl>
+        </body></html>
+        """
+            .formatted(
+                escape(report.tenantId()),
+                escape(report.eventType()),
+                escape(report.publicationId()),
+                escape(report.entityType()),
+                escape(report.entityRef()),
+                escape(report.summary()),
+                escape(report.referenceType()),
+                escape(report.referenceId()),
+                escape(report.affectedUserId()),
+                escape(report.detectedAt()),
+                escape(ageMinutes(report.detectedAt())));
+
+    emailOutboxService.queueSystemEmail(report.tenantId(), opsEmail, subject, html);
+  }
+
+  private long ageMinutes(Instant detectedAt) {
+    if (detectedAt == null) {
+      return 0;
+    }
+    return Math.max(0, Duration.between(detectedAt, Instant.now()).toMinutes());
+  }
+
+  private String escape(Object value) {
+    return HtmlUtils.htmlEscape(value(value));
+  }
+
+  private String value(Object value) {
+    return value == null ? "" : value.toString();
+  }
+
+  private String stripHeaderBreaks(String value) {
+    return value.replace("\r", "").replace("\n", "");
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -169,6 +169,11 @@ application:
     from-email: ${MAIL_FROM_EMAIL:noreply@fabricmanagement.com}
     from-name: ${MAIL_FROM_NAME:Fabric Management}
 
+  # Stuck-follow-up feedback reports (EVENT-VISIBILITY-1): where the "Report this"
+  # button sends its bug report. Override per environment via EVENT_VISIBILITY_OPS_EMAIL.
+  event-visibility:
+    ops-email: ${EVENT_VISIBILITY_OPS_EMAIL:akkaya064@gmail.com}
+
   # Email Template Configuration
   # Note: Frontend pi email render endpoint removed - backend uses its own HTML templates
   email:

--- a/src/main/resources/db/migration/V20260712110000__add_feedback_reported_at_to_follow_up_flag.sql
+++ b/src/main/resources/db/migration/V20260712110000__add_feedback_reported_at_to_follow_up_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE common_infrastructure.incomplete_follow_up_flag
+    ADD COLUMN feedback_reported_at TIMESTAMPTZ;

--- a/src/test/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackServiceTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/events/FollowUpFeedbackServiceTest.java
@@ -1,0 +1,107 @@
+package com.fabricmanagement.common.infrastructure.events;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FollowUpFeedbackServiceTest {
+
+  @Mock private IncompleteFollowUpFlagRepository flagRepository;
+  @Mock private StuckEventFeedbackSender feedbackSender;
+
+  private FollowUpFeedbackService service;
+  private UUID tenantId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    service = new FollowUpFeedbackService(flagRepository, feedbackSender);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void firstReportSendsOnceAndMarksFlag() {
+    IncompleteFollowUpFlag flag = flag();
+    when(flagRepository.findByTenantIdAndIdForUpdate(tenantId, flag.getId()))
+        .thenReturn(Optional.of(flag));
+
+    service.report(flag.getId());
+
+    ArgumentCaptor<FollowUpFeedbackReport> reportCaptor =
+        ArgumentCaptor.forClass(FollowUpFeedbackReport.class);
+    verify(feedbackSender).sendOpsReport(reportCaptor.capture());
+    assertThat(reportCaptor.getValue().tenantId()).isEqualTo(tenantId);
+    assertThat(reportCaptor.getValue().publicationId()).isEqualTo(flag.getPublicationId());
+    assertThat(flag.getFeedbackReportedAt()).isNotNull();
+    verify(flagRepository).save(flag);
+    verify(flagRepository).findByTenantIdAndIdForUpdate(tenantId, flag.getId());
+  }
+
+  @Test
+  void alreadyReportedFlagReturnsWithoutSendingAgain() {
+    IncompleteFollowUpFlag flag = flag();
+    flag.markFeedbackReported(Instant.now().minusSeconds(60));
+    when(flagRepository.findByTenantIdAndIdForUpdate(tenantId, flag.getId()))
+        .thenReturn(Optional.of(flag));
+
+    service.report(flag.getId());
+
+    verifyNoInteractions(feedbackSender);
+    verify(flagRepository, never()).save(flag);
+  }
+
+  @Test
+  void missingFlagSignalsNotFoundWithoutSending() {
+    UUID flagId = UUID.randomUUID();
+    when(flagRepository.findByTenantIdAndIdForUpdate(tenantId, flagId))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.report(flagId))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining(flagId.toString());
+
+    verifyNoInteractions(feedbackSender);
+  }
+
+  private IncompleteFollowUpFlag flag() {
+    UUID entityId = UUID.randomUUID();
+    IncompleteFollowUpFlag flag =
+        IncompleteFollowUpFlag.raise(
+            tenantId,
+            UUID.randomUUID(),
+            "SUPPLIER_QUOTE_ACCEPTED",
+            new StuckEventPresentation(
+                "SUPPLIER_QUOTE",
+                entityId,
+                "SQ-1042",
+                "Purchase order creation for quote SQ-1042 did not complete.",
+                "SUPPLIER_QUOTE",
+                entityId,
+                UUID.randomUUID()));
+    flag.setId(UUID.randomUUID());
+    flag.setCreatedAt(Instant.now().minusSeconds(900));
+    return flag;
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/communication/app/EmailOutboxServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/communication/app/EmailOutboxServiceTest.java
@@ -1,0 +1,60 @@
+package com.fabricmanagement.platform.communication.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.platform.communication.domain.EmailOutbox;
+import com.fabricmanagement.platform.communication.domain.strategy.EmailStrategy;
+import com.fabricmanagement.platform.communication.infra.repository.EmailOutboxRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EmailOutboxServiceTest {
+
+  @Mock private EmailOutboxRepository emailOutboxRepository;
+  @Mock private EmailStrategy emailStrategy;
+  @Mock private EmailRecipientPolicy emailRecipientPolicy;
+  @Mock private SystemTransactionExecutor systemTransactionExecutor;
+  @Mock private MeterRegistry meterRegistry;
+
+  private EmailOutboxService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new EmailOutboxService(
+            emailOutboxRepository,
+            emailStrategy,
+            emailRecipientPolicy,
+            systemTransactionExecutor,
+            meterRegistry);
+  }
+
+  @Test
+  void queueSystemEmailBypassesRecipientPolicyAndKeepsFixedRecipient() {
+    UUID tenantId = UUID.randomUUID();
+    String recipient = "fixed-ops@example.test";
+    when(emailOutboxRepository.save(any(EmailOutbox.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    EmailOutbox saved =
+        service.queueSystemEmail(tenantId, recipient, "Ops report", "<p>Details</p>");
+
+    assertThat(saved.getTenantId()).isEqualTo(tenantId);
+    assertThat(saved.getRecipient()).isEqualTo(recipient);
+    assertThat(saved.getOriginalRecipient()).isNull();
+    assertThat(saved.getSubject()).isEqualTo("Ops report");
+    verify(emailOutboxRepository).save(saved);
+    verifyNoInteractions(emailRecipientPolicy);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/communication/app/StuckEventFeedbackEmailAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/platform/communication/app/StuckEventFeedbackEmailAdapterTest.java
@@ -1,0 +1,81 @@
+package com.fabricmanagement.platform.communication.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.common.infrastructure.events.FollowUpFeedbackReport;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StuckEventFeedbackEmailAdapterTest {
+
+  private static final String OPS_EMAIL = "fixed-ops@example.test";
+
+  @Mock private EmailOutboxService emailOutboxService;
+
+  private StuckEventFeedbackEmailAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    adapter = new StuckEventFeedbackEmailAdapter(emailOutboxService, OPS_EMAIL);
+  }
+
+  @Test
+  void sendsCompleteReportToConfiguredOpsAddress() {
+    FollowUpFeedbackReport report = report("SQ-1042", "Order creation did not complete.");
+
+    adapter.sendOpsReport(report);
+
+    ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(emailOutboxService)
+        .queueSystemEmail(
+            eq(report.tenantId()), eq(OPS_EMAIL), subjectCaptor.capture(), htmlCaptor.capture());
+    assertThat(subjectCaptor.getValue()).contains("SQ-1042");
+    assertThat(htmlCaptor.getValue())
+        .contains(report.eventType(), report.publicationId().toString(), "SQ-1042");
+  }
+
+  @Test
+  void escapesDynamicHtmlAndStripsSubjectHeaderBreaks() {
+    String entityRef = "SQ-1\r\nBcc: visitor@example.test <a href=\"https://bad.test\">&";
+    String summary = "<script>alert(\"x\")</script> & broken";
+    FollowUpFeedbackReport report = report(entityRef, summary);
+
+    adapter.sendOpsReport(report);
+
+    ArgumentCaptor<String> subjectCaptor = ArgumentCaptor.forClass(String.class);
+    ArgumentCaptor<String> htmlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(emailOutboxService)
+        .queueSystemEmail(
+            eq(report.tenantId()), eq(OPS_EMAIL), subjectCaptor.capture(), htmlCaptor.capture());
+    assertThat(subjectCaptor.getValue()).doesNotContain("\r", "\n");
+    assertThat(htmlCaptor.getValue())
+        .doesNotContain("<a href=", "<script>")
+        .contains(
+            "&lt;a href=&quot;https://bad.test&quot;&gt;&amp;",
+            "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt; &amp; broken");
+  }
+
+  private FollowUpFeedbackReport report(String entityRef, String summary) {
+    return new FollowUpFeedbackReport(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        "SUPPLIER_QUOTE_ACCEPTED",
+        "SUPPLIER_QUOTE",
+        entityRef,
+        summary,
+        "SUPPLIER_QUOTE",
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        Instant.now().minusSeconds(900));
+  }
+}


### PR DESCRIPTION
…SIBILITY-1 Slice B/3)

The Slice-C "Report this" button's backend: POST
/api/v1/follow-up-flags/{flagId}/feedback snapshots a flagged stuck follow-up into an ops email so one click is a complete bug report to us. The outbox row is the record (no feedback table). Completes the BE side of EVENT-VISIBILITY-1.

- StuckEventFeedbackSender port + FollowUpFeedbackReport record in common; StuckEventFeedbackEmailAdapter in platform.communication (common does not import platform.communication).
- EmailOutboxService.queueSystemEmail: a trusted-internal send that bypasses the tenant email sandbox for a FIXED, config-supplied ops address (application.event-visibility.ops-email) that is never user input — so a sandboxed playground tenant's report still reaches ops, not the prospect.
- FollowUpFeedbackService (@Component, not @Service — arch gate): loads the flag with a PESSIMISTIC_WRITE, tenant-scoped query so concurrent clicks are idempotent (second waits, sees feedback_reported_at, returns without a second email); outbox insert and the timestamp share one transaction.
- Adapter HTML-escapes every dynamic value and strips CR/LF from the subject (tenant text must not inject markup/headers into the ops mailbox).
- Migration adds feedback_reported_at to incomplete_follow_up_flag; api/openapi.yaml regenerated for the new endpoint.
- Tests: adapter (config recipient, escaping), service (idempotency, not-found, pessimistic load), EmailOutboxService.queueSystemEmail (no sandbox/redirect).