### PR TITLE
feat(sales): server-side quote status filter, search and status counts

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -38683,6 +38683,28 @@ paths:
     get:
       operationId: listQuotes
       parameters:
+      - description: Optional quote status filter
+        in: query
+        name: status
+        required: false
+        schema:
+          type: string
+          enum:
+          - DRAFT
+          - EVALUATION
+          - PENDING_APPROVAL
+          - APPROVED
+          - REJECTED
+          - CONVERTED
+          - EXPIRED
+          - SUPERSEDED
+      - description: Literal quote-number or customer-name search; trimmed values
+          shorter than two characters are ignored
+        in: query
+        name: q
+        required: false
+        schema:
+          type: string
       - in: query
         name: pageable
         required: true
@@ -38816,6 +38838,70 @@ paths:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
       summary: Create a new quote
+      tags:
+      - Quotes
+  /api/v1/sales/quotes/status-counts:
+    get:
+      operationId: getStatusCounts
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseQuoteStatusCountsResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Count active quotes by status
       tags:
       - Quotes
   /api/v1/sales/quotes/{quoteId}:
@@ -46662,6 +46748,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/QuoteSendRequestDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseQuoteStatusCountsResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/QuoteStatusCountsResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -55942,6 +56046,51 @@ components:
       - requestedAt
       - requestedBy
       - status
+    QuoteStatusCountsResponse:
+      type: object
+      description: Active quote totals by status for the current tenant
+      properties:
+        approved:
+          type: integer
+          format: int64
+          description: APPROVED quote count
+        converted:
+          type: integer
+          format: int64
+          description: CONVERTED quote count
+        draft:
+          type: integer
+          format: int64
+          description: DRAFT quote count
+        evaluation:
+          type: integer
+          format: int64
+          description: EVALUATION quote count
+        expired:
+          type: integer
+          format: int64
+          description: EXPIRED quote count
+        pendingApproval:
+          type: integer
+          format: int64
+          description: PENDING_APPROVAL quote count
+        rejected:
+          type: integer
+          format: int64
+          description: REJECTED quote count
+        superseded:
+          type: integer
+          format: int64
+          description: SUPERSEDED quote count
+      required:
+      - approved
+      - converted
+      - draft
+      - evaluation
+      - expired
+      - pendingApproval
+      - rejected
+      - superseded
     RealizedFxCurrencyDto:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/common/infrastructure/persistence/LikePattern.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/persistence/LikePattern.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.common.infrastructure.persistence;
+
+/** Builds escaped SQL {@code LIKE} patterns for literal user-entered text. */
+public final class LikePattern {
+
+  public static final char ESCAPE_CHARACTER = '\\';
+
+  private LikePattern() {}
+
+  public static String literalContains(String value) {
+    String escaped = value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+    return "%" + escaped + "%";
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.platform.tradingpartner.app;
 
+import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
 import com.fabricmanagement.platform.tradingpartner.infra.repository.TradingPartnerRepository;
 import java.util.List;
@@ -189,6 +190,16 @@ public class TradingPartnerResolver {
     }
     return partnerRepository.findByTenantIdAndIdInWithRegistry(tenantId, partnerIds).stream()
         .collect(Collectors.toMap(TradingPartner::getId, this::displayNameOrFallback));
+  }
+
+  /** Returns every active CUSTOMER/BOTH partner whose display name contains {@code query}. */
+  public List<UUID> findCustomerIdsByNameContains(UUID tenantId, String query) {
+    if (query == null || query.isBlank()) {
+      return List.of();
+    }
+    String pattern = LikePattern.literalContains(query.trim());
+    return partnerRepository.findActiveCustomerIdsByNamePattern(
+        tenantId, pattern, LikePattern.ESCAPE_CHARACTER);
   }
 
   private String displayNameOrFallback(TradingPartner partner) {

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/infra/repository/TradingPartnerRepository.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/infra/repository/TradingPartnerRepository.java
@@ -150,6 +150,30 @@ public interface TradingPartnerRepository extends JpaRepository<TradingPartner, 
       @Param("tenantId") UUID tenantId, @Param("term") String searchTerm);
 
   /**
+   * Find active customer IDs whose tenant-specific or official name contains a literal pattern.
+   *
+   * <p>The caller supplies an escaped contains pattern and its escape character so {@code %} and
+   * {@code _} in user input retain their literal meaning.
+   */
+  @Query(
+      """
+      SELECT tp.id
+      FROM TradingPartner tp
+      JOIN tp.registry registry
+      WHERE tp.tenantId = :tenantId
+        AND tp.isActive = true
+        AND tp.partnerType IN ('CUSTOMER', 'BOTH')
+        AND (
+          LOWER(tp.customName) LIKE LOWER(:pattern) ESCAPE :escapeCharacter
+          OR LOWER(registry.officialName) LIKE LOWER(:pattern) ESCAPE :escapeCharacter
+        )
+      """)
+  List<UUID> findActiveCustomerIdsByNamePattern(
+      @Param("tenantId") UUID tenantId,
+      @Param("pattern") String pattern,
+      @Param("escapeCharacter") char escapeCharacter);
+
+  /**
    * Count partners by type for tenant.
    *
    * @param tenantId Tenant ID

--- a/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/api/QuoteController.java
@@ -6,11 +6,13 @@ import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.sales.quote.app.QuoteApprovalService;
 import com.fabricmanagement.sales.quote.app.QuoteService;
 import com.fabricmanagement.sales.quote.app.SendQuoteResult;
+import com.fabricmanagement.sales.quote.domain.QuoteStatus;
 import com.fabricmanagement.sales.quote.dto.AddQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.GenerateQuoteTokenRequest;
 import com.fabricmanagement.sales.quote.dto.QuoteApprovalTokenDto;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.sales.quote.dto.QuoteSendRequestDto;
+import com.fabricmanagement.sales.quote.dto.QuoteStatusCountsResponse;
 import com.fabricmanagement.sales.quote.dto.RejectQuoteSendRequest;
 import com.fabricmanagement.sales.quote.dto.SendQuoteRequest;
 import com.fabricmanagement.sales.quote.dto.SendQuoteResponse;
@@ -18,6 +20,7 @@ import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.mapper.QuoteMapper;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
@@ -36,6 +39,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -57,9 +61,24 @@ public class QuoteController {
   @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
   @Operation(summary = "List all quotes (paginated)")
   public ResponseEntity<ApiResponse<PagedResponse<QuoteResponse>>> listQuotes(
+      @Parameter(description = "Optional quote status filter") @RequestParam(required = false)
+          QuoteStatus status,
+      @Parameter(
+              description =
+                  "Literal quote-number or customer-name search; trimmed values shorter than two characters are ignored")
+          @RequestParam(required = false)
+          String q,
       @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
     return ResponseEntity.ok(
-        ApiResponse.success(PagedResponse.from(quoteService.findAllResponses(pageable))));
+        ApiResponse.success(
+            PagedResponse.from(quoteService.findAllResponses(status, q, pageable))));
+  }
+
+  @GetMapping("/status-counts")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
+  @Operation(summary = "Count active quotes by status")
+  public ResponseEntity<ApiResponse<QuoteStatusCountsResponse>> getStatusCounts() {
+    return ResponseEntity.ok(ApiResponse.success(quoteService.getStatusCounts()));
   }
 
   @GetMapping("/{quoteId}")

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.sales.quote.app;
 
 import com.fabricmanagement.common.domain.vo.ConvertedMoney;
+import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.common.util.Money;
@@ -40,6 +41,7 @@ import com.fabricmanagement.sales.quote.dto.QuoteLineLotSelectionRequest;
 import com.fabricmanagement.sales.quote.dto.QuoteLineLotSnapshot;
 import com.fabricmanagement.sales.quote.dto.QuoteLineLotSnapshotCodec;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
+import com.fabricmanagement.sales.quote.dto.QuoteStatusCountsResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
@@ -50,6 +52,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneOffset;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -94,8 +97,14 @@ public class QuoteService {
 
   @Transactional(readOnly = true)
   public Page<QuoteResponse> findAllResponses(Pageable pageable) {
+    return findAllResponses(null, null, pageable);
+  }
+
+  @Transactional(readOnly = true)
+  public Page<QuoteResponse> findAllResponses(QuoteStatus status, String query, Pageable pageable) {
     UUID tenantId = TenantContext.requireTenantId();
-    Page<Quote> page = quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable);
+    String normalizedQuery = normalizeSearchQuery(query);
+    Page<Quote> page = findQuotePage(tenantId, status, normalizedQuery, pageable);
     Map<UUID, String> customerNames =
         tradingPartnerResolver.resolveDisplayNames(
             tenantId,
@@ -106,6 +115,43 @@ public class QuoteService {
                 .toList());
     Map<UUID, String> safeCustomerNames = customerNames != null ? customerNames : Map.of();
     return page.map(quote -> toResponse(quote, safeCustomerNames));
+  }
+
+  @Transactional(readOnly = true)
+  public QuoteStatusCountsResponse getStatusCounts() {
+    UUID tenantId = TenantContext.requireTenantId();
+    Map<QuoteStatus, Long> counts = new EnumMap<>(QuoteStatus.class);
+    quoteRepository
+        .countActiveByStatus(tenantId)
+        .forEach(row -> counts.put(row.getStatus(), row.getCount()));
+    return QuoteStatusCountsResponse.from(counts);
+  }
+
+  private Page<Quote> findQuotePage(
+      UUID tenantId, QuoteStatus status, String normalizedQuery, Pageable pageable) {
+    if (normalizedQuery == null) {
+      return status == null
+          ? quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable)
+          : quoteRepository.findAllByTenantIdAndStatusAndIsActiveTrue(tenantId, status, pageable);
+    }
+
+    String pattern = LikePattern.literalContains(normalizedQuery);
+    List<UUID> customerIds =
+        tradingPartnerResolver.findCustomerIdsByNameContains(tenantId, normalizedQuery);
+    if (customerIds.isEmpty()) {
+      return quoteRepository.searchByQuoteNumber(
+          tenantId, status, pattern, LikePattern.ESCAPE_CHARACTER, pageable);
+    }
+    return quoteRepository.searchByQuoteNumberOrCustomerId(
+        tenantId, status, pattern, LikePattern.ESCAPE_CHARACTER, customerIds, pageable);
+  }
+
+  private String normalizeSearchQuery(String query) {
+    if (query == null) {
+      return null;
+    }
+    String trimmed = query.trim();
+    return trimmed.length() >= 2 ? trimmed : null;
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteStatusCountsResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteStatusCountsResponse.java
@@ -1,0 +1,58 @@
+package com.fabricmanagement.sales.quote.dto;
+
+import com.fabricmanagement.sales.quote.domain.QuoteStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+
+@Schema(
+    name = "QuoteStatusCountsResponse",
+    description = "Active quote totals by status for the current tenant")
+public record QuoteStatusCountsResponse(
+    @Schema(description = "DRAFT quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long draft,
+    @Schema(description = "EVALUATION quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long evaluation,
+    @Schema(
+            description = "PENDING_APPROVAL quote count",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        long pendingApproval,
+    @Schema(description = "APPROVED quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long approved,
+    @Schema(description = "REJECTED quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long rejected,
+    @Schema(description = "EXPIRED quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long expired,
+    @Schema(description = "CONVERTED quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long converted,
+    @Schema(description = "SUPERSEDED quote count", requiredMode = Schema.RequiredMode.REQUIRED)
+        long superseded) {
+
+  public static QuoteStatusCountsResponse from(Map<QuoteStatus, Long> counts) {
+    return new QuoteStatusCountsResponse(
+        count(counts, QuoteStatus.DRAFT),
+        count(counts, QuoteStatus.EVALUATION),
+        count(counts, QuoteStatus.PENDING_APPROVAL),
+        count(counts, QuoteStatus.APPROVED),
+        count(counts, QuoteStatus.REJECTED),
+        count(counts, QuoteStatus.EXPIRED),
+        count(counts, QuoteStatus.CONVERTED),
+        count(counts, QuoteStatus.SUPERSEDED));
+  }
+
+  public long countFor(QuoteStatus status) {
+    return switch (status) {
+      case DRAFT -> draft;
+      case EVALUATION -> evaluation;
+      case PENDING_APPROVAL -> pendingApproval;
+      case APPROVED -> approved;
+      case REJECTED -> rejected;
+      case EXPIRED -> expired;
+      case CONVERTED -> converted;
+      case SUPERSEDED -> superseded;
+    };
+  }
+
+  private static long count(Map<QuoteStatus, Long> counts, QuoteStatus status) {
+    return counts.getOrDefault(status, 0L);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepository.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.sales.quote.infra.repository;
 
 import com.fabricmanagement.sales.quote.domain.Quote;
+import com.fabricmanagement.sales.quote.domain.QuoteStatus;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -22,6 +23,61 @@ public interface QuoteRepository extends JpaRepository<Quote, UUID> {
 
   @EntityGraph(attributePaths = "lines")
   Page<Quote> findAllByTenantIdAndIsActiveTrue(UUID tenantId, Pageable pageable);
+
+  @EntityGraph(attributePaths = "lines")
+  Page<Quote> findAllByTenantIdAndStatusAndIsActiveTrue(
+      UUID tenantId, QuoteStatus status, Pageable pageable);
+
+  @EntityGraph(attributePaths = "lines")
+  @Query(
+      """
+      SELECT q FROM Quote q
+      WHERE q.tenantId = :tenantId
+        AND q.isActive = true
+        AND (:status IS NULL OR q.status = :status)
+        AND LOWER(q.quoteNumber) LIKE LOWER(:pattern) ESCAPE :escapeCharacter
+      """)
+  Page<Quote> searchByQuoteNumber(
+      @Param("tenantId") UUID tenantId,
+      @Param("status") QuoteStatus status,
+      @Param("pattern") String pattern,
+      @Param("escapeCharacter") char escapeCharacter,
+      Pageable pageable);
+
+  @EntityGraph(attributePaths = "lines")
+  @Query(
+      """
+      SELECT q FROM Quote q
+      WHERE q.tenantId = :tenantId
+        AND q.isActive = true
+        AND (:status IS NULL OR q.status = :status)
+        AND (
+          LOWER(q.quoteNumber) LIKE LOWER(:pattern) ESCAPE :escapeCharacter
+          OR q.customerId IN :customerIds
+        )
+      """)
+  Page<Quote> searchByQuoteNumberOrCustomerId(
+      @Param("tenantId") UUID tenantId,
+      @Param("status") QuoteStatus status,
+      @Param("pattern") String pattern,
+      @Param("escapeCharacter") char escapeCharacter,
+      @Param("customerIds") List<UUID> customerIds,
+      Pageable pageable);
+
+  @Query(
+      """
+      SELECT q.status AS status, COUNT(q.id) AS count
+      FROM Quote q
+      WHERE q.tenantId = :tenantId AND q.isActive = true
+      GROUP BY q.status
+      """)
+  List<StatusCountProjection> countActiveByStatus(@Param("tenantId") UUID tenantId);
+
+  interface StatusCountProjection {
+    QuoteStatus getStatus();
+
+    Long getCount();
+  }
 
   List<Quote> findAllByTenantIdAndCustomerIdAndIsActiveTrue(UUID tenantId, UUID customerId);
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/LikePatternTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/LikePatternTest.java
@@ -1,0 +1,13 @@
+package com.fabricmanagement.common.infrastructure.persistence;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class LikePatternTest {
+
+  @Test
+  void escapesLikeWildcardsAndEscapeCharacter() {
+    assertEquals("%50\\%\\_off\\\\line%", LikePattern.literalContains("50%_off\\line"));
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolverTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolverTest.java
@@ -2,11 +2,14 @@ package com.fabricmanagement.platform.tradingpartner.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
 import com.fabricmanagement.platform.tradingpartner.infra.repository.TradingPartnerRepository;
 import java.lang.reflect.Field;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -234,6 +237,34 @@ class TradingPartnerResolverTest {
       Optional<TradingPartner> result = resolver.resolvePartner(tenantId, unknownId);
 
       assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("findCustomerIdsByNameContains")
+  class FindCustomerIdsByNameContains {
+
+    @Test
+    @DisplayName("escapes literal wildcards before querying active customer IDs")
+    void escapesLiteralWildcards() {
+      List<UUID> matches = List.of(tradingPartnerId);
+      when(partnerRepository.findActiveCustomerIdsByNamePattern(tenantId, "%Acme\\%\\_%", '\\'))
+          .thenReturn(matches);
+
+      assertThat(resolver.findCustomerIdsByNameContains(tenantId, " Acme%_ "))
+          .containsExactly(tradingPartnerId);
+    }
+
+    @Test
+    @DisplayName("does not query for blank text")
+    void skipsBlankText() {
+      assertThat(resolver.findCustomerIdsByNameContains(tenantId, "  ")).isEmpty();
+
+      verify(partnerRepository, never())
+          .findActiveCustomerIdsByNamePattern(
+              org.mockito.ArgumentMatchers.any(),
+              org.mockito.ArgumentMatchers.any(),
+              org.mockito.ArgumentMatchers.anyChar());
     }
   }
 

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/infra/repository/TradingPartnerRepositoryIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/infra/repository/TradingPartnerRepositoryIntegrationTest.java
@@ -1,0 +1,73 @@
+package com.fabricmanagement.platform.tradingpartner.infra.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.tenant.domain.Tenant;
+import com.fabricmanagement.platform.tenant.infra.repository.TenantRepository;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
+import com.fabricmanagement.platform.tradingpartner.domain.TradingPartnerRegistry;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+class TradingPartnerRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+  @Autowired private TradingPartnerRepository partnerRepository;
+  @Autowired private TradingPartnerRegistryRepository registryRepository;
+  @Autowired private TenantRepository tenantRepository;
+
+  private UUID tenantId;
+
+  @BeforeEach
+  void setUp() {
+    String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 12).toUpperCase();
+    Tenant tenant = Tenant.create("SUX-3b Test Tenant " + suffix, "SUX3B-" + suffix);
+    tenant.activate("test");
+    tenantId = tenantRepository.saveAndFlush(tenant).getId();
+    TenantContext.setCurrentTenantId(tenantId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @Transactional
+  void customerNameSearchReturnsOnlyActiveCustomerAndBothIdsWithLiteralMatching() {
+    TradingPartner customer = partner(PartnerType.CUSTOMER, "Acme%_Customer", true);
+    TradingPartner both = partner(PartnerType.BOTH, null, true, "Acme%_Official");
+    partner(PartnerType.SUPPLIER, "Acme%_Supplier", true);
+    partner(PartnerType.CUSTOMER, "Acme%_Inactive", false);
+    partner(PartnerType.CUSTOMER, "AcmeABWildcard", true);
+
+    var matches =
+        partnerRepository.findActiveCustomerIdsByNamePattern(
+            tenantId, LikePattern.literalContains("Acme%_"), LikePattern.ESCAPE_CHARACTER);
+
+    assertThat(matches).containsExactlyInAnyOrder(customer.getId(), both.getId());
+  }
+
+  private TradingPartner partner(PartnerType type, String customName, boolean active) {
+    return partner(type, customName, active, "Registry " + UUID.randomUUID());
+  }
+
+  private TradingPartner partner(
+      PartnerType type, String customName, boolean active, String officialName) {
+    TradingPartnerRegistry registry = TradingPartnerRegistry.create(null, officialName, "GBR");
+    registry.setUid("REG-" + UUID.randomUUID());
+    registry = registryRepository.save(registry);
+
+    TradingPartner partner = TradingPartner.create(registry, type, customName);
+    partner.setTenantId(tenantId);
+    partner.setIsActive(active);
+    return partnerRepository.saveAndFlush(partner);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -5,7 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyChar;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -57,6 +59,7 @@ import com.fabricmanagement.sales.quote.dto.QuoteLineLotSelectionRequest;
 import com.fabricmanagement.sales.quote.dto.QuoteLineLotSnapshot;
 import com.fabricmanagement.sales.quote.dto.QuoteLineLotSnapshotCodec;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
+import com.fabricmanagement.sales.quote.dto.QuoteStatusCountsResponse;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteLineRequest;
 import com.fabricmanagement.sales.quote.dto.UpdateQuoteRequest;
 import com.fabricmanagement.sales.quote.infra.repository.QuoteRepository;
@@ -172,6 +175,85 @@ class QuoteServiceTest {
     Page<QuoteResponse> page = quoteService.findAllResponses(pageable);
 
     assertNull(page.getContent().get(0).getCustomerName());
+  }
+
+  @Test
+  @DisplayName("Should filter quote list by status without searching partners")
+  void shouldFilterQuoteListByStatus() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(quoteRepository.findAllByTenantIdAndStatusAndIsActiveTrue(
+            tenantId, QuoteStatus.APPROVED, pageable))
+        .thenReturn(Page.empty(pageable));
+
+    quoteService.findAllResponses(QuoteStatus.APPROVED, null, pageable);
+
+    verify(tradingPartnerResolver, never()).findCustomerIdsByNameContains(any(), any());
+  }
+
+  @Test
+  @DisplayName("Should treat a trimmed query shorter than two characters as unfiltered")
+  void shouldTreatShortQueryAsUnfiltered() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable))
+        .thenReturn(Page.empty(pageable));
+
+    quoteService.findAllResponses(null, " a ", pageable);
+
+    verify(quoteRepository).findAllByTenantIdAndIsActiveTrue(tenantId, pageable);
+    verify(tradingPartnerResolver, never()).findCustomerIdsByNameContains(any(), any());
+  }
+
+  @Test
+  @DisplayName("Should search quote number only when no customer IDs match")
+  void shouldSearchQuoteNumberWhenCustomerIdsAreEmpty() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(tradingPartnerResolver.findCustomerIdsByNameContains(tenantId, "50%_"))
+        .thenReturn(List.of());
+    when(quoteRepository.searchByQuoteNumber(tenantId, null, "%50\\%\\_%", '\\', pageable))
+        .thenReturn(Page.empty(pageable));
+
+    quoteService.findAllResponses(null, " 50%_ ", pageable);
+
+    verify(quoteRepository, never())
+        .searchByQuoteNumberOrCustomerId(any(), any(), any(), anyChar(), any(), any());
+  }
+
+  @Test
+  @DisplayName("Should combine status with quote-number or customer-name search")
+  void shouldCombineStatusAndCustomerSearch() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    UUID matchingCustomerId = UUID.randomUUID();
+    when(tradingPartnerResolver.findCustomerIdsByNameContains(tenantId, "Acme"))
+        .thenReturn(List.of(matchingCustomerId));
+    when(quoteRepository.searchByQuoteNumberOrCustomerId(
+            tenantId, QuoteStatus.DRAFT, "%Acme%", '\\', List.of(matchingCustomerId), pageable))
+        .thenReturn(Page.empty(pageable));
+
+    quoteService.findAllResponses(QuoteStatus.DRAFT, "Acme", pageable);
+
+    verify(quoteRepository)
+        .searchByQuoteNumberOrCustomerId(
+            tenantId, QuoteStatus.DRAFT, "%Acme%", '\\', List.of(matchingCustomerId), pageable);
+  }
+
+  @Test
+  @DisplayName("Should zero-fill every quote status count")
+  void shouldZeroFillEveryQuoteStatusCount() {
+    QuoteRepository.StatusCountProjection draft = mock(QuoteRepository.StatusCountProjection.class);
+    QuoteRepository.StatusCountProjection expired =
+        mock(QuoteRepository.StatusCountProjection.class);
+    when(draft.getStatus()).thenReturn(QuoteStatus.DRAFT);
+    when(draft.getCount()).thenReturn(4L);
+    when(expired.getStatus()).thenReturn(QuoteStatus.EXPIRED);
+    when(expired.getCount()).thenReturn(2L);
+    when(quoteRepository.countActiveByStatus(tenantId)).thenReturn(List.of(draft, expired));
+
+    QuoteStatusCountsResponse counts = quoteService.getStatusCounts();
+
+    assertEquals(4L, counts.draft());
+    assertEquals(2L, counts.expired());
+    assertEquals(0L, counts.converted());
+    assertEquals(0L, counts.countFor(QuoteStatus.SUPERSEDED));
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
@@ -3,15 +3,19 @@ package com.fabricmanagement.sales.quote.infra.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
+import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.sales.quote.domain.Quote;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
+import com.fabricmanagement.sales.quote.domain.QuoteStatus;
 import com.fabricmanagement.sales.quote.dto.QuoteResponse;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
 import java.math.BigDecimal;
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -73,12 +77,117 @@ class QuoteRepositoryIntegrationTest extends AbstractIntegrationTest {
         .isEqualByComparingTo(new BigDecimal("12.500"));
   }
 
+  @Test
+  @DisplayName("search is tenant-scoped, active-only, status-aware, and treats wildcards literally")
+  void searchByQuoteNumber_appliesAllGuardsAndLiteralContains() {
+    String suffix = UUID.randomUUID().toString().substring(0, 8);
+    Quote expected = quote(tenantId, "QT-50%_-" + suffix, customerId, QuoteStatus.DRAFT, true);
+    UUID expectedId = persist(expected);
+    persist(quote(tenantId, "QT-50AB-" + suffix, customerId, QuoteStatus.DRAFT, true));
+    persist(quote(tenantId, "QT-50%_-inactive-" + suffix, customerId, QuoteStatus.DRAFT, false));
+    persist(
+        quote(UUID.randomUUID(), "QT-50%_-other-" + suffix, customerId, QuoteStatus.DRAFT, true));
+    persist(quote(tenantId, "QT-50%_-approved-" + suffix, customerId, QuoteStatus.APPROVED, true));
+
+    Page<Quote> result =
+        quoteRepository.searchByQuoteNumber(
+            tenantId,
+            QuoteStatus.DRAFT,
+            LikePattern.literalContains("50%_"),
+            LikePattern.ESCAPE_CHARACTER,
+            PageRequest.of(0, 20));
+
+    assertThat(result.getContent()).extracting(Quote::getId).containsExactly(expectedId);
+  }
+
+  @Test
+  @DisplayName("customer IDs and quote number compose with status in one paged search")
+  void searchByQuoteNumberOrCustomerId_composesWithStatus() {
+    UUID matchedCustomerId = UUID.randomUUID();
+    UUID expectedId =
+        persist(
+            quote(
+                tenantId,
+                "QT-CUSTOMER-" + UUID.randomUUID(),
+                matchedCustomerId,
+                QuoteStatus.DRAFT,
+                true));
+    persist(
+        quote(
+            tenantId,
+            "QT-CUSTOMER-" + UUID.randomUUID(),
+            matchedCustomerId,
+            QuoteStatus.APPROVED,
+            true));
+
+    Page<Quote> result =
+        quoteRepository.searchByQuoteNumberOrCustomerId(
+            tenantId,
+            QuoteStatus.DRAFT,
+            LikePattern.literalContains("no-number-match"),
+            LikePattern.ESCAPE_CHARACTER,
+            java.util.List.of(matchedCustomerId),
+            PageRequest.of(0, 20));
+
+    assertThat(result.getContent()).extracting(Quote::getId).containsExactly(expectedId);
+  }
+
+  @Test
+  @DisplayName("status counts are tenant-scoped and active-only")
+  void countActiveByStatus_isTenantScopedAndActiveOnly() {
+    persist(quote(tenantId, "QT-COUNT-" + UUID.randomUUID(), customerId, QuoteStatus.DRAFT, true));
+    persist(
+        quote(tenantId, "QT-COUNT-" + UUID.randomUUID(), customerId, QuoteStatus.EXPIRED, true));
+    persist(quote(tenantId, "QT-COUNT-" + UUID.randomUUID(), customerId, QuoteStatus.DRAFT, false));
+    persist(
+        quote(
+            UUID.randomUUID(),
+            "QT-COUNT-" + UUID.randomUUID(),
+            customerId,
+            QuoteStatus.DRAFT,
+            true));
+
+    Map<QuoteStatus, Long> counts =
+        quoteRepository.countActiveByStatus(tenantId).stream()
+            .collect(
+                Collectors.toMap(
+                    QuoteRepository.StatusCountProjection::getStatus,
+                    QuoteRepository.StatusCountProjection::getCount));
+
+    assertThat(counts).containsEntry(QuoteStatus.DRAFT, 1L).containsEntry(QuoteStatus.EXPIRED, 1L);
+    assertThat(counts).hasSize(2);
+  }
+
   private UUID persistQuoteWithLine() {
     return transactionTemplate.execute(
         status -> {
           Quote saved = quoteRepository.saveAndFlush(quoteWithLine());
           return saved.getId();
         });
+  }
+
+  private UUID persist(Quote quote) {
+    return transactionTemplate.execute(status -> quoteRepository.saveAndFlush(quote).getId());
+  }
+
+  private Quote quote(
+      UUID quoteTenantId,
+      String quoteNumber,
+      UUID quoteCustomerId,
+      QuoteStatus status,
+      boolean active) {
+    Quote quote = new Quote();
+    quote.setTenantId(quoteTenantId);
+    quote.setQuoteNumber(quoteNumber);
+    quote.setCustomerId(quoteCustomerId);
+    quote.setAssignedToId(assignedToId);
+    quote.setModuleType("FABRIC");
+    quote.setStatus(status);
+    quote.setCurrency("GBP");
+    quote.setValidUntil(LocalDate.now().plusDays(30));
+    quote.setPaymentTerms("NET_30");
+    quote.setActive(active);
+    return quote;
   }
 
   private Quote quoteWithLine() {


### PR DESCRIPTION
SUX-3b backend. GET /sales/quotes gains optional status and q params; q does literal-contains (escaped LIKE, shared LikePattern helper) on quoteNumber and, via TradingPartnerResolver's new ID-only active CUSTOMER/BOTH name search, on customer name — uncapped, empty-IN avoided by branching. Short q (<2 after trim) behaves as no filter.

New GET /sales/quotes/status-counts returns the named QuoteStatusCountsResponse DTO: one required field per QuoteStatus, zero-filled, exhaustive switch so new enum values break compilation instead of silently dropping a chip. All queries explicitly tenant-scoped and active-only.

Tests: repository integration (filters, escaping, tenant isolation), service unit, resolver unit + integration, LikePattern unit; ConstitutionArchTest green; OpenAPI spec regenerated.