### PR TITLE
feat(sales): allow customer and currency change on line-less draft qu…

### DIFF
--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -940,6 +940,27 @@ class QuoteServiceTest {
   }
 
   @Test
+  @DisplayName("Should preserve tenant isolation when updating customer and currency")
+  void shouldPreserveTenantIsolationWhenUpdatingCustomerAndCurrency() {
+    UpdateQuoteRequest req = new UpdateQuoteRequest();
+    req.setCustomerId(UUID.randomUUID());
+    req.setCurrency("USD");
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.empty());
+
+    SalesDomainException ex =
+        assertThrows(
+            SalesDomainException.class, () -> quoteService.updateQuoteHeader(quoteId, req));
+
+    assertEquals("SALES_002_QUOTE_NOT_FOUND", ex.getErrorCode());
+    verify(quoteRepository).findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId);
+    verify(quoteRepository, never()).save(any(Quote.class));
+    verify(tradingPartnerResolver, never()).resolveDisplayNames(eq(tenantId), any());
+    verify(tenantReportingCurrencyPort, never()).getReportingCurrency(any());
+  }
+
+  @Test
   @DisplayName("Should update line quantity and price, re-evaluate zone, and recompute totals")
   void shouldUpdateLineQuantityAndPriceReevaluateZoneAndRecomputeTotals() {
     UUID lineId = UUID.randomUUID();


### PR DESCRIPTION
…otes

DRAFT-FLEX-1 backend. UpdateQuoteRequest gains optional customerId and currency (ISO-4217 validated). assertDraftIdentityEditable guards both: accepted only while status is DRAFT or EVALUATION AND the quote has no lines; otherwise 409 quoteDraftIdentityLocked. Currency change on a line-less quote recomputes the (zero) totals; customer change re-resolves customerName.

Tests: change accepted pre-lines, rejected post-lines, rejected on locked statuses, plus tenant isolation (cross-tenant quote not found — no save, no total recompute, no customer resolution). Full suite 1301 green; OpenAPI spec regenerated.