### PR TITLE
feat(sales): quote retention purge job — abandoned drafts, dead tokens

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -55755,6 +55755,7 @@ components:
           - PENDING
           - USED
           - EXPIRED
+          - REVOKED
         token:
           type: string
         usedAt:

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJob.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJob.java
@@ -14,6 +14,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+/**
+ * Purges quote data that has no business or evidential value.
+ *
+ * <p>{@link Scheduled} methods have no ambient tenant and are therefore blind under RLS. This job
+ * must keep the explicit active-tenant iteration and execute each tenant's deletes through the
+ * privileged {@link SystemTransactionExecutor} inside {@link TenantContext}.
+ */
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,7 +37,8 @@ public class QuoteRetentionPurgeJob {
         AND q.updated_at < ?
         AND NOT EXISTS (
           SELECT 1 FROM sales.quote_line ql
-          WHERE ql.quote_id = q.id
+          WHERE ql.tenant_id = q.tenant_id
+            AND ql.quote_id = q.id
         )
       """;
 
@@ -46,7 +54,7 @@ public class QuoteRetentionPurgeJob {
   private final SystemTransactionExecutor systemExecutor;
   private final Clock clock;
 
-  @Value("${retention.quote.enabled:false}")
+  @Value("${retention.quote.enabled:true}")
   private boolean enabled;
 
   @Value("${retention.quote.abandonedDraftDays:90}")

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteApprovalStatus.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteApprovalStatus.java
@@ -3,5 +3,6 @@ package com.fabricmanagement.sales.quote.domain;
 public enum QuoteApprovalStatus {
   PENDING,
   USED,
-  EXPIRED
+  EXPIRED,
+  REVOKED
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -79,6 +79,11 @@ logging:
 server:
   port: ${LOCAL_SERVER_PORT:8081}
 
+# Retention jobs are opt-in for local development.
+retention:
+  quote:
+    enabled: ${QUOTE_RETENTION_ENABLED:false}
+
 application:
   jwt:
     secret: local-dev-secret-key-must-be-at-least-256-bits-long-for-hs256-algorithm

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -262,6 +262,14 @@ batch:
   certification:
     enforce-on-reserve: ${BATCH_CERT_ENFORCE_ON_RESERVE:true}
 
+# Quote transient-data retention. Local development overrides this to disabled.
+retention:
+  quote:
+    enabled: ${QUOTE_RETENTION_ENABLED:true}
+    abandonedDraftDays: ${QUOTE_RETENTION_ABANDONED_DRAFT_DAYS:90}
+    deadTokenDays: ${QUOTE_RETENTION_DEAD_TOKEN_DAYS:365}
+    cron: ${QUOTE_RETENTION_CRON:0 30 3 * * ?}
+
 # Feature Flags
 feature:
   trading-partner:

--- a/src/main/resources/db/migration/V20260714120000__quote_retention_indexes.sql
+++ b/src/main/resources/db/migration/V20260714120000__quote_retention_indexes.sql
@@ -1,0 +1,7 @@
+CREATE INDEX IF NOT EXISTS idx_quote_retention_abandoned_draft
+    ON sales.quote (tenant_id, updated_at)
+    WHERE status = 'DRAFT';
+
+CREATE INDEX IF NOT EXISTS idx_quote_approval_token_retention_dead
+    ON sales.quote_approval_token (tenant_id, created_at)
+    WHERE status IN ('EXPIRED', 'REVOKED') AND used_at IS NULL;

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJobIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJobIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.fabricmanagement.sales.quote.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.math.BigDecimal;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class QuoteRetentionPurgeJobIntegrationTest extends AbstractIntegrationTest {
+
+  private static final int ABANDONED_DRAFT_DAYS = 90;
+  private static final int DEAD_TOKEN_DAYS = 365;
+
+  @Autowired private QuoteRetentionPurgeJob job;
+  @Autowired private JdbcTemplate jdbc;
+
+  private final UUID tenantA = UUID.randomUUID();
+  private final UUID tenantB = UUID.randomUUID();
+
+  @BeforeEach
+  void setUp() {
+    insertTenant(tenantA, "a");
+    insertTenant(tenantB, "b");
+    ReflectionTestUtils.setField(job, "enabled", true);
+    ReflectionTestUtils.setField(job, "abandonedDraftDays", ABANDONED_DRAFT_DAYS);
+    ReflectionTestUtils.setField(job, "deadTokenDays", DEAD_TOKEN_DAYS);
+  }
+
+  @AfterEach
+  void tearDown() {
+    ReflectionTestUtils.setField(job, "enabled", false);
+    deleteTenantFixtures(tenantA);
+    deleteTenantFixtures(tenantB);
+  }
+
+  /**
+   * Testcontainers connects as a PostgreSQL superuser and therefore bypasses RLS. This test proves
+   * the explicit tenant iteration and retention predicates, not production-role RLS enforcement. A
+   * real-environment smoke check with fabric_system/fabric_app roles remains required.
+   */
+  @Test
+  void purgesEligibleRowsAcrossTwoTenantsAndPreservesBusinessEvidence() {
+    Instant now = Instant.now();
+    Instant staleDraftTime = now.minus(ABANDONED_DRAFT_DAYS + 10L, ChronoUnit.DAYS);
+    Instant staleTokenTime = now.minus(DEAD_TOKEN_DAYS + 10L, ChronoUnit.DAYS);
+    Instant recentTime = now.minus(5, ChronoUnit.DAYS);
+
+    UUID staleEmptyDraftA = insertQuote(tenantA, "DRAFT", staleDraftTime, staleDraftTime);
+    UUID staleDraftWithLine = insertQuote(tenantA, "DRAFT", staleDraftTime, staleDraftTime);
+    insertQuoteLine(tenantA, staleDraftWithLine);
+    UUID recentlyTouchedDraft = insertQuote(tenantA, "DRAFT", staleDraftTime, recentTime);
+    UUID staleApprovedQuote = insertQuote(tenantA, "APPROVED", staleDraftTime, staleDraftTime);
+
+    UUID usedToken =
+        insertToken(tenantA, staleApprovedQuote, "USED", staleTokenTime, staleTokenTime);
+    UUID staleExpiredTokenA =
+        insertToken(tenantA, staleApprovedQuote, "EXPIRED", staleTokenTime, null);
+    UUID staleRevokedToken =
+        insertToken(tenantA, staleApprovedQuote, "REVOKED", staleTokenTime, null);
+    UUID recentExpiredToken = insertToken(tenantA, staleApprovedQuote, "EXPIRED", recentTime, null);
+
+    UUID staleEmptyDraftB = insertQuote(tenantB, "DRAFT", staleDraftTime, staleDraftTime);
+    UUID approvedQuoteB = insertQuote(tenantB, "APPROVED", staleDraftTime, staleDraftTime);
+    UUID staleExpiredTokenB = insertToken(tenantB, approvedQuoteB, "EXPIRED", staleTokenTime, null);
+
+    job.purgeQuotesAndTokens();
+
+    assertThat(rowExists("sales.quote", staleEmptyDraftA)).isFalse();
+    assertThat(rowExists("sales.quote", staleEmptyDraftB)).isFalse();
+    assertThat(rowExists("sales.quote", staleDraftWithLine)).isTrue();
+    assertThat(rowExists("sales.quote", recentlyTouchedDraft)).isTrue();
+    assertThat(rowExists("sales.quote", staleApprovedQuote)).isTrue();
+
+    assertThat(rowExists("sales.quote_approval_token", usedToken)).isTrue();
+    assertThat(rowExists("sales.quote_approval_token", staleExpiredTokenA)).isFalse();
+    assertThat(rowExists("sales.quote_approval_token", staleRevokedToken)).isFalse();
+    assertThat(rowExists("sales.quote_approval_token", recentExpiredToken)).isTrue();
+    assertThat(rowExists("sales.quote_approval_token", staleExpiredTokenB)).isFalse();
+  }
+
+  private void insertTenant(UUID tenantId, String suffix) {
+    String unique = tenantId.toString();
+    jdbc.update(
+        """
+        INSERT INTO common_tenant.common_tenant
+          (id, uid, slug, name, type, billing_email, status, settings, is_active,
+           created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, 'REGULAR', ?, 'ACTIVE', '{}'::jsonb, true, now(), now(), 0)
+        """,
+        tenantId,
+        "RET-" + unique,
+        "ret-quote-" + suffix + "-" + unique,
+        "Quote Retention " + suffix + " " + unique,
+        "retention-" + suffix + "-" + unique + "@example.com");
+  }
+
+  private UUID insertQuote(UUID tenantId, String status, Instant createdAt, Instant updatedAt) {
+    UUID quoteId = UUID.randomUUID();
+    String unique = quoteId.toString();
+    jdbc.update(
+        """
+        INSERT INTO sales.quote
+          (id, tenant_id, uid, quote_number, customer_id, assigned_to_id, module_type,
+           status, valid_until, attachments, is_active, created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, ?, ?, 'FABRIC', ?, current_date + 30, '[]'::jsonb,
+                true, ?, ?, 0)
+        """,
+        quoteId,
+        tenantId,
+        "RET-Q-" + unique,
+        "RET-Q-" + unique,
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        status,
+        Timestamp.from(createdAt),
+        Timestamp.from(updatedAt));
+    return quoteId;
+  }
+
+  private void insertQuoteLine(UUID tenantId, UUID quoteId) {
+    UUID lineId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO sales.quote_line
+          (id, tenant_id, uid, quote_id, product_desc, requested_qty, unit, list_price,
+           offered_price, discount_rate, profit_margin, price_zone, module_specs,
+           is_active, created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, 'Retention fixture', ?, 'METER', ?, ?, ?, ?, 'FREE',
+                '{}'::jsonb, true, now(), now(), 0)
+        """,
+        lineId,
+        tenantId,
+        "RET-QL-" + lineId,
+        quoteId,
+        new BigDecimal("100.000"),
+        new BigDecimal("10.0000"),
+        new BigDecimal("9.0000"),
+        new BigDecimal("0.1000"),
+        new BigDecimal("0.2000"));
+  }
+
+  private UUID insertToken(
+      UUID tenantId, UUID quoteId, String status, Instant createdAt, Instant usedAt) {
+    UUID tokenId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO sales.quote_approval_token
+          (id, tenant_id, uid, quote_id, token, channel, sent_to, expires_at, status,
+           used_at, is_active, created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, ?, 'EMAIL', 'retention@example.com', ?, ?, ?, true, ?, ?, 0)
+        """,
+        tokenId,
+        tenantId,
+        "RET-QT-" + tokenId,
+        quoteId,
+        "retention-token-" + tokenId,
+        Timestamp.from(createdAt.plus(7, ChronoUnit.DAYS)),
+        status,
+        usedAt == null ? null : Timestamp.from(usedAt),
+        Timestamp.from(createdAt),
+        Timestamp.from(createdAt));
+    return tokenId;
+  }
+
+  private boolean rowExists(String table, UUID id) {
+    Integer count =
+        jdbc.queryForObject("SELECT count(*) FROM " + table + " WHERE id = ?", Integer.class, id);
+    return count != null && count == 1;
+  }
+
+  private void deleteTenantFixtures(UUID tenantId) {
+    jdbc.update("DELETE FROM sales.quote_approval_token WHERE tenant_id = ?", tenantId);
+    jdbc.update("DELETE FROM sales.quote_line WHERE tenant_id = ?", tenantId);
+    jdbc.update("DELETE FROM sales.quote WHERE tenant_id = ?", tenantId);
+    jdbc.update("DELETE FROM common_tenant.common_tenant WHERE id = ?", tenantId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJobTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteRetentionPurgeJobTest.java
@@ -14,6 +14,7 @@ import java.sql.Timestamp;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
@@ -64,14 +65,21 @@ class QuoteRetentionPurgeJobTest {
   @Test
   void scheduledJobIteratesAllActiveTenantsInTenantContext() {
     ReflectionTestUtils.setField(job, "enabled", true);
+    List<UUID> observedTenantContexts = new ArrayList<>();
     when(systemExecutor.executeQuery(eq(QuoteRetentionPurgeJob.ACTIVE_TENANTS_SQL), any()))
         .thenReturn(List.of(TENANT_A, TENANT_B));
-    when(systemExecutor.executeInTransaction(any())).thenAnswer(invocation -> runSql(invocation));
+    when(systemExecutor.executeInTransaction(any()))
+        .thenAnswer(
+            invocation -> {
+              observedTenantContexts.add(TenantContext.requireTenantId());
+              return runSql(invocation);
+            });
     when(jdbcTemplate.update(any(String.class), any(), any(Timestamp.class))).thenReturn(1);
 
     job.purgeQuotesAndTokens();
 
     verify(systemExecutor, times(2)).executeInTransaction(any());
+    assertThat(observedTenantContexts).containsExactly(TENANT_A, TENANT_B);
     assertThat(TenantContext.getCurrentTenantIdOrNull()).isNull();
   }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -42,6 +42,10 @@ management:
       export:
         enabled: false
 
+retention:
+  quote:
+    enabled: false
+
 # OpenApiExportIT requires springdoc enabled to fetch /api-docs.yaml.
 # Default profile disables it for security (CVE mitigations for swagger-ui/DOMPurify).
 springdoc:


### PR DESCRIPTION
RET-1. Daily 03:30 scheduled job implementing the data-retention policy for sales: hard-deletes DRAFT quotes with no lines untouched for retention.quote.abandonedDraftDays (default 90), and unused EXPIRED/REVOKED approval tokens older than retention.quote.deadTokenDays (default 365). USED tokens are approval evidence and never touched.

@Scheduled is RLS-blind, so the job iterates active tenants explicitly and runs each tenant's deletes through SystemTransactionExecutor inside TenantContext; delete SQL additionally carries explicit tenant_id. Partial indexes added matching both delete predicates. Job disabled in local/test profiles; per-tenant info logging only when something was deleted. REVOKED added to QuoteApprovalStatus for the retention rule (no flow sets it yet — future revoke support).

Tests: predicate unit tests (survivors vs deletions, USED immortal) and a two-tenant Testcontainers integration test proving the iteration logic. NOTE: Testcontainers runs as superuser and bypasses RLS — a real environment smoke check under the fabric_system role is still required.