### PR TITLE
feat(color): dedicated colors RBAC resource and explicit API contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29701,6 +29701,9 @@ paths:
       tags:
       - Color
     put:
+      description: "Full replacement: code and name are required; omitted nullable\
+        \ fields are cleared. Omitted colorType and colorFamily resolve to DYED and\
+        \ UNDEFINED. The standard lifecycle changes only through approve/revert endpoints."
       operationId: updateColor
       parameters:
       - in: path
@@ -29773,7 +29776,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
-      summary: Update a color card
+      summary: Replace a color card's mutable state
       tags:
       - Color
   /api/v1/production/colors/{id}/activate:
@@ -48663,6 +48666,8 @@ components:
           format: int32
     ColorDto:
       type: object
+      description: Complete color-card representation. Every property is present;
+        optional values are explicit nulls.
       properties:
         active:
           type: boolean
@@ -48689,7 +48694,9 @@ components:
           - MULTI
           - UNDEFINED
         colorHex:
-          type: string
+          type:
+          - string
+          - "null"
           description: Screen approximation only; never an authoritative colour standard
         colorType:
           type: string
@@ -48702,16 +48709,21 @@ components:
           - PFD
           - GREIGE
         deltaEFormula:
-          type: string
-          description: Formula used to calculate Delta-E against the target
+          type:
+          - string
+          - "null"
+          description: Formula used to calculate Delta-E; null when no tolerance is
+            configured
           enum:
           - CIE76
           - CIE94
           - CIEDE2000
           - CMC_2_1
         deltaETolerance:
-          type: number
-          description: Maximum accepted Delta-E; requires a target and a formula
+          type:
+          - number
+          - "null"
+          description: Maximum accepted Delta-E; null when no tolerance is configured
         id:
           type: string
           format: uuid
@@ -48720,16 +48732,24 @@ components:
           type: string
           description: "Human-readable color-card name, stored trimmed"
         notes:
-          type: string
+          type:
+          - string
+          - "null"
           description: Optional internal notes about the color card
         pantoneCode:
-          type: string
+          type:
+          - string
+          - "null"
           description: "Optional external Pantone reference, stored trimmed and uppercase"
         pantoneLabel:
-          type: string
+          type:
+          - string
+          - "null"
           description: Display-ready Pantone reference such as '19-4024 TCX'
         pantoneSystem:
-          type: string
+          type:
+          - string
+          - "null"
           description: Pantone carrier system; null when no Pantone reference exists
           enum:
           - TCX
@@ -48745,14 +48765,23 @@ components:
           - DRAFT
           - APPROVED
         targetLabA:
-          type: number
-          description: "Target CIE Lab green-red axis a*, from -128 to 127"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab green-red axis a*, from -128 to 127; null with\
+            \ no target"
         targetLabB:
-          type: number
-          description: "Target CIE Lab blue-yellow axis b*, from -128 to 127"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab blue-yellow axis b*, from -128 to 127; null\
+            \ with no target"
         targetLabIlluminant:
-          type: string
-          description: Illuminant under which the target Lab values are defined
+          type:
+          - string
+          - "null"
+          description: Illuminant under which the target Lab values are defined; null
+            with no target
           enum:
           - D65
           - D50
@@ -48760,15 +48789,40 @@ components:
           - F11
           - TL84
         targetLabL:
-          type: number
-          description: "Target CIE Lab lightness L*, from 0 to 100; not a measured\
-            \ batch value"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab lightness L*, from 0 to 100; null when no target\
+            \ is defined"
         targetLabObserver:
-          type: string
-          description: Standard observer angle used for the target Lab values
+          type:
+          - string
+          - "null"
+          description: Standard observer angle used for the target Lab values; null
+            with no target
           enum:
           - DEG_2
           - DEG_10
+      required:
+      - active
+      - code
+      - colorFamily
+      - colorHex
+      - colorType
+      - deltaEFormula
+      - deltaETolerance
+      - id
+      - name
+      - notes
+      - pantoneCode
+      - pantoneLabel
+      - pantoneSystem
+      - standardStatus
+      - targetLabA
+      - targetLabB
+      - targetLabIlluminant
+      - targetLabL
+      - targetLabObserver
     CompanyTypeOptionDto:
       type: object
       properties:
@@ -59059,6 +59113,10 @@ components:
       - changeReason
     UpdateColorRequest:
       type: object
+      description: "Full replacement of mutable color-card state. Code and name are\
+        \ required; omitted nullable values are cleared, colorType defaults to DYED,\
+        \ and colorFamily defaults to UNDEFINED. standardStatus is changed only through\
+        \ transition endpoints."
       properties:
         code:
           type: string
@@ -59066,8 +59124,10 @@ components:
           maxLength: 50
           minLength: 0
         colorFamily:
-          type: string
-          description: Visual family; omission resolves to UNDEFINED
+          type:
+          - string
+          - "null"
+          description: Visual family; omission or null resolves to UNDEFINED
           enum:
           - RED
           - ORANGE
@@ -59084,12 +59144,17 @@ components:
           - MULTI
           - UNDEFINED
         colorHex:
-          type: string
-          description: Screen approximation only; omission clears the stored approximation
+          type:
+          - string
+          - "null"
+          description: Screen approximation only; omission or null clears the stored
+            approximation
           pattern: "^#[0-9A-Fa-f]{6}$"
         colorType:
-          type: string
-          description: Process classification; omission resolves to DYED
+          type:
+          - string
+          - "null"
+          description: Process classification; omission or null resolves to DYED
           enum:
           - DYED
           - YARN_DYED
@@ -59098,16 +59163,22 @@ components:
           - PFD
           - GREIGE
         deltaEFormula:
-          type: string
-          description: Delta-E calculation formula; valid only with a tolerance
+          type:
+          - string
+          - "null"
+          description: Delta-E formula; omission or null defaults to CMC_2_1 when
+            a tolerance is supplied and is cleared otherwise
           enum:
           - CIE76
           - CIE94
           - CIEDE2000
           - CMC_2_1
         deltaETolerance:
-          type: number
-          description: Maximum accepted Delta-E; omission clears tolerance and formula
+          type:
+          - number
+          - "null"
+          description: Maximum accepted Delta-E; omission or null clears both tolerance
+            and formula
           maximum: 99.99
         name:
           type: string
@@ -59115,20 +59186,26 @@ components:
           maxLength: 255
           minLength: 0
         notes:
-          type: string
-          description: Optional internal notes; omission clears notes
+          type:
+          - string
+          - "null"
+          description: "Optional internal notes; omission, null, or blank clears notes"
           maxLength: 1000
           minLength: 0
         pantoneCode:
-          type: string
-          description: External Pantone reference; omission clears it; stored trimmed
-            and uppercase
+          type:
+          - string
+          - "null"
+          description: "External Pantone reference; omission, null, or blank clears\
+            \ it; stored trimmed and uppercase"
           maxLength: 20
           minLength: 0
         pantoneSystem:
-          type: string
-          description: Pantone carrier system; omission clears it when no code is
-            supplied
+          type:
+          - string
+          - "null"
+          description: "Pantone carrier system; omission or null defaults to TCX when\
+            \ pantoneCode is supplied, otherwise it is cleared"
           enum:
           - TCX
           - TPG
@@ -59136,19 +59213,27 @@ components:
           - TN
           - TSX
         targetLabA:
-          type: number
-          description: "Target CIE Lab green-red axis a*, from -128 to 127"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab green-red axis a*, from -128 to 127; supplied\
+            \ with all target fields"
           maximum: 127
           minimum: -128
         targetLabB:
-          type: number
-          description: "Target CIE Lab blue-yellow axis b*, from -128 to 127"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab blue-yellow axis b*, from -128 to 127; supplied\
+            \ with all target fields"
           maximum: 127
           minimum: -128
         targetLabIlluminant:
-          type: string
+          type:
+          - string
+          - "null"
           description: Illuminant defining the target Lab values; supplied with all
-            Lab fields
+            target fields
           enum:
           - D65
           - D50
@@ -59156,15 +59241,19 @@ components:
           - F11
           - TL84
         targetLabL:
-          type: number
-          description: "Target CIE Lab lightness L*, from 0 to 100; omission clears\
-            \ target Lab"
+          type:
+          - number
+          - "null"
+          description: "Target CIE Lab lightness L*, from 0 to 100; omit or null all\
+            \ five target fields to clear the target"
           maximum: 100
           minimum: 0
         targetLabObserver:
-          type: string
+          type:
+          - string
+          - "null"
           description: Observer angle defining the target Lab values; supplied with
-            all Lab fields
+            all target fields
           enum:
           - DEG_2
           - DEG_10

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeeder.java
@@ -192,6 +192,9 @@ public class PermissionTemplateSeeder {
             new String[] {"MANAGER", "reports", "export", "DEPARTMENT"},
             new String[] {"WORKER", "finance", "read", "OWN"},
             new String[] {"SUPERVISOR", "finance", "read", "DEPARTMENT"},
+            new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "finance", "read", "ORGANIZATION"}));
 
     // 3. Production sub-departments (FIBER, YARN, WEAVING, KNITTING, DYEING, GARMENT)
@@ -213,7 +216,11 @@ public class PermissionTemplateSeeder {
             new String[] {"MANAGER", "products", "write", "DEPARTMENT"},
             new String[] {"MANAGER", "projects", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "projects", "write", "DEPARTMENT"},
-            new String[] {"MANAGER", "projects", "manage", "DEPARTMENT"});
+            new String[] {"MANAGER", "projects", "manage", "DEPARTMENT"},
+            // COLOR-RBAC-1: every production department reads tenant colour cards.
+            new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "read", "ORGANIZATION"});
     for (String deptCode :
         List.of(
             SystemDepartment.FIBER.code(),
@@ -224,6 +231,15 @@ public class PermissionTemplateSeeder {
             SystemDepartment.GARMENT.code())) {
       seedDepartment(templates, deptCode, productionRules);
     }
+
+    // COLOR-RBAC-1: only the Dyeing department gets colour write by template; every other
+    // production department stays read-only, so this cannot live in the shared productionRules.
+    seedDepartment(
+        templates,
+        SystemDepartment.DYEING.code(),
+        List.of(
+            new String[] {"SUPERVISOR", "colors", "write", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "write", "ORGANIZATION"}));
 
     // 4. QUALITY
     seedDepartment(
@@ -238,6 +254,13 @@ public class PermissionTemplateSeeder {
             new String[] {"MANAGER", "fiber", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "products", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "products", "write", "DEPARTMENT"},
+            new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "write", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "write", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "approve", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "manage", "ORGANIZATION"},
             new String[] {"MANAGER", "reports", "export", "DEPARTMENT"}));
 
     // 5. WAREHOUSE
@@ -266,6 +289,9 @@ public class PermissionTemplateSeeder {
             new String[] {"MANAGER", "logistics", "prepare", "DEPARTMENT"},
             new String[] {"MANAGER", "logistics", "ship", "ORGANIZATION"},
             new String[] {"MANAGER", "logistics", "deliver", "ORGANIZATION"},
+            new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "logistics", "cancel", "ORGANIZATION"}));
 
     // 6. FINANCE
@@ -330,6 +356,9 @@ public class PermissionTemplateSeeder {
             new String[] {"MANAGER", "partners", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "partners", "write", "DEPARTMENT"},
             new String[] {"MANAGER", "products", "read", "ORGANIZATION"},
+            new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "colors", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "products", "write", "DEPARTMENT"}));
 
     // 9. PARTNER roles — visible only in partner invitation UIs

--- a/src/main/java/com/fabricmanagement/common/infrastructure/security/PermissionRegistry.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/security/PermissionRegistry.java
@@ -19,6 +19,7 @@ public final class PermissionRegistry {
           "fiber",
           "projects",
           "products",
+          "colors",
           "partners",
           "procurement",
           "flowboard",

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorController.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorController.java
@@ -41,7 +41,7 @@ public class ColorController {
   private final ColorMapper colorMapper;
 
   @GetMapping
-  @PreAuthorize("@auth.can(authentication, 'products', 'read')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'read')")
   @Operation(
       operationId = "listColors",
       summary = "List color cards",
@@ -72,14 +72,14 @@ public class ColorController {
   }
 
   @GetMapping("/{id}")
-  @PreAuthorize("@auth.can(authentication, 'products', 'read')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'read')")
   @Operation(operationId = "findColorById", summary = "Get a color card by ID")
   public ResponseEntity<ApiResponse<ColorDto>> findById(@PathVariable UUID id) {
     return ResponseEntity.ok(ApiResponse.success(colorMapper.toDto(colorService.findById(id))));
   }
 
   @PostMapping
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
   @Operation(operationId = "createColor", summary = "Create a color card")
   public ResponseEntity<ApiResponse<ColorDto>> create(
       @Valid @RequestBody CreateColorRequest request) {
@@ -88,8 +88,14 @@ public class ColorController {
   }
 
   @PutMapping("/{id}")
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
-  @Operation(operationId = "updateColor", summary = "Update a color card")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "updateColor",
+      summary = "Replace a color card's mutable state",
+      description =
+          "Full replacement: code and name are required; omitted nullable fields are cleared. "
+              + "Omitted colorType and colorFamily resolve to DYED and UNDEFINED. "
+              + "The standard lifecycle changes only through approve/revert endpoints.")
   public ResponseEntity<ApiResponse<ColorDto>> update(
       @PathVariable UUID id, @Valid @RequestBody UpdateColorRequest request) {
     return ResponseEntity.ok(
@@ -97,21 +103,21 @@ public class ColorController {
   }
 
   @PostMapping("/{id}/deactivate")
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'manage')")
   @Operation(operationId = "deactivateColor", summary = "Deactivate a color card")
   public ResponseEntity<ApiResponse<ColorDto>> deactivate(@PathVariable UUID id) {
     return ResponseEntity.ok(ApiResponse.success(colorMapper.toDto(colorService.deactivate(id))));
   }
 
   @PostMapping("/{id}/activate")
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'manage')")
   @Operation(operationId = "activateColor", summary = "Reactivate a deactivated color card")
   public ResponseEntity<ApiResponse<ColorDto>> activate(@PathVariable UUID id) {
     return ResponseEntity.ok(ApiResponse.success(colorMapper.toDto(colorService.activate(id))));
   }
 
   @PostMapping("/{id}/approve")
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'approve')")
   @Operation(
       operationId = "approveColorStandard",
       summary = "Approve the card's shade standard, freezing its standard-defining fields")
@@ -120,7 +126,7 @@ public class ColorController {
   }
 
   @PostMapping("/{id}/revert-to-draft")
-  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'approve')")
   @Operation(
       operationId = "revertColorStandardToDraft",
       summary = "Reopen the card's shade standard for editing")

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorDto.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorDto.java
@@ -7,41 +7,105 @@ import com.fabricmanagement.production.masterdata.color.domain.DeltaEFormula;
 import com.fabricmanagement.production.masterdata.color.domain.LabIlluminant;
 import com.fabricmanagement.production.masterdata.color.domain.LabObserver;
 import com.fabricmanagement.production.masterdata.color.domain.PantoneSystem;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.util.UUID;
 
+@Schema(
+    description =
+        "Complete color-card representation. Every property is present; optional values are explicit nulls.")
+@JsonInclude(JsonInclude.Include.ALWAYS)
 public record ColorDto(
-    @Schema(description = "Tenant-owned color-card identifier") UUID id,
-    @Schema(description = "Canonical tenant-unique code, stored trimmed and uppercase") String code,
-    @Schema(description = "Human-readable color-card name, stored trimmed") String name,
-    @Schema(description = "Screen approximation only; never an authoritative colour standard")
+    @Schema(
+            description = "Tenant-owned color-card identifier",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID id,
+    @Schema(
+            description = "Canonical tenant-unique code, stored trimmed and uppercase",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String code,
+    @Schema(
+            description = "Human-readable color-card name, stored trimmed",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String name,
+    @Schema(
+            description = "Screen approximation only; never an authoritative colour standard",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         String colorHex,
-    @Schema(description = "Process classification of the color card") ColorType colorType,
-    @Schema(description = "Optional external Pantone reference, stored trimmed and uppercase")
+    @Schema(
+            description = "Process classification of the color card",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        ColorType colorType,
+    @Schema(
+            description = "Optional external Pantone reference, stored trimmed and uppercase",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         String pantoneCode,
-    @Schema(description = "Pantone carrier system; null when no Pantone reference exists")
+    @Schema(
+            description = "Pantone carrier system; null when no Pantone reference exists",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         PantoneSystem pantoneSystem,
-    @Schema(description = "Display-ready Pantone reference such as '19-4024 TCX'")
+    @Schema(
+            description = "Display-ready Pantone reference such as '19-4024 TCX'",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         String pantoneLabel,
-    @Schema(description = "Visual family used for classification and filtering")
+    @Schema(
+            description = "Visual family used for classification and filtering",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         ColorFamily colorFamily,
-    @Schema(description = "Target CIE Lab lightness L*, from 0 to 100; not a measured batch value")
+    @Schema(
+            description =
+                "Target CIE Lab lightness L*, from 0 to 100; null when no target is defined",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         BigDecimal targetLabL,
-    @Schema(description = "Target CIE Lab green-red axis a*, from -128 to 127")
+    @Schema(
+            description = "Target CIE Lab green-red axis a*, from -128 to 127; null with no target",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         BigDecimal targetLabA,
-    @Schema(description = "Target CIE Lab blue-yellow axis b*, from -128 to 127")
+    @Schema(
+            description =
+                "Target CIE Lab blue-yellow axis b*, from -128 to 127; null with no target",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         BigDecimal targetLabB,
-    @Schema(description = "Illuminant under which the target Lab values are defined")
+    @Schema(
+            description =
+                "Illuminant under which the target Lab values are defined; null with no target",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         LabIlluminant targetLabIlluminant,
-    @Schema(description = "Standard observer angle used for the target Lab values")
+    @Schema(
+            description =
+                "Standard observer angle used for the target Lab values; null with no target",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         LabObserver targetLabObserver,
-    @Schema(description = "Maximum accepted Delta-E; requires a target and a formula")
+    @Schema(
+            description = "Maximum accepted Delta-E; null when no tolerance is configured",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         BigDecimal deltaETolerance,
-    @Schema(description = "Formula used to calculate Delta-E against the target")
+    @Schema(
+            description = "Formula used to calculate Delta-E; null when no tolerance is configured",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
         DeltaEFormula deltaEFormula,
-    @Schema(description = "Shade-standard lifecycle state; changed only by transition endpoints")
+    @Schema(
+            description = "Shade-standard lifecycle state; changed only by transition endpoints",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         ColorStandardStatus standardStatus,
-    @Schema(description = "Optional internal notes about the color card") String notes,
-    @Schema(description = "Whether the color card is active; false means soft-deleted")
+    @Schema(
+            description = "Optional internal notes about the color card",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
+        String notes,
+    @Schema(
+            description = "Whether the color card is active; false means soft-deleted",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         boolean active) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorRequest.java
@@ -17,12 +17,16 @@ import jakarta.validation.constraints.Size;
 import java.math.BigDecimal;
 
 /**
- * Full replacement of the card's mutable state: an absent field clears its column.
+ * Full replacement of the card's mutable state. Code and name are required; omitted nullable fields
+ * clear their values, while omitted type and family resolve to their documented domain defaults.
  *
  * <p>No {@code standardStatus}: sign-off moves through {@code /approve} and {@code
  * /revert-to-draft}, never as a side effect of an edit. While APPROVED, the standard-defining
  * fields are frozen.
  */
+@Schema(
+    description =
+        "Full replacement of mutable color-card state. Code and name are required; omitted nullable values are cleared, colorType defaults to DYED, and colorFamily defaults to UNDEFINED. standardStatus is changed only through transition endpoints.")
 public record UpdateColorRequest(
     @Schema(
             description = "Tenant-unique code; trimmed and normalized to uppercase",
@@ -38,44 +42,77 @@ public record UpdateColorRequest(
         @NotBlank
         @Size(max = 255)
         String name,
-    @Schema(description = "Screen approximation only; omission clears the stored approximation")
-        @Pattern(regexp = "^#[0-9A-Fa-f]{6}$")
-        String colorHex,
-    @Schema(description = "Process classification; omission resolves to DYED") ColorType colorType,
     @Schema(
             description =
-                "External Pantone reference; omission clears it; stored trimmed and uppercase",
+                "Screen approximation only; omission or null clears the stored approximation",
+            nullable = true)
+        @Pattern(regexp = "^#[0-9A-Fa-f]{6}$")
+        String colorHex,
+    @Schema(
+            description = "Process classification; omission or null resolves to DYED",
+            nullable = true)
+        ColorType colorType,
+    @Schema(
+            description =
+                "External Pantone reference; omission, null, or blank clears it; stored trimmed and uppercase",
+            nullable = true,
             maxLength = 20)
         @Size(max = 20)
         String pantoneCode,
-    @Schema(description = "Pantone carrier system; omission clears it when no code is supplied")
+    @Schema(
+            description =
+                "Pantone carrier system; omission or null defaults to TCX when pantoneCode is supplied, otherwise it is cleared",
+            nullable = true)
         PantoneSystem pantoneSystem,
-    @Schema(description = "Visual family; omission resolves to UNDEFINED") ColorFamily colorFamily,
-    @Schema(description = "Target CIE Lab lightness L*, from 0 to 100; omission clears target Lab")
+    @Schema(description = "Visual family; omission or null resolves to UNDEFINED", nullable = true)
+        ColorFamily colorFamily,
+    @Schema(
+            description =
+                "Target CIE Lab lightness L*, from 0 to 100; omit or null all five target fields to clear the target",
+            nullable = true)
         @DecimalMin("0")
         @DecimalMax("100")
         BigDecimal targetLabL,
-    @Schema(description = "Target CIE Lab green-red axis a*, from -128 to 127")
+    @Schema(
+            description =
+                "Target CIE Lab green-red axis a*, from -128 to 127; supplied with all target fields",
+            nullable = true)
         @DecimalMin("-128")
         @DecimalMax("127")
         BigDecimal targetLabA,
-    @Schema(description = "Target CIE Lab blue-yellow axis b*, from -128 to 127")
+    @Schema(
+            description =
+                "Target CIE Lab blue-yellow axis b*, from -128 to 127; supplied with all target fields",
+            nullable = true)
         @DecimalMin("-128")
         @DecimalMax("127")
         BigDecimal targetLabB,
-    @Schema(description = "Illuminant defining the target Lab values; supplied with all Lab fields")
+    @Schema(
+            description =
+                "Illuminant defining the target Lab values; supplied with all target fields",
+            nullable = true)
         LabIlluminant targetLabIlluminant,
     @Schema(
             description =
-                "Observer angle defining the target Lab values; supplied with all Lab fields")
+                "Observer angle defining the target Lab values; supplied with all target fields",
+            nullable = true)
         LabObserver targetLabObserver,
-    @Schema(description = "Maximum accepted Delta-E; omission clears tolerance and formula")
+    @Schema(
+            description =
+                "Maximum accepted Delta-E; omission or null clears both tolerance and formula",
+            nullable = true)
         @Positive
         @DecimalMax("99.99")
         BigDecimal deltaETolerance,
-    @Schema(description = "Delta-E calculation formula; valid only with a tolerance")
+    @Schema(
+            description =
+                "Delta-E formula; omission or null defaults to CMC_2_1 when a tolerance is supplied and is cleared otherwise",
+            nullable = true)
         DeltaEFormula deltaEFormula,
-    @Schema(description = "Optional internal notes; omission clears notes", maxLength = 1000)
+    @Schema(
+            description = "Optional internal notes; omission, null, or blank clears notes",
+            nullable = true,
+            maxLength = 1000)
         @Size(max = 1000)
         String notes) {
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederSystemDepartmentTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederSystemDepartmentTest.java
@@ -78,6 +78,24 @@ class PermissionTemplateSeederSystemDepartmentTest {
                 "MANAGER", "products", "read", DataScope.ORGANIZATION),
             org.assertj.core.groups.Tuple.tuple(
                 "MANAGER", "products", "write", DataScope.DEPARTMENT));
+
+    assertThat(savedTemplates)
+        .filteredOn(
+            template -> SystemDepartment.PROCUREMENT.code().equals(template.getDepartmentCode()))
+        .extracting(
+            PermissionTemplate::getRoleCode,
+            PermissionTemplate::getResource,
+            PermissionTemplate::getAction,
+            PermissionTemplate::getDataScope)
+        .contains(
+            org.assertj.core.groups.Tuple.tuple("WORKER", "colors", "read", DataScope.ORGANIZATION),
+            org.assertj.core.groups.Tuple.tuple(
+                "MANAGER", "colors", "read", DataScope.ORGANIZATION))
+        .doesNotContain(
+            org.assertj.core.groups.Tuple.tuple(
+                "SUPERVISOR", "colors", "write", DataScope.ORGANIZATION),
+            org.assertj.core.groups.Tuple.tuple(
+                "MANAGER", "colors", "write", DataScope.ORGANIZATION));
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederTest.java
@@ -141,6 +141,75 @@ class PermissionTemplateSeederTest {
             Tuple.tuple("SUPERVISOR", null, "sales", "approve", DataScope.ORGANIZATION));
   }
 
+  @Test
+  @DisplayName("COLOR-RBAC-1: colours matrix is ORGANIZATION-scoped with the right grants/absences")
+  void seedsColourMatrix() {
+    List<PermissionTemplate> saved = new ArrayList<>();
+    seeder(List.of(), saved).seed();
+
+    List<PermissionTemplate> colours =
+        saved.stream().filter(t -> "colors".equals(t.getResource())).toList();
+
+    assertThat(colours)
+        .as("colour cards are tenant-wide master data")
+        .isNotEmpty()
+        .allSatisfy(t -> assertThat(t.getDataScope()).isEqualTo(DataScope.ORGANIZATION));
+
+    List<Tuple> grants =
+        colours.stream()
+            .map(t -> Tuple.tuple(t.getRoleCode(), t.getDepartmentCode(), t.getAction()))
+            .toList();
+
+    // Quality: worker read; supervisor read+write; manager full.
+    assertThat(grants)
+        .contains(
+            Tuple.tuple("WORKER", "QUALITY", "read"),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "read"),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "write"),
+            Tuple.tuple("MANAGER", "QUALITY", "read"),
+            Tuple.tuple("MANAGER", "QUALITY", "write"),
+            Tuple.tuple("MANAGER", "QUALITY", "approve"),
+            Tuple.tuple("MANAGER", "QUALITY", "manage"))
+        .doesNotContain(
+            Tuple.tuple("WORKER", "QUALITY", "write"),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "approve"),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "manage"));
+
+    // Dyeing supervisor/manager write; dyeing worker read only.
+    assertThat(grants)
+        .contains(
+            Tuple.tuple("WORKER", "DYEING", "read"),
+            Tuple.tuple("SUPERVISOR", "DYEING", "write"),
+            Tuple.tuple("MANAGER", "DYEING", "write"))
+        .doesNotContain(Tuple.tuple("WORKER", "DYEING", "write"));
+
+    // Non-dyeing production departments read only (e.g. WEAVING).
+    assertThat(grants)
+        .contains(Tuple.tuple("SUPERVISOR", "WEAVING", "read"))
+        .doesNotContain(
+            Tuple.tuple("SUPERVISOR", "WEAVING", "write"),
+            Tuple.tuple("MANAGER", "WEAVING", "write"));
+
+    // Sales, Warehouse & Procurement read only.
+    assertThat(grants)
+        .contains(
+            Tuple.tuple("WORKER", "SALES", "read"),
+            Tuple.tuple("MANAGER", "WAREHOUSE", "read"),
+            Tuple.tuple("MANAGER", "PROCUREMENT", "read"))
+        .doesNotContain(
+            Tuple.tuple("MANAGER", "SALES", "write"),
+            Tuple.tuple("MANAGER", "WAREHOUSE", "write"),
+            Tuple.tuple("MANAGER", "PROCUREMENT", "write"));
+
+    // Finance, HR and partner roles receive no colours rows at all.
+    assertThat(colours)
+        .noneMatch(
+            t ->
+                "FINANCE".equals(t.getDepartmentCode())
+                    || "HR".equals(t.getDepartmentCode())
+                    || t.getRoleCode().startsWith("PARTNER_"));
+  }
+
   private static PermissionTemplate template(
       String roleCode, String departmentCode, String resource, String action, DataScope scope) {
     PermissionTemplate template =

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/PermissionTemplateBackfillIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/PermissionTemplateBackfillIT.java
@@ -94,6 +94,12 @@ class PermissionTemplateBackfillIT {
         .withFailMessage("the generic backfill must subsume the old finance-only backfill")
         .isGreaterThan(0);
 
+    // COLOR-RBAC-1: the dedicated colours resource reaches existing tenants through the same path.
+    assertThat(countOf(crippled, "colors", "read")).isGreaterThan(0);
+    assertThat(countOf(crippled, "colors", "write")).isGreaterThan(0);
+    assertThat(countOf(crippled, "colors", "approve")).isGreaterThan(0);
+    assertThat(countOf(crippled, "colors", "manage")).isGreaterThan(0);
+
     // A tenant that never existed before the fix still gets the full set.
     assertThat(countOf(healthy, "sales", "read")).isGreaterThan(0);
 

--- a/src/test/java/com/fabricmanagement/common/infrastructure/security/PermissionRegistryTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/security/PermissionRegistryTest.java
@@ -1,0 +1,31 @@
+package com.fabricmanagement.common.infrastructure.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** COLOR-RBAC-1: {@code colors} must be a valid resource without widening the action catalogue. */
+class PermissionRegistryTest {
+
+  @Test
+  void colorsIsAValidResource() {
+    assertThat(PermissionRegistry.isValidResource("colors")).isTrue();
+  }
+
+  @Test
+  void theFourColourActionsRemainValid() {
+    assertThat(PermissionRegistry.isValidAction("read")).isTrue();
+    assertThat(PermissionRegistry.isValidAction("write")).isTrue();
+    assertThat(PermissionRegistry.isValidAction("approve")).isTrue();
+    assertThat(PermissionRegistry.isValidAction("manage")).isTrue();
+  }
+
+  @Test
+  void unknownResourceOrActionStaysRejected() {
+    assertThat(PermissionRegistry.isValidResource("colours")).isFalse();
+    assertThat(PermissionRegistry.isValidResource("color")).isFalse();
+    assertThat(PermissionRegistry.isValidResource(null)).isFalse();
+    assertThat(PermissionRegistry.isValidAction("paint")).isFalse();
+    assertThat(PermissionRegistry.isValidAction(null)).isFalse();
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/api/ColorControllerTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/api/ColorControllerTest.java
@@ -25,6 +25,8 @@ import com.fabricmanagement.production.masterdata.color.domain.ColorStandardStat
 import com.fabricmanagement.production.masterdata.color.domain.ColorType;
 import com.fabricmanagement.production.masterdata.color.domain.exception.ColorDomainException;
 import com.fabricmanagement.production.masterdata.color.mapper.ColorMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,6 +54,7 @@ class ColorControllerTest {
   private static final UUID COLOR_ID = UUID.fromString("22222222-2222-4222-8222-222222222222");
 
   @Autowired private MockMvc mockMvc;
+  @Autowired private ObjectMapper objectMapper;
 
   @MockBean private ColorService colorService;
   @MockBean private ColorMapper colorMapper;
@@ -153,19 +156,31 @@ class ColorControllerTest {
               return updated;
             });
 
-    mockMvc
-        .perform(
-            put("/api/v1/production/colors/{id}", COLOR_ID)
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(
-                    """
-                    {"code":"navy-02","name":"Replacement"}
-                    """))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.data.code").value("NAVY-02"))
-        .andExpect(jsonPath("$.data.notes").doesNotExist())
-        .andExpect(jsonPath("$.data.colorHex").doesNotExist());
+    String responseBody =
+        mockMvc
+            .perform(
+                put("/api/v1/production/colors/{id}", COLOR_ID)
+                    .with(csrf())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {"code":"navy-02","name":"Replacement"}
+                        """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.code").value("NAVY-02"))
+            .andExpect(jsonPath("$.data.colorType").value("DYED"))
+            .andExpect(jsonPath("$.data.colorFamily").value("UNDEFINED"))
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+    JsonNode responseData = objectMapper.readTree(responseBody).path("data");
+    assertThat(responseData.has("notes")).isTrue();
+    assertThat(responseData.get("notes").isNull()).isTrue();
+    assertThat(responseData.has("colorHex")).isTrue();
+    assertThat(responseData.get("colorHex").isNull()).isTrue();
+    assertThat(responseData.has("pantoneCode")).isTrue();
+    assertThat(responseData.get("pantoneCode").isNull()).isTrue();
 
     ArgumentCaptor<ColorCardSpec> specCaptor = ArgumentCaptor.forClass(ColorCardSpec.class);
     verify(colorService).update(eq(COLOR_ID), specCaptor.capture());
@@ -244,11 +259,98 @@ class ColorControllerTest {
 
   @Test
   @WithMockUser
-  void readAndWritePermissionsAreIndependentlyEnforced() throws Exception {
-    when(authEvaluator.can(any(Authentication.class), eq("products"), eq("read")))
-        .thenReturn(false);
+  void colorsReadPermitsBothReadEndpoints() throws Exception {
+    allow("read");
+    when(colorService.list(isNull(), isNull(), isNull(), isNull(), eq(false), any(Pageable.class)))
+        .thenReturn(new PageImpl<>(List.of()));
+    when(colorService.findById(eq(COLOR_ID))).thenReturn(color("NAVY-01", "Navy"));
+
+    mockMvc.perform(get("/api/v1/production/colors")).andExpect(status().isOk());
+    mockMvc.perform(get("/api/v1/production/colors/{id}", COLOR_ID)).andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void colorsWritePermitsCreateAndReplace() throws Exception {
+    allow("write");
+    when(colorService.create(any(ColorCardSpec.class))).thenReturn(color("NAVY-01", "Navy"));
+    when(colorService.update(eq(COLOR_ID), any(ColorCardSpec.class)))
+        .thenReturn(color("NAVY-01", "Navy"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"code":"NAVY-01","name":"Navy"}
+                    """))
+        .andExpect(status().isCreated());
+    mockMvc
+        .perform(
+            put("/api/v1/production/colors/{id}", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"code":"NAVY-01","name":"Navy"}
+                    """))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void colorsApprovePermitsApproveAndRevert() throws Exception {
+    allow("approve");
+    when(colorService.approve(eq(COLOR_ID))).thenReturn(color("NAVY-01", "Navy"));
+    when(colorService.revertToDraft(eq(COLOR_ID))).thenReturn(color("NAVY-01", "Navy"));
+
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/approve", COLOR_ID).with(csrf()))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/revert-to-draft", COLOR_ID).with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void colorsManagePermitsActivateAndDeactivate() throws Exception {
+    allow("manage");
+    when(colorService.activate(eq(COLOR_ID))).thenReturn(color("NAVY-01", "Navy"));
+    when(colorService.deactivate(eq(COLOR_ID))).thenReturn(color("NAVY-01", "Navy"));
+
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/activate", COLOR_ID).with(csrf()))
+        .andExpect(status().isOk());
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/deactivate", COLOR_ID).with(csrf()))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @WithMockUser
+  void oneColourActionDoesNotImplyAnother() throws Exception {
+    // colors:write must not confer approve or manage authority.
+    allow("write");
+
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/approve", COLOR_ID).with(csrf()))
+        .andExpect(status().isForbidden());
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/activate", COLOR_ID).with(csrf()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void legacyProductsPermissionGrantsNoColourAuthority() throws Exception {
+    // Clean cutover: a caller who still holds the old broad products grant is fully locked out.
+    when(authEvaluator.can(any(Authentication.class), eq("products"), eq("read"))).thenReturn(true);
     when(authEvaluator.can(any(Authentication.class), eq("products"), eq("write")))
-        .thenReturn(false);
+        .thenReturn(true);
+    // No colors:* stubbed -> every colours action resolves false.
 
     mockMvc.perform(get("/api/v1/production/colors")).andExpect(status().isForbidden());
     mockMvc
@@ -261,10 +363,16 @@ class ColorControllerTest {
                     {"code":"NAVY-01","name":"Navy"}
                     """))
         .andExpect(status().isForbidden());
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/approve", COLOR_ID).with(csrf()))
+        .andExpect(status().isForbidden());
+    mockMvc
+        .perform(post("/api/v1/production/colors/{id}/deactivate", COLOR_ID).with(csrf()))
+        .andExpect(status().isForbidden());
   }
 
   private void allow(String action) {
-    when(authEvaluator.can(any(Authentication.class), eq("products"), eq(action))).thenReturn(true);
+    when(authEvaluator.can(any(Authentication.class), eq("colors"), eq(action))).thenReturn(true);
   }
 
   private Color color(String code, String name) {

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPersistenceIT.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPersistenceIT.java
@@ -13,8 +13,12 @@ import com.fabricmanagement.production.masterdata.color.domain.ColorType;
 import com.fabricmanagement.production.masterdata.color.domain.PantoneSystem;
 import java.sql.DriverManager;
 import java.util.UUID;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
@@ -175,27 +179,79 @@ class ColorPersistenceIT {
         .isInstanceOf(NotFoundException.class);
   }
 
-  @Test
-  void databaseRejectsLowercaseCodeWhenDomainIsBypassed() {
-    assertThatThrownBy(
-            () -> {
-              try (var connection =
-                      DriverManager.getConnection(
-                          postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
-                  var statement =
-                      connection.prepareStatement(
-                          "INSERT INTO production.color "
-                              + "(id, tenant_id, created_at, updated_at, is_active, version, "
-                              + "code, name, color_type, color_family, standard_status) "
-                              + "VALUES (?, ?, now(), now(), true, 0, ?, ?, 'DYED', "
-                              + "'UNDEFINED', 'DRAFT')")) {
-                statement.setObject(1, UUID.randomUUID());
-                statement.setObject(2, UUID.randomUUID());
-                statement.setString(3, "lower-case");
-                statement.setString(4, "Raw writer");
-                statement.executeUpdate();
-              }
-            })
-        .hasMessageContaining("chk_color_code_canonical");
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("nonCanonicalRawColorRows")
+  void databaseRejectsNonCanonicalValuesWhenDomainIsBypassed(
+      String scenario,
+      String code,
+      String name,
+      String pantoneCode,
+      String colorHex,
+      String expectedConstraint) {
+    assertThatThrownBy(() -> insertRawColor(code, name, pantoneCode, colorHex))
+        .hasMessageContaining(expectedConstraint);
+  }
+
+  private static Stream<Arguments> nonCanonicalRawColorRows() {
+    return Stream.of(
+        Arguments.of(
+            "lowercase code", "lower-case", "Raw writer", null, null, "chk_color_code_canonical"),
+        Arguments.of(
+            "untrimmed code", " PADDED ", "Raw writer", null, null, "chk_color_code_canonical"),
+        Arguments.of("blank code", "", "Raw writer", null, null, "chk_color_code_not_blank"),
+        Arguments.of(
+            "untrimmed name", "VALID-CODE", " Raw writer ", null, null, "chk_color_name_canonical"),
+        Arguments.of("blank name", "VALID-CODE", "", null, null, "chk_color_name_not_blank"),
+        Arguments.of(
+            "lowercase Pantone code",
+            "VALID-CODE",
+            "Raw writer",
+            "19-4024 tcx",
+            null,
+            "chk_color_pantone_code_canonical"),
+        Arguments.of(
+            "untrimmed Pantone code",
+            "VALID-CODE",
+            "Raw writer",
+            " 19-4024 ",
+            null,
+            "chk_color_pantone_code_canonical"),
+        Arguments.of(
+            "blank Pantone code",
+            "VALID-CODE",
+            "Raw writer",
+            "",
+            null,
+            "chk_color_pantone_code_not_blank"),
+        Arguments.of(
+            "lowercase color hex",
+            "VALID-CODE",
+            "Raw writer",
+            null,
+            "#abcdef",
+            "chk_color_hex_uppercase"));
+  }
+
+  private void insertRawColor(String code, String name, String pantoneCode, String colorHex)
+      throws Exception {
+    try (var connection =
+            DriverManager.getConnection(
+                postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+        var statement =
+            connection.prepareStatement(
+                "INSERT INTO production.color "
+                    + "(id, tenant_id, created_at, updated_at, is_active, version, "
+                    + "code, name, pantone_code, color_hex, color_type, color_family, "
+                    + "standard_status) "
+                    + "VALUES (?, ?, now(), now(), true, 0, ?, ?, ?, ?, 'DYED', "
+                    + "'UNDEFINED', 'DRAFT')")) {
+      statement.setObject(1, UUID.randomUUID());
+      statement.setObject(2, UUID.randomUUID());
+      statement.setString(3, code);
+      statement.setString(4, name);
+      statement.setString(5, pantoneCode);
+      statement.setString(6, colorHex);
+      statement.executeUpdate();
+    }
   }
 }


### PR DESCRIPTION
COLOR-RBAC-1 — stop piggybacking colour endpoints on 'products':
- ColorController guards endpoints with the new 'colors' resource and granular actions: read/write for CRUD, 'manage' for activate/deactivate, 'approve' for the shade-standard lifecycle
- PermissionRegistry registers 'colors' as a known resource
- PermissionTemplateSeeder seeds org-wide colour read for sales, all production sub-departments, quality, logistics and purchasing roles; colour write only for Dyeing supervisors/managers; full write/approve/manage for Quality managers

API contract polish:
- ColorDto and UpdateColorRequest document explicit nullability ([type, null]), the full required-properties list, and PUT full-replacement semantics (omission/null clearing, TCX default when a Pantone code is supplied, CMC_2_1 default formula with a tolerance)
- api/openapi.yaml snapshot regenerated via OpenApiExportIT

Tests: ColorControllerTest and ColorPersistenceIT cover the new guards and replace semantics; seeder tests and PermissionTemplateBackfillIT cover the new templates; new PermissionRegistryTest added.