### PR TITLE
feat(production): add color partner reference aliases

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -68,6 +68,8 @@ tags:
   name: Permission Management
 - description: Invoice operations
   name: Invoice
+- description: Partner-specific color codes and aliases
+  name: Color Partner Reference
 - description: Fiber Request operations
   name: Fiber Request
 - description: Sales-readable lot and piece projection
@@ -29410,6 +29412,183 @@ paths:
       summary: Record Batch Waste
       tags:
       - Batch
+  /api/v1/production/color-partner-refs/forward:
+    get:
+      operationId: findPrimaryColorPartnerCode
+      parameters:
+      - description: Tenant-owned color identifier
+        in: query
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Trading partner identifier
+        in: query
+        name: partnerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Business direction of the mapping
+        in: query
+        name: role
+        required: true
+        schema:
+          type: string
+          enum:
+          - CUSTOMER
+          - SUPPLIER
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerForwardResolutionDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Find the active primary partner code for a color
+      tags:
+      - Color Partner Reference
+  /api/v1/production/color-partner-refs/resolve:
+    get:
+      operationId: resolveColorPartnerCode
+      parameters:
+      - description: Trading partner identifier
+        in: query
+        name: partnerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Business direction of the mapping
+        in: query
+        name: role
+        required: true
+        schema:
+          type: string
+          enum:
+          - CUSTOMER
+          - SUPPLIER
+      - description: Partner code in any case
+        in: query
+        name: externalCode
+        required: true
+        schema:
+          type: string
+          maxLength: 50
+          minLength: 0
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerReverseResolutionDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Resolve any active partner alias to a color
+      tags:
+      - Color Partner Reference
   /api/v1/production/colors:
     get:
       description: "Returns a tenant-scoped, filtered and paginated list of color\
@@ -29629,6 +29808,780 @@ paths:
       summary: Create a color card
       tags:
       - Color
+  /api/v1/production/colors/{colorId}/partner-refs:
+    get:
+      operationId: listColorPartnerRefs
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 0
+          minimum: 0
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+      - description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        in: query
+        name: sort
+        required: false
+        schema:
+          type: array
+          default:
+          - "createdAt,ASC"
+          items:
+            type: string
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List a color card's partner references
+      tags:
+      - Color Partner Reference
+    post:
+      operationId: createColorPartnerRef
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateColorPartnerRefRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: Color partner reference created successfully
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Create a partner reference and initial primary code atomically
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}:
+    put:
+      operationId: updateColorPartnerRef
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateColorPartnerRefRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Replace a partner reference's mutable state
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/codes:
+    post:
+      operationId: addColorPartnerCode
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddColorPartnerCodeRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerCodeDto"
+          description: Color partner alias created successfully
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Add an alias code
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/codes/{codeId}:
+    put:
+      operationId: updateColorPartnerCode
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Partner code identifier
+        in: path
+        name: codeId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateColorPartnerCodeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerCodeDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Replace an alias's mutable name
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/codes/{codeId}/deactivate:
+    post:
+      operationId: deactivateColorPartnerCode
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Partner code identifier
+        in: path
+        name: codeId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Deactivate a non-primary alias
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/codes/{codeId}/make-primary:
+    post:
+      operationId: makeColorPartnerCodePrimary
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Target active partner code identifier
+        in: path
+        name: codeId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Switch the active primary code
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/deactivate:
+    post:
+      operationId: deactivateColorPartnerRef
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Deactivate a relationship and all its codes
+      tags:
+      - Color Partner Reference
+  /api/v1/production/colors/{colorId}/partner-refs/{refId}/reactivate:
+    post:
+      operationId: reactivateColorPartnerRef
+      parameters:
+      - description: Tenant-owned color identifier
+        in: path
+        name: colorId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Color partner-reference identifier
+        in: path
+        name: refId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReactivateColorPartnerRefRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseColorPartnerRefDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Reactivate with one available primary code
+      tags:
+      - Color Partner Reference
   /api/v1/production/colors/{id}:
     get:
       operationId: findColorById
@@ -43116,6 +44069,25 @@ components:
           format: date
       required:
       - certificationId
+    AddColorPartnerCodeRequest:
+      type: object
+      description: Adds an immutable code identity as an alias of an active relationship
+      properties:
+        externalCode:
+          type: string
+          description: Partner's original code spelling; stored trimmed and immutable
+          maxLength: 50
+          minLength: 0
+        externalName:
+          type:
+          - string
+          - "null"
+          description: "Optional partner-owned color name, already trimmed when supplied"
+          maxLength: 255
+          minLength: 0
+          pattern: ^\S(?:.*\S)?$
+      required:
+      - externalCode
     AddOrganizationCertificationRequest:
       type: object
       properties:
@@ -43827,6 +44799,78 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/ColorDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseColorPartnerCodeDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/ColorPartnerCodeDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseColorPartnerForwardResolutionDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/ColorPartnerForwardResolutionDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseColorPartnerRefDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/ColorPartnerRefDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseColorPartnerReverseResolutionDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/ColorPartnerReverseResolutionDto"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -46036,6 +47080,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/PagedResponseColorDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponsePagedResponseColorPartnerRefDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseColorPartnerRefDto"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -48823,6 +49885,171 @@ components:
       - targetLabIlluminant
       - targetLabL
       - targetLabObserver
+    ColorPartnerCodeDto:
+      type: object
+      description: A partner-owned primary or alias code retained by a color mapping
+      properties:
+        active:
+          type: boolean
+          description: Whether this alias can currently participate in lookup
+        externalCode:
+          type: string
+          description: Partner's original trimmed spelling
+        externalName:
+          type:
+          - string
+          - "null"
+          description: Optional partner-owned color name
+        id:
+          type: string
+          format: uuid
+          description: Partner code identifier
+        primary:
+          type: boolean
+          description: Whether this is the relationship's current active primary code
+      required:
+      - active
+      - externalCode
+      - externalName
+      - id
+      - primary
+    ColorPartnerCodeInput:
+      type: object
+      description: Partner-owned code used to create or reactivate a color mapping
+      properties:
+        externalCode:
+          type: string
+          description: Partner's original code spelling; stored trimmed and immutable
+          maxLength: 50
+          minLength: 0
+        externalName:
+          type:
+          - string
+          - "null"
+          description: "Optional partner-owned color name, already trimmed when supplied"
+          maxLength: 255
+          minLength: 0
+          pattern: ^\S(?:.*\S)?$
+      required:
+      - externalCode
+    ColorPartnerForwardResolutionDto:
+      type: object
+      description: Forward lookup result containing the active primary partner code
+      properties:
+        colorId:
+          type: string
+          format: uuid
+          description: Tenant-owned color identifier
+        colorPartnerRefId:
+          type: string
+          format: uuid
+          description: Resolved partner-reference identifier
+        externalCode:
+          type: string
+          description: Partner's active primary code in its original spelling
+        externalName:
+          type:
+          - string
+          - "null"
+          description: Optional name stored on the primary code
+        partnerId:
+          type: string
+          format: uuid
+          description: Trading partner identifier
+        role:
+          type: string
+          description: Business direction of the mapping
+          enum:
+          - CUSTOMER
+          - SUPPLIER
+      required:
+      - colorId
+      - colorPartnerRefId
+      - externalCode
+      - externalName
+      - partnerId
+      - role
+    ColorPartnerRefDto:
+      type: object
+      description: Partner-to-color relationship with retained primary and alias codes
+      properties:
+        active:
+          type: boolean
+          description: Whether the mapping is active
+        codes:
+          type: array
+          description: Retained primary and alias codes
+          items:
+            $ref: "#/components/schemas/ColorPartnerCodeDto"
+        colorId:
+          type: string
+          format: uuid
+          description: Tenant-owned color identifier
+        deltaETolerance:
+          type:
+          - number
+          - "null"
+          description: Optional partner-specific Delta-E tolerance override
+        id:
+          type: string
+          format: uuid
+          description: Color partner-reference identifier
+        partnerId:
+          type: string
+          format: uuid
+          description: Trading partner identifier
+        role:
+          type: string
+          description: Business direction of the mapping
+          enum:
+          - CUSTOMER
+          - SUPPLIER
+        version:
+          type: integer
+          format: int64
+          description: Optimistic-lock version of the aggregate root
+      required:
+      - active
+      - codes
+      - colorId
+      - deltaETolerance
+      - id
+      - partnerId
+      - role
+      - version
+    ColorPartnerReverseResolutionDto:
+      type: object
+      description: "Reverse partner-code lookup result, including alias and current-primary\
+        \ context"
+      properties:
+        color:
+          $ref: "#/components/schemas/ColorDto"
+          description: Resolved active tenant color card
+        colorPartnerRefId:
+          type: string
+          format: uuid
+          description: Resolved partner-reference identifier for downstream traceability
+        matchedExternalCode:
+          type: string
+          description: Original display spelling of the alias that matched
+        matchedExternalName:
+          type:
+          - string
+          - "null"
+          description: Optional name stored on the matched alias
+        matchedIsPrimary:
+          type: boolean
+          description: Whether the matched alias is the current primary
+        primaryExternalCode:
+          type: string
+          description: Current active primary code for the relationship
+      required:
+      - color
+      - colorPartnerRefId
+      - matchedExternalCode
+      - matchedExternalName
+      - matchedIsPrimary
+      - primaryExternalCode
     CompanyTypeOptionDto:
       type: object
       properties:
@@ -49547,6 +50774,35 @@ components:
       required:
       - boardType
       - name
+    CreateColorPartnerRefRequest:
+      type: object
+      description: Creates a partner-color relationship and its first primary code
+        atomically
+      properties:
+        deltaETolerance:
+          type:
+          - number
+          - "null"
+          description: Optional partner-specific Delta-E tolerance override; must
+            be positive
+          maximum: 99.99
+        initialPrimaryCode:
+          $ref: "#/components/schemas/ColorPartnerCodeInput"
+          description: "Required first code, created as the sole active primary"
+        partnerId:
+          type: string
+          format: uuid
+          description: Trading partner identifier
+        role:
+          type: string
+          description: Business direction in which the partner code is used
+          enum:
+          - CUSTOMER
+          - SUPPLIER
+      required:
+      - initialPrimaryCode
+      - partnerId
+      - role
     CreateColorRequest:
       type: object
       properties:
@@ -54084,6 +55340,29 @@ components:
         totalPages:
           type: integer
           format: int32
+    PagedResponseColorPartnerRefDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ColorPartnerRefDto"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
     PagedResponseFiberRequestDto:
       type: object
       properties:
@@ -56286,6 +57565,43 @@ components:
       - pendingApproval
       - rejected
       - superseded
+    ReactivateColorPartnerRefRequest:
+      type: object
+      description: Reactivates a relationship with exactly one existing inactive code
+        or one new primary code
+      oneOf:
+      - $ref: "#/components/schemas/ReactivateColorPartnerRefWithExistingCodeRequest"
+      - $ref: "#/components/schemas/ReactivateColorPartnerRefWithNewCodeRequest"
+      properties:
+        existingCodeId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Inactive retained code to reactivate as the sole primary
+        newPrimaryCode:
+          type: "null"
+          $ref: "#/components/schemas/ColorPartnerCodeInput"
+          description: New code to create as the sole primary
+    ReactivateColorPartnerRefWithExistingCodeRequest:
+      type: object
+      description: Reactivation branch selecting one retained inactive partner code
+      properties:
+        existingCodeId:
+          type: string
+          format: uuid
+          description: Inactive retained code to reactivate as the sole primary
+      required:
+      - existingCodeId
+    ReactivateColorPartnerRefWithNewCodeRequest:
+      type: object
+      description: Reactivation branch creating one new active primary partner code
+      properties:
+        newPrimaryCode:
+          $ref: "#/components/schemas/ColorPartnerCodeInput"
+          description: New code to create as the sole primary
+      required:
+      - newPrimaryCode
     RealizedFxCurrencyDto:
       type: object
       properties:
@@ -59111,6 +60427,29 @@ components:
           format: date
       required:
       - changeReason
+    UpdateColorPartnerCodeRequest:
+      type: object
+      description: Full mutable state of a partner code; its code identity is immutable
+      properties:
+        externalName:
+          type:
+          - string
+          - "null"
+          description: Optional partner-owned color name; null clears it
+          maxLength: 255
+          minLength: 0
+          pattern: ^\S(?:.*\S)?$
+    UpdateColorPartnerRefRequest:
+      type: object
+      description: Full mutable state of a partner-color relationship
+      properties:
+        deltaETolerance:
+          type:
+          - number
+          - "null"
+          description: Optional partner-specific Delta-E tolerance override; null
+            clears it
+          maximum: 99.99
     UpdateColorRequest:
       type: object
       description: "Full replacement of mutable color-card state. Code and name are\

--- a/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/web/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.common.infrastructure.web.exception;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.persistence.OptimisticLockException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.ConstraintViolationException;
@@ -206,6 +207,7 @@ public class GlobalExceptionHandler {
   }
 
   @ExceptionHandler({
+    OptimisticLockException.class,
     ObjectOptimisticLockingFailureException.class,
     StaleObjectStateException.class
   })

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -416,6 +416,18 @@ public class TenantTransactionalPurgeService {
     delete(
         jdbc,
         rows,
+        "production.color_partner_code",
+        "DELETE FROM production.color_partner_code WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
+        "production.color_partner_ref",
+        "DELETE FROM production.color_partner_ref WHERE tenant_id = ?",
+        tenantId);
+    delete(
+        jdbc,
+        rows,
         "production.prod_product_attribute",
         "DELETE FROM production.prod_product_attribute WHERE tenant_id = ?",
         tenantId);

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerQueryService.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerQueryService.java
@@ -1,0 +1,32 @@
+package com.fabricmanagement.platform.tradingpartner.app;
+
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerStatus;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.platform.tradingpartner.infra.repository.TradingPartnerRepository;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Read-only bounded-context contract for consumers that must classify a trading partner. */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TradingPartnerQueryService {
+
+  private final TradingPartnerRepository tradingPartnerRepository;
+
+  public Optional<PartnerClassification> findClassification(UUID tenantId, UUID partnerId) {
+    return tradingPartnerRepository
+        .findByTenantIdAndId(tenantId, partnerId)
+        .map(
+            partner ->
+                new PartnerClassification(
+                    partner.getPartnerType(),
+                    partner.getStatus(),
+                    Boolean.TRUE.equals(partner.getIsActive())));
+  }
+
+  public record PartnerClassification(PartnerType type, PartnerStatus status, boolean active) {}
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorPartnerRefController.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorPartnerRefController.java
@@ -1,0 +1,215 @@
+package com.fabricmanagement.production.masterdata.color.api;
+
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.production.masterdata.color.app.ColorPartnerRefQueryService;
+import com.fabricmanagement.production.masterdata.color.app.ColorPartnerRefService;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.dto.AddColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerCodeDto;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerForwardResolutionDto;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerRefDto;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerReverseResolutionDto;
+import com.fabricmanagement.production.masterdata.color.dto.CreateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ReactivateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.mapper.ColorPartnerRefMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/production")
+@RequiredArgsConstructor
+@Validated
+@Tag(name = "Color Partner Reference", description = "Partner-specific color codes and aliases")
+public class ColorPartnerRefController {
+
+  private final ColorPartnerRefService colorPartnerRefService;
+  private final ColorPartnerRefQueryService colorPartnerRefQueryService;
+  private final ColorPartnerRefMapper colorPartnerRefMapper;
+
+  @GetMapping("/colors/{colorId}/partner-refs")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'read')")
+  @Operation(
+      operationId = "listColorPartnerRefs",
+      summary = "List a color card's partner references")
+  public ResponseEntity<ApiResponse<PagedResponse<ColorPartnerRefDto>>> list(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @ParameterObject @PageableDefault(size = 20, sort = "createdAt") Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            PagedResponse.from(
+                colorPartnerRefQueryService.list(colorId, pageable),
+                colorPartnerRefMapper::toDto)));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "createColorPartnerRef",
+      summary = "Create a partner reference and initial primary code atomically")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "201",
+      description = "Color partner reference created successfully")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> create(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Valid @RequestBody CreateColorPartnerRefRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(
+            ApiResponse.success(
+                colorPartnerRefMapper.toDto(colorPartnerRefService.create(colorId, request))));
+  }
+
+  @PutMapping("/colors/{colorId}/partner-refs/{refId}")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "updateColorPartnerRef",
+      summary = "Replace a partner reference's mutable state")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> update(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Valid @RequestBody UpdateColorPartnerRefRequest request) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(colorPartnerRefService.update(colorId, refId, request))));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs/{refId}/codes")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(operationId = "addColorPartnerCode", summary = "Add an alias code")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "201",
+      description = "Color partner alias created successfully")
+  public ResponseEntity<ApiResponse<ColorPartnerCodeDto>> addCode(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Valid @RequestBody AddColorPartnerCodeRequest request) {
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(
+            ApiResponse.success(
+                colorPartnerRefMapper.toDto(
+                    colorPartnerRefService.addCode(colorId, refId, request))));
+  }
+
+  @PutMapping("/colors/{colorId}/partner-refs/{refId}/codes/{codeId}")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(operationId = "updateColorPartnerCode", summary = "Replace an alias's mutable name")
+  public ResponseEntity<ApiResponse<ColorPartnerCodeDto>> updateCode(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Parameter(description = "Partner code identifier") @PathVariable UUID codeId,
+      @Valid @RequestBody UpdateColorPartnerCodeRequest request) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(
+                colorPartnerRefService.updateCode(colorId, refId, codeId, request))));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs/{refId}/codes/{codeId}/make-primary")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "makeColorPartnerCodePrimary",
+      summary = "Switch the active primary code")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> makePrimary(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Parameter(description = "Target active partner code identifier") @PathVariable UUID codeId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(
+                colorPartnerRefService.makePrimary(colorId, refId, codeId))));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs/{refId}/codes/{codeId}/deactivate")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(operationId = "deactivateColorPartnerCode", summary = "Deactivate a non-primary alias")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> deactivateCode(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Parameter(description = "Partner code identifier") @PathVariable UUID codeId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(
+                colorPartnerRefService.deactivateCode(colorId, refId, codeId))));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs/{refId}/deactivate")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "deactivateColorPartnerRef",
+      summary = "Deactivate a relationship and all its codes")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> deactivate(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(colorPartnerRefService.deactivate(colorId, refId))));
+  }
+
+  @PostMapping("/colors/{colorId}/partner-refs/{refId}/reactivate")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
+  @Operation(
+      operationId = "reactivateColorPartnerRef",
+      summary = "Reactivate with one available primary code")
+  public ResponseEntity<ApiResponse<ColorPartnerRefDto>> reactivate(
+      @Parameter(description = "Tenant-owned color identifier") @PathVariable UUID colorId,
+      @Parameter(description = "Color partner-reference identifier") @PathVariable UUID refId,
+      @Valid @RequestBody ReactivateColorPartnerRefRequest request) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            colorPartnerRefMapper.toDto(
+                colorPartnerRefService.reactivate(colorId, refId, request))));
+  }
+
+  @GetMapping("/color-partner-refs/resolve")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'read')")
+  @Operation(
+      operationId = "resolveColorPartnerCode",
+      summary = "Resolve any active partner alias to a color")
+  public ResponseEntity<ApiResponse<ColorPartnerReverseResolutionDto>> resolve(
+      @Parameter(description = "Trading partner identifier") @RequestParam @NotNull UUID partnerId,
+      @Parameter(description = "Business direction of the mapping") @RequestParam @NotNull
+          PartnerRole role,
+      @Parameter(description = "Partner code in any case") @RequestParam @NotBlank @Size(max = 50)
+          String externalCode) {
+    return ResponseEntity.ok(
+        ApiResponse.success(colorPartnerRefQueryService.resolve(partnerId, role, externalCode)));
+  }
+
+  @GetMapping("/color-partner-refs/forward")
+  @PreAuthorize("@auth.can(authentication, 'colors', 'read')")
+  @Operation(
+      operationId = "findPrimaryColorPartnerCode",
+      summary = "Find the active primary partner code for a color")
+  public ResponseEntity<ApiResponse<ColorPartnerForwardResolutionDto>> forward(
+      @Parameter(description = "Tenant-owned color identifier") @RequestParam @NotNull UUID colorId,
+      @Parameter(description = "Trading partner identifier") @RequestParam @NotNull UUID partnerId,
+      @Parameter(description = "Business direction of the mapping") @RequestParam @NotNull
+          PartnerRole role) {
+    return ResponseEntity.ok(
+        ApiResponse.success(colorPartnerRefQueryService.forward(colorId, partnerId, role)));
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefQueryService.java
@@ -1,0 +1,108 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerForwardResolutionDto;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerReverseResolutionDto;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorPartnerRefRepository;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
+import com.fabricmanagement.production.masterdata.color.mapper.ColorMapper;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ColorPartnerRefQueryService {
+
+  private final ColorPartnerRefRepository colorPartnerRefRepository;
+  private final ColorRepository colorRepository;
+  private final TradingPartnerQueryPort tradingPartnerQueryPort;
+  private final ColorMapper colorMapper;
+
+  public Page<ColorPartnerRef> list(UUID colorId, Pageable pageable) {
+    UUID tenantId = TenantContext.requireTenantId();
+    colorRepository
+        .findByTenantIdAndId(tenantId, colorId)
+        .orElseThrow(() -> new NotFoundException("Color not found: " + colorId));
+    Page<ColorPartnerRef> page =
+        colorPartnerRefRepository.findByTenantIdAndColorId(tenantId, colorId, pageable);
+    if (page.isEmpty()) {
+      return page;
+    }
+
+    Map<UUID, ColorPartnerRef> refsWithCodes =
+        colorPartnerRefRepository
+            .findWithCodesByTenantIdAndIdIn(
+                tenantId, page.getContent().stream().map(ColorPartnerRef::getId).toList())
+            .stream()
+            .collect(Collectors.toMap(ColorPartnerRef::getId, Function.identity()));
+
+    return new PageImpl<>(
+        page.getContent().stream().map(ref -> refsWithCodes.get(ref.getId())).toList(),
+        pageable,
+        page.getTotalElements());
+  }
+
+  public ColorPartnerReverseResolutionDto resolve(
+      UUID partnerId, PartnerRole role, String externalCode) {
+    UUID tenantId = TenantContext.requireTenantId();
+    requirePartner(tenantId, partnerId, role);
+    ColorPartnerCode matched =
+        colorPartnerRefRepository
+            .findActiveCodeForReverseLookup(
+                tenantId, partnerId, role, ColorPartnerCode.keyOf(externalCode))
+            .orElseThrow(
+                () -> new NotFoundException("No active color mapping found for partner code"));
+    ColorPartnerRef ref = matched.getColorPartnerRef();
+    Color color =
+        colorRepository
+            .findByTenantIdAndIdAndIsActiveTrue(tenantId, ref.getColorId())
+            .orElseThrow(() -> new NotFoundException("Resolved color is inactive or missing"));
+
+    return new ColorPartnerReverseResolutionDto(
+        colorMapper.toDto(color),
+        matched.getExternalCode(),
+        matched.getExternalName(),
+        matched.isPrimary(),
+        ref.primaryCode().getExternalCode(),
+        ref.getId());
+  }
+
+  public ColorPartnerForwardResolutionDto forward(UUID colorId, UUID partnerId, PartnerRole role) {
+    UUID tenantId = TenantContext.requireTenantId();
+    requirePartner(tenantId, partnerId, role);
+    ColorPartnerCode primary =
+        colorPartnerRefRepository
+            .findActivePrimaryForForwardLookup(tenantId, colorId, partnerId, role)
+            .orElseThrow(() -> new NotFoundException("No active primary partner color code found"));
+    ColorPartnerRef ref = primary.getColorPartnerRef();
+    return new ColorPartnerForwardResolutionDto(
+        ref.getId(),
+        ref.getColorId(),
+        ref.getPartnerId(),
+        ref.getRole(),
+        primary.getExternalCode(),
+        primary.getExternalName());
+  }
+
+  private void requirePartner(UUID tenantId, UUID partnerId, PartnerRole role) {
+    if (!tradingPartnerQueryPort.isActiveAndCompatible(tenantId, partnerId, role)) {
+      throw ColorPartnerRefDomainException.unavailablePartner();
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefService.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefService.java
@@ -1,0 +1,184 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import com.fabricmanagement.production.masterdata.color.dto.AddColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.CreateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ReactivateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorPartnerRefRepository;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
+import jakarta.persistence.EntityManager;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ColorPartnerRefService {
+
+  private final ColorPartnerRefRepository colorPartnerRefRepository;
+  private final ColorRepository colorRepository;
+  private final TradingPartnerQueryPort tradingPartnerQueryPort;
+  private final EntityManager entityManager;
+
+  @Transactional
+  public ColorPartnerRef create(UUID colorId, CreateColorPartnerRefRequest request) {
+    UUID tenantId = TenantContext.requireTenantId();
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, request.partnerId(), request.role());
+    if (colorPartnerRefRepository.existsByTenantIdAndColorIdAndPartnerIdAndRole(
+        tenantId, colorId, request.partnerId(), request.role())) {
+      throw ColorPartnerRefDomainException.conflict(
+          "A relationship already exists for this color, partner, and role");
+    }
+    requireCodeAvailable(
+        tenantId, request.partnerId(), request.role(), request.initialPrimaryCode().externalCode());
+
+    ColorPartnerRef ref =
+        ColorPartnerRef.create(
+            tenantId,
+            colorId,
+            request.partnerId(),
+            request.role(),
+            request.deltaETolerance(),
+            request.initialPrimaryCode().externalCode(),
+            request.initialPrimaryCode().externalName());
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  @Transactional
+  public ColorPartnerRef update(UUID colorId, UUID refId, UpdateColorPartnerRefRequest request) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, ref.getPartnerId(), ref.getRole());
+    ref.updateTolerance(request.deltaETolerance());
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  @Transactional
+  public ColorPartnerCode addCode(UUID colorId, UUID refId, AddColorPartnerCodeRequest request) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, ref.getPartnerId(), ref.getRole());
+    requireCodeAvailable(tenantId, ref.getPartnerId(), ref.getRole(), request.externalCode());
+    ColorPartnerCode code = ref.addCode(request.externalCode(), request.externalName());
+    entityManager.flush();
+    return code;
+  }
+
+  @Transactional
+  public ColorPartnerCode updateCode(
+      UUID colorId, UUID refId, UUID codeId, UpdateColorPartnerCodeRequest request) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, ref.getPartnerId(), ref.getRole());
+    ref.updateCodeName(codeId, request.externalName());
+    colorPartnerRefRepository.save(ref);
+    return code(ref, codeId);
+  }
+
+  @Transactional
+  public ColorPartnerRef makePrimary(UUID colorId, UUID refId, UUID codeId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, ref.getPartnerId(), ref.getRole());
+    ref.preparePrimarySwitch(codeId);
+    entityManager.flush();
+    ref.completePrimarySwitch(codeId);
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  @Transactional
+  public ColorPartnerRef deactivateCode(UUID colorId, UUID refId, UUID codeId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    ref.deactivateCode(codeId);
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  @Transactional
+  public ColorPartnerRef deactivate(UUID colorId, UUID refId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    ref.deactivate();
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  @Transactional
+  public ColorPartnerRef reactivate(
+      UUID colorId, UUID refId, ReactivateColorPartnerRefRequest request) {
+    UUID tenantId = TenantContext.requireTenantId();
+    ColorPartnerRef ref = loadForMutation(tenantId, colorId, refId);
+    requireActiveColor(tenantId, colorId);
+    requirePartner(tenantId, ref.getPartnerId(), ref.getRole());
+
+    if ((request.existingCodeId() == null) == (request.newPrimaryCode() == null)) {
+      throw ColorPartnerRefDomainException.invalid(
+          "Exactly one reactivation code alternative is required");
+    }
+
+    if (request.existingCodeId() != null) {
+      ColorPartnerCode selected = code(ref, request.existingCodeId());
+      requireCodeAvailable(tenantId, ref.getPartnerId(), ref.getRole(), selected.getExternalCode());
+      ref.reactivateWithExistingCode(request.existingCodeId());
+    } else if (request.newPrimaryCode() != null) {
+      requireCodeAvailable(
+          tenantId, ref.getPartnerId(), ref.getRole(), request.newPrimaryCode().externalCode());
+      ref.reactivateWithNewCode(
+          request.newPrimaryCode().externalCode(), request.newPrimaryCode().externalName());
+    }
+    return colorPartnerRefRepository.save(ref);
+  }
+
+  private ColorPartnerRef loadForMutation(UUID tenantId, UUID colorId, UUID refId) {
+    ColorPartnerRef ref =
+        colorPartnerRefRepository
+            .findForMutationByTenantIdAndId(tenantId, refId)
+            .orElseThrow(
+                () -> new NotFoundException("Color partner reference not found: " + refId));
+    if (!ref.getColorId().equals(colorId)) {
+      throw new NotFoundException("Color partner reference not found for color: " + colorId);
+    }
+    return ref;
+  }
+
+  private void requireActiveColor(UUID tenantId, UUID colorId) {
+    colorRepository
+        .findByTenantIdAndIdAndIsActiveTrue(tenantId, colorId)
+        .orElseThrow(() -> new NotFoundException("Active color not found: " + colorId));
+  }
+
+  private void requirePartner(UUID tenantId, UUID partnerId, PartnerRole role) {
+    if (!tradingPartnerQueryPort.isActiveAndCompatible(tenantId, partnerId, role)) {
+      throw ColorPartnerRefDomainException.unavailablePartner();
+    }
+  }
+
+  private void requireCodeAvailable(
+      UUID tenantId, UUID partnerId, PartnerRole role, String externalCode) {
+    String key = ColorPartnerCode.keyOf(externalCode);
+    if (colorPartnerRefRepository.existsActiveCode(tenantId, partnerId, role, key)) {
+      throw ColorPartnerRefDomainException.duplicateCode(externalCode);
+    }
+  }
+
+  private ColorPartnerCode code(ColorPartnerRef ref, UUID codeId) {
+    return ref.getCodes().stream()
+        .filter(candidate -> Objects.equals(candidate.getId(), codeId))
+        .findFirst()
+        .orElseThrow(() -> new NotFoundException("Color partner code not found: " + codeId));
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/app/adapter/TradingPartnerQueryAdapter.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/app/adapter/TradingPartnerQueryAdapter.java
@@ -1,0 +1,41 @@
+package com.fabricmanagement.production.masterdata.color.app.adapter;
+
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerQueryService;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerStatus;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Anti-corruption adapter translating platform partner types into Production's color roles. */
+@Component
+@RequiredArgsConstructor
+public class TradingPartnerQueryAdapter implements TradingPartnerQueryPort {
+
+  private static final Set<PartnerType> CUSTOMER_TYPES =
+      Set.of(PartnerType.CUSTOMER, PartnerType.BOTH);
+  private static final Set<PartnerType> SUPPLIER_TYPES =
+      Set.of(PartnerType.SUPPLIER, PartnerType.BOTH, PartnerType.SUBCONTRACTOR);
+
+  private final TradingPartnerQueryService tradingPartnerQueryService;
+
+  @Override
+  public boolean isActiveAndCompatible(UUID tenantId, UUID partnerId, PartnerRole role) {
+    return tradingPartnerQueryService
+        .findClassification(tenantId, partnerId)
+        .filter(TradingPartnerQueryService.PartnerClassification::active)
+        .filter(classification -> classification.status() == PartnerStatus.ACTIVE)
+        .map(classification -> acceptedTypes(role).contains(classification.type()))
+        .orElse(false);
+  }
+
+  private Set<PartnerType> acceptedTypes(PartnerRole role) {
+    return switch (role) {
+      case CUSTOMER -> CUSTOMER_TYPES;
+      case SUPPLIER -> SUPPLIER_TYPES;
+    };
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/app/port/TradingPartnerQueryPort.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/app/port/TradingPartnerQueryPort.java
@@ -1,0 +1,10 @@
+package com.fabricmanagement.production.masterdata.color.app.port;
+
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import java.util.UUID;
+
+/** Production-owned boundary for role-compatible, active trading-partner validation. */
+public interface TradingPartnerQueryPort {
+
+  boolean isActiveAndCompatible(UUID tenantId, UUID partnerId, PartnerRole role);
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerCode.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerCode.java
@@ -1,0 +1,136 @@
+package com.fabricmanagement.production.masterdata.color.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.Locale;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** Immutable partner-code identity owned and mutated exclusively by {@link ColorPartnerRef}. */
+@Entity
+@Table(name = "color_partner_code", schema = "production")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ColorPartnerCode extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @JoinColumn(name = "color_partner_ref_id", nullable = false)
+  private ColorPartnerRef colorPartnerRef;
+
+  @Column(name = "partner_id", nullable = false, updatable = false)
+  private UUID partnerId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "role", nullable = false, updatable = false, length = 20)
+  private PartnerRole role;
+
+  @Column(name = "external_code", nullable = false, updatable = false, length = 50)
+  private String externalCode;
+
+  @Column(name = "external_code_key", nullable = false, updatable = false, length = 50)
+  private String externalCodeKey;
+
+  @Column(name = "external_name", length = 255)
+  private String externalName;
+
+  @Column(name = "is_primary", nullable = false)
+  private boolean primary;
+
+  static ColorPartnerCode create(
+      ColorPartnerRef owner,
+      UUID tenantId,
+      String externalCode,
+      String externalName,
+      boolean primary) {
+    String display = normalizeCode(externalCode);
+    ColorPartnerCode code = new ColorPartnerCode();
+    code.colorPartnerRef = owner;
+    code.partnerId = owner.getPartnerId();
+    code.role = owner.getRole();
+    code.externalCode = display;
+    code.externalCodeKey = keyFromDisplay(display);
+    code.externalName = normalizeName(externalName);
+    code.primary = primary;
+    code.setTenantId(tenantId);
+    code.onCreate();
+    return code;
+  }
+
+  void updateName(String externalName) {
+    this.externalName = normalizeName(externalName);
+  }
+
+  void promote() {
+    if (!Boolean.TRUE.equals(getIsActive())) {
+      throw ColorPartnerRefDomainException.conflict("An inactive partner code cannot be primary");
+    }
+    this.primary = true;
+  }
+
+  void demote() {
+    this.primary = false;
+  }
+
+  void deactivate() {
+    demote();
+    delete();
+  }
+
+  void reactivateAsPrimary() {
+    activate();
+    this.primary = true;
+  }
+
+  public static String keyOf(String externalCode) {
+    return keyFromDisplay(normalizeCode(externalCode));
+  }
+
+  private static String keyFromDisplay(String display) {
+    String key = display.toUpperCase(Locale.ROOT);
+    if (key.length() > 50) {
+      throw ColorPartnerRefDomainException.invalid(
+          "Canonical external code must not exceed 50 characters");
+    }
+    return key;
+  }
+
+  private static String normalizeCode(String externalCode) {
+    if (externalCode == null || externalCode.isBlank()) {
+      throw ColorPartnerRefDomainException.invalid("External code must not be blank");
+    }
+    String normalized = externalCode.trim();
+    if (normalized.length() > 50) {
+      throw ColorPartnerRefDomainException.invalid("External code must not exceed 50 characters");
+    }
+    return normalized;
+  }
+
+  private static String normalizeName(String externalName) {
+    if (externalName == null) {
+      return null;
+    }
+    String normalized = externalName.trim();
+    if (normalized.isEmpty()) {
+      throw ColorPartnerRefDomainException.invalid("External name must be null or non-blank");
+    }
+    if (normalized.length() > 255) {
+      throw ColorPartnerRefDomainException.invalid("External name must not exceed 255 characters");
+    }
+    return normalized;
+  }
+
+  @Override
+  protected String getModuleCode() {
+    return "CPC";
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerRef.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerRef.java
@@ -1,0 +1,234 @@
+package com.fabricmanagement.production.masterdata.color.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.BatchSize;
+
+/** Partner-to-color relationship aggregate. Alias writes must always pass through this root. */
+@Entity
+@Table(name = "color_partner_ref", schema = "production")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ColorPartnerRef extends BaseEntity {
+
+  @Column(name = "color_id", nullable = false, updatable = false)
+  private UUID colorId;
+
+  @Column(name = "partner_id", nullable = false, updatable = false)
+  private UUID partnerId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "role", nullable = false, updatable = false, length = 20)
+  private PartnerRole role;
+
+  @Column(name = "delta_e_tolerance", precision = 4, scale = 2)
+  private BigDecimal deltaETolerance;
+
+  @OneToMany(
+      mappedBy = "colorPartnerRef",
+      cascade = CascadeType.ALL,
+      orphanRemoval = false,
+      fetch = FetchType.LAZY)
+  @OrderBy("createdAt ASC")
+  @BatchSize(size = 50)
+  private List<ColorPartnerCode> codes = new ArrayList<>();
+
+  @Transient private UUID preparedPrimaryTargetId;
+
+  public static ColorPartnerRef create(
+      UUID tenantId,
+      UUID colorId,
+      UUID partnerId,
+      PartnerRole role,
+      BigDecimal deltaETolerance,
+      String initialCode,
+      String initialName) {
+    if (colorId == null || partnerId == null || role == null) {
+      throw ColorPartnerRefDomainException.invalid("Color, partner, and role are required");
+    }
+    ColorPartnerRef ref = new ColorPartnerRef();
+    ref.colorId = colorId;
+    ref.partnerId = partnerId;
+    ref.role = role;
+    ref.setTenantId(tenantId);
+    ref.onCreate();
+    ref.updateToleranceInternal(deltaETolerance);
+    ref.codes.add(ColorPartnerCode.create(ref, tenantId, initialCode, initialName, true));
+    return ref;
+  }
+
+  public ColorPartnerCode addCode(String externalCode, String externalName) {
+    requireActive();
+    String key = ColorPartnerCode.keyOf(externalCode);
+    if (codes.stream()
+        .anyMatch(
+            code ->
+                Boolean.TRUE.equals(code.getIsActive()) && code.getExternalCodeKey().equals(key))) {
+      throw ColorPartnerRefDomainException.duplicateCode(externalCode);
+    }
+    boolean firstActive = codes.stream().noneMatch(code -> Boolean.TRUE.equals(code.getIsActive()));
+    ColorPartnerCode code =
+        ColorPartnerCode.create(this, getTenantId(), externalCode, externalName, firstActive);
+    codes.add(code);
+    return code;
+  }
+
+  public void updateCodeName(UUID codeId, String externalName) {
+    requireActive();
+    activeCode(codeId).updateName(externalName);
+  }
+
+  public void updateTolerance(BigDecimal value) {
+    requireActive();
+    updateToleranceInternal(value);
+  }
+
+  public void preparePrimarySwitch(UUID targetCodeId) {
+    requireActive();
+    ColorPartnerCode target = activeCode(targetCodeId);
+    if (target.isPrimary()) {
+      preparedPrimaryTargetId = targetCodeId;
+      return;
+    }
+    codes.stream().filter(ColorPartnerCode::isPrimary).forEach(ColorPartnerCode::demote);
+    preparedPrimaryTargetId = targetCodeId;
+  }
+
+  public void completePrimarySwitch(UUID targetCodeId) {
+    requireActive();
+    if (preparedPrimaryTargetId == null || !preparedPrimaryTargetId.equals(targetCodeId)) {
+      throw ColorPartnerRefDomainException.conflict(
+          "Primary switch completion does not match a prepared target");
+    }
+    activeCode(targetCodeId).promote();
+    preparedPrimaryTargetId = null;
+  }
+
+  public void deactivateCode(UUID codeId) {
+    requireActive();
+    ColorPartnerCode code = activeCode(codeId);
+    if (code.isPrimary()) {
+      throw ColorPartnerRefDomainException.conflict(
+          "The active primary code cannot be deactivated; switch primary first");
+    }
+    code.deactivate();
+  }
+
+  public void deactivate() {
+    requireActive();
+    codes.stream()
+        .filter(code -> Boolean.TRUE.equals(code.getIsActive()))
+        .forEach(ColorPartnerCode::deactivate);
+    delete();
+  }
+
+  public void reactivateWithExistingCode(UUID codeId) {
+    requireInactive();
+    ColorPartnerCode selected = code(codeId);
+    if (Boolean.TRUE.equals(selected.getIsActive())) {
+      throw ColorPartnerRefDomainException.conflict(
+          "Only an inactive retained code can reactivate a relationship");
+    }
+    codes.forEach(
+        code -> {
+          if (Boolean.TRUE.equals(code.getIsActive())) {
+            code.deactivate();
+          } else {
+            code.demote();
+          }
+        });
+    selected.reactivateAsPrimary();
+    activate();
+  }
+
+  public ColorPartnerCode reactivateWithNewCode(String externalCode, String externalName) {
+    requireInactive();
+    String key = ColorPartnerCode.keyOf(externalCode);
+    if (codes.stream().anyMatch(code -> code.getExternalCodeKey().equals(key))) {
+      throw ColorPartnerRefDomainException.conflict(
+          "This aggregate already retains that code; reactivate it by ID instead");
+    }
+    codes.forEach(ColorPartnerCode::demote);
+    ColorPartnerCode selected =
+        ColorPartnerCode.create(this, getTenantId(), externalCode, externalName, true);
+    codes.add(selected);
+    activate();
+    return selected;
+  }
+
+  public ColorPartnerCode primaryCode() {
+    return codes.stream()
+        .filter(code -> Boolean.TRUE.equals(code.getIsActive()) && code.isPrimary())
+        .findFirst()
+        .orElseThrow(
+            () ->
+                ColorPartnerRefDomainException.conflict("Active relationship has no primary code"));
+  }
+
+  private void updateToleranceInternal(BigDecimal value) {
+    if (value != null && value.signum() <= 0) {
+      throw ColorPartnerRefDomainException.invalid(
+          "Partner Delta-E tolerance must be greater than zero");
+    }
+    if (value != null && value.compareTo(new BigDecimal("99.99")) > 0) {
+      throw ColorPartnerRefDomainException.invalid(
+          "Partner Delta-E tolerance must not exceed 99.99");
+    }
+    if (value != null && value.scale() > 2) {
+      throw ColorPartnerRefDomainException.invalid(
+          "Partner Delta-E tolerance must not have more than two decimal places");
+    }
+    this.deltaETolerance = value;
+  }
+
+  private ColorPartnerCode activeCode(UUID codeId) {
+    ColorPartnerCode code = code(codeId);
+    if (!Boolean.TRUE.equals(code.getIsActive())) {
+      throw ColorPartnerRefDomainException.conflict("Partner code is inactive: " + codeId);
+    }
+    return code;
+  }
+
+  private ColorPartnerCode code(UUID codeId) {
+    return codes.stream()
+        .filter(candidate -> Objects.equals(candidate.getId(), codeId))
+        .findFirst()
+        .orElseThrow(() -> ColorPartnerRefDomainException.codeNotFound(String.valueOf(codeId)));
+  }
+
+  private void requireActive() {
+    if (!Boolean.TRUE.equals(getIsActive())) {
+      throw ColorPartnerRefDomainException.conflict(
+          "Inactive partner references can only be reactivated");
+    }
+  }
+
+  private void requireInactive() {
+    if (Boolean.TRUE.equals(getIsActive())) {
+      throw ColorPartnerRefDomainException.conflict("Partner reference is already active");
+    }
+  }
+
+  @Override
+  protected String getModuleCode() {
+    return "CPR";
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/domain/PartnerRole.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/domain/PartnerRole.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.production.masterdata.color.domain;
+
+/** The business direction in which a partner identifies a tenant-owned color card. */
+public enum PartnerRole {
+  CUSTOMER,
+  SUPPLIER
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/domain/exception/ColorPartnerRefDomainException.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/domain/exception/ColorPartnerRefDomainException.java
@@ -1,0 +1,38 @@
+package com.fabricmanagement.production.masterdata.color.domain.exception;
+
+import com.fabricmanagement.production.common.exception.ProductionDomainException;
+
+public class ColorPartnerRefDomainException extends ProductionDomainException {
+
+  private ColorPartnerRefDomainException(String message, String errorCode, int httpStatus) {
+    super(message, errorCode, httpStatus);
+  }
+
+  public static ColorPartnerRefDomainException conflict(String message) {
+    return new ColorPartnerRefDomainException(
+        message, "PRODUCTION_COLOR_PARTNER_REF_CONFLICT", 409);
+  }
+
+  public static ColorPartnerRefDomainException invalid(String message) {
+    return new ColorPartnerRefDomainException(message, "PRODUCTION_COLOR_PARTNER_REF_INVALID", 422);
+  }
+
+  public static ColorPartnerRefDomainException duplicateCode(String externalCode) {
+    return new ColorPartnerRefDomainException(
+        "An active partner color code already exists: " + externalCode,
+        "PRODUCTION_COLOR_PARTNER_CODE_DUPLICATE",
+        409);
+  }
+
+  public static ColorPartnerRefDomainException unavailablePartner() {
+    return new ColorPartnerRefDomainException(
+        "The trading partner is missing, inactive, or incompatible with the requested role",
+        "PRODUCTION_COLOR_PARTNER_UNAVAILABLE",
+        409);
+  }
+
+  public static ColorPartnerRefDomainException codeNotFound(String codeId) {
+    return new ColorPartnerRefDomainException(
+        "Partner color code not found: " + codeId, "PRODUCTION_COLOR_PARTNER_CODE_NOT_FOUND", 404);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/AddColorPartnerCodeRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/AddColorPartnerCodeRequest.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "Adds an immutable code identity as an alias of an active relationship")
+public record AddColorPartnerCodeRequest(
+    @Schema(
+            description = "Partner's original code spelling; stored trimmed and immutable",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            maxLength = 50)
+        @NotBlank
+        @Size(max = 50)
+        String externalCode,
+    @Schema(
+            description = "Optional partner-owned color name, already trimmed when supplied",
+            nullable = true,
+            maxLength = 255)
+        @Size(max = 255)
+        @Pattern(regexp = "^\\S(?:.*\\S)?$", message = "must be null or trimmed and non-blank")
+        String externalName) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerCodeDto.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerCodeDto.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "A partner-owned primary or alias code retained by a color mapping")
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record ColorPartnerCodeDto(
+    @Schema(description = "Partner code identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID id,
+    @Schema(
+            description = "Partner's original trimmed spelling",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String externalCode,
+    @Schema(
+            description = "Optional partner-owned color name",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
+        String externalName,
+    @Schema(
+            description = "Whether this is the relationship's current active primary code",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean primary,
+    @Schema(
+            description = "Whether this alias can currently participate in lookup",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean active) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerCodeInput.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerCodeInput.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "Partner-owned code used to create or reactivate a color mapping")
+public record ColorPartnerCodeInput(
+    @Schema(
+            description = "Partner's original code spelling; stored trimmed and immutable",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            maxLength = 50)
+        @NotBlank
+        @Size(max = 50)
+        String externalCode,
+    @Schema(
+            description = "Optional partner-owned color name, already trimmed when supplied",
+            nullable = true,
+            maxLength = 255)
+        @Size(max = 255)
+        @Pattern(regexp = "^\\S(?:.*\\S)?$", message = "must be null or trimmed and non-blank")
+        String externalName) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerForwardResolutionDto.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerForwardResolutionDto.java
@@ -1,0 +1,33 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Forward lookup result containing the active primary partner code")
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record ColorPartnerForwardResolutionDto(
+    @Schema(
+            description = "Resolved partner-reference identifier",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID colorPartnerRefId,
+    @Schema(
+            description = "Tenant-owned color identifier",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID colorId,
+    @Schema(description = "Trading partner identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID partnerId,
+    @Schema(
+            description = "Business direction of the mapping",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        PartnerRole role,
+    @Schema(
+            description = "Partner's active primary code in its original spelling",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String externalCode,
+    @Schema(
+            description = "Optional name stored on the primary code",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
+        String externalName) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerRefDto.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerRefDto.java
@@ -1,0 +1,43 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(description = "Partner-to-color relationship with retained primary and alias codes")
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record ColorPartnerRefDto(
+    @Schema(
+            description = "Color partner-reference identifier",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID id,
+    @Schema(
+            description = "Tenant-owned color identifier",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID colorId,
+    @Schema(description = "Trading partner identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID partnerId,
+    @Schema(
+            description = "Business direction of the mapping",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        PartnerRole role,
+    @Schema(
+            description = "Optional partner-specific Delta-E tolerance override",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
+        BigDecimal deltaETolerance,
+    @Schema(
+            description = "Retained primary and alias codes",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        List<ColorPartnerCodeDto> codes,
+    @Schema(
+            description = "Whether the mapping is active",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean active,
+    @Schema(
+            description = "Optimistic-lock version of the aggregate root",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        long version) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerReverseResolutionDto.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ColorPartnerReverseResolutionDto.java
@@ -1,0 +1,35 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(
+    description = "Reverse partner-code lookup result, including alias and current-primary context")
+@JsonInclude(JsonInclude.Include.ALWAYS)
+public record ColorPartnerReverseResolutionDto(
+    @Schema(
+            description = "Resolved active tenant color card",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        ColorDto color,
+    @Schema(
+            description = "Original display spelling of the alias that matched",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String matchedExternalCode,
+    @Schema(
+            description = "Optional name stored on the matched alias",
+            requiredMode = Schema.RequiredMode.REQUIRED,
+            nullable = true)
+        String matchedExternalName,
+    @Schema(
+            description = "Whether the matched alias is the current primary",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean matchedIsPrimary,
+    @Schema(
+            description = "Current active primary code for the relationship",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String primaryExternalCode,
+    @Schema(
+            description = "Resolved partner-reference identifier for downstream traceability",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID colorPartnerRefId) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/CreateColorPartnerRefRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/CreateColorPartnerRefRequest.java
@@ -1,0 +1,35 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Schema(description = "Creates a partner-color relationship and its first primary code atomically")
+public record CreateColorPartnerRefRequest(
+    @Schema(description = "Trading partner identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        UUID partnerId,
+    @Schema(
+            description = "Business direction in which the partner code is used",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        PartnerRole role,
+    @Schema(
+            description = "Optional partner-specific Delta-E tolerance override; must be positive",
+            nullable = true)
+        @Positive
+        @DecimalMax("99.99")
+        @Digits(integer = 2, fraction = 2)
+        BigDecimal deltaETolerance,
+    @Schema(
+            description = "Required first code, created as the sole active primary",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        @Valid
+        ColorPartnerCodeInput initialPrimaryCode) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefRequest.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.AssertTrue;
+import java.util.UUID;
+
+@Schema(
+    description =
+        "Reactivates a relationship with exactly one existing inactive code or one new primary code",
+    oneOf = {
+      ReactivateColorPartnerRefWithExistingCodeRequest.class,
+      ReactivateColorPartnerRefWithNewCodeRequest.class
+    })
+public record ReactivateColorPartnerRefRequest(
+    @Schema(
+            description = "Inactive retained code to reactivate as the sole primary",
+            nullable = true)
+        UUID existingCodeId,
+    @Schema(description = "New code to create as the sole primary", nullable = true) @Valid
+        ColorPartnerCodeInput newPrimaryCode) {
+
+  @AssertTrue(message = "exactly one of existingCodeId or newPrimaryCode is required")
+  @Schema(hidden = true)
+  public boolean isExactlyOneAlternativePresent() {
+    return (existingCodeId == null) != (newPrimaryCode == null);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefWithExistingCodeRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefWithExistingCodeRequest.java
@@ -1,0 +1,13 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+@Schema(description = "Reactivation branch selecting one retained inactive partner code")
+public record ReactivateColorPartnerRefWithExistingCodeRequest(
+    @Schema(
+            description = "Inactive retained code to reactivate as the sole primary",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        UUID existingCodeId) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefWithNewCodeRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/ReactivateColorPartnerRefWithNewCodeRequest.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "Reactivation branch creating one new active primary partner code")
+public record ReactivateColorPartnerRefWithNewCodeRequest(
+    @Schema(
+            description = "New code to create as the sole primary",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        @Valid
+        ColorPartnerCodeInput newPrimaryCode) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorPartnerCodeRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorPartnerCodeRequest.java
@@ -1,0 +1,15 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "Full mutable state of a partner code; its code identity is immutable")
+public record UpdateColorPartnerCodeRequest(
+    @Schema(
+            description = "Optional partner-owned color name; null clears it",
+            nullable = true,
+            maxLength = 255)
+        @Size(max = 255)
+        @Pattern(regexp = "^\\S(?:.*\\S)?$", message = "must be null or trimmed and non-blank")
+        String externalName) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorPartnerRefRequest.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/dto/UpdateColorPartnerRefRequest.java
@@ -1,0 +1,17 @@
+package com.fabricmanagement.production.masterdata.color.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.Digits;
+import jakarta.validation.constraints.Positive;
+import java.math.BigDecimal;
+
+@Schema(description = "Full mutable state of a partner-color relationship")
+public record UpdateColorPartnerRefRequest(
+    @Schema(
+            description = "Optional partner-specific Delta-E tolerance override; null clears it",
+            nullable = true)
+        @Positive
+        @DecimalMax("99.99")
+        @Digits(integer = 2, fraction = 2)
+        BigDecimal deltaETolerance) {}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/infra/repository/ColorPartnerRefRepository.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/infra/repository/ColorPartnerRefRepository.java
@@ -1,0 +1,114 @@
+package com.fabricmanagement.production.masterdata.color.infra.repository;
+
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import jakarta.persistence.LockModeType;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ColorPartnerRefRepository extends JpaRepository<ColorPartnerRef, UUID> {
+
+  Page<ColorPartnerRef> findByTenantIdAndColorId(UUID tenantId, UUID colorId, Pageable pageable);
+
+  @Query(
+      """
+      select distinct ref
+      from ColorPartnerRef ref
+      left join fetch ref.codes
+      where ref.tenantId = :tenantId
+        and ref.id in :ids
+      """)
+  List<ColorPartnerRef> findWithCodesByTenantIdAndIdIn(
+      @Param("tenantId") UUID tenantId, @Param("ids") Collection<UUID> ids);
+
+  @EntityGraph(attributePaths = "codes")
+  Optional<ColorPartnerRef> findByTenantIdAndId(UUID tenantId, UUID id);
+
+  @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
+  @EntityGraph(attributePaths = "codes")
+  @Query(
+      "select distinct ref from ColorPartnerRef ref left join ref.codes "
+          + "where ref.tenantId = :tenantId and ref.id = :id")
+  Optional<ColorPartnerRef> findForMutationByTenantIdAndId(
+      @Param("tenantId") UUID tenantId, @Param("id") UUID id);
+
+  boolean existsByTenantIdAndColorIdAndPartnerIdAndRole(
+      UUID tenantId, UUID colorId, UUID partnerId, PartnerRole role);
+
+  @Query(
+      """
+      select count(code) > 0
+      from ColorPartnerCode code
+      where code.tenantId = :tenantId
+        and code.partnerId = :partnerId
+        and code.role = :role
+        and code.externalCodeKey = :externalCodeKey
+        and code.isActive = true
+      """)
+  boolean existsActiveCode(
+      @Param("tenantId") UUID tenantId,
+      @Param("partnerId") UUID partnerId,
+      @Param("role") PartnerRole role,
+      @Param("externalCodeKey") String externalCodeKey);
+
+  @Query(
+      """
+      select code
+      from ColorPartnerCode code
+      join fetch code.colorPartnerRef ref
+      where code.tenantId = :tenantId
+        and code.partnerId = :partnerId
+        and code.role = :role
+        and code.externalCodeKey = :externalCodeKey
+        and code.isActive = true
+        and ref.isActive = true
+        and exists (
+          select color.id from Color color
+          where color.tenantId = :tenantId
+            and color.id = ref.colorId
+            and color.isActive = true
+        )
+      """)
+  Optional<ColorPartnerCode> findActiveCodeForReverseLookup(
+      @Param("tenantId") UUID tenantId,
+      @Param("partnerId") UUID partnerId,
+      @Param("role") PartnerRole role,
+      @Param("externalCodeKey") String externalCodeKey);
+
+  @Query(
+      """
+      select code
+      from ColorPartnerCode code
+      join fetch code.colorPartnerRef ref
+      where code.tenantId = :tenantId
+        and ref.colorId = :colorId
+        and ref.partnerId = :partnerId
+        and ref.role = :role
+        and code.isActive = true
+        and code.primary = true
+        and ref.isActive = true
+        and exists (
+          select color.id from Color color
+          where color.tenantId = :tenantId
+            and color.id = ref.colorId
+            and color.isActive = true
+        )
+      """)
+  Optional<ColorPartnerCode> findActivePrimaryForForwardLookup(
+      @Param("tenantId") UUID tenantId,
+      @Param("colorId") UUID colorId,
+      @Param("partnerId") UUID partnerId,
+      @Param("role") PartnerRole role);
+}

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/mapper/ColorPartnerRefMapper.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/mapper/ColorPartnerRefMapper.java
@@ -1,0 +1,22 @@
+package com.fabricmanagement.production.masterdata.color.mapper;
+
+import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerCodeDto;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerRefDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapStructConfig.class)
+public interface ColorPartnerRefMapper {
+
+  @Mapping(target = "active", expression = "java(Boolean.TRUE.equals(ref.getIsActive()))")
+  @Mapping(
+      target = "version",
+      expression = "java(ref.getVersion() == null ? 0L : ref.getVersion())")
+  ColorPartnerRefDto toDto(ColorPartnerRef ref);
+
+  @Mapping(target = "active", expression = "java(Boolean.TRUE.equals(code.getIsActive()))")
+  ColorPartnerCodeDto toDto(ColorPartnerCode code);
+}

--- a/src/main/resources/db/migration/V20260717120000__color_partner_ref.sql
+++ b/src/main/resources/db/migration/V20260717120000__color_partner_ref.sql
@@ -1,0 +1,127 @@
+ALTER TABLE production.color
+    DROP CONSTRAINT IF EXISTS uq_color_tenant_id;
+
+ALTER TABLE production.color
+    ADD CONSTRAINT uq_color_tenant_id UNIQUE (tenant_id, id);
+
+CREATE TABLE IF NOT EXISTS production.color_partner_ref (
+    id UUID PRIMARY KEY,
+    uid VARCHAR(100) UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by UUID,
+    updated_by UUID,
+    tenant_id UUID NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+
+    color_id UUID NOT NULL,
+    partner_id UUID NOT NULL,
+    role VARCHAR(20) NOT NULL,
+    delta_e_tolerance NUMERIC(4,2),
+
+    CONSTRAINT chk_color_partner_ref_role
+        CHECK (role IN ('CUSTOMER', 'SUPPLIER')),
+    CONSTRAINT chk_color_partner_ref_tolerance
+        CHECK (delta_e_tolerance IS NULL OR delta_e_tolerance > 0),
+    CONSTRAINT uq_color_partner_ref_relationship
+        UNIQUE (tenant_id, color_id, partner_id, role),
+    CONSTRAINT uq_color_partner_ref_child_target
+        UNIQUE (tenant_id, id, partner_id, role),
+    CONSTRAINT fk_color_partner_ref_color
+        FOREIGN KEY (tenant_id, color_id)
+        REFERENCES production.color (tenant_id, id)
+        ON DELETE RESTRICT
+);
+
+CREATE TABLE IF NOT EXISTS production.color_partner_code (
+    id UUID PRIMARY KEY,
+    uid VARCHAR(100) UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL,
+    created_by UUID,
+    updated_by UUID,
+    tenant_id UUID NOT NULL,
+    is_active BOOLEAN NOT NULL DEFAULT true,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+
+    color_partner_ref_id UUID NOT NULL,
+    partner_id UUID NOT NULL,
+    role VARCHAR(20) NOT NULL,
+    external_code VARCHAR(50) NOT NULL,
+    external_code_key VARCHAR(50) NOT NULL,
+    external_name VARCHAR(255),
+    is_primary BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT fk_color_partner_code_ref
+        FOREIGN KEY (tenant_id, color_partner_ref_id, partner_id, role)
+        REFERENCES production.color_partner_ref (tenant_id, id, partner_id, role)
+        ON DELETE RESTRICT
+);
+
+ALTER TABLE production.color_partner_code
+    DROP CONSTRAINT IF EXISTS chk_color_partner_code_key,
+    DROP CONSTRAINT IF EXISTS chk_color_partner_code_display,
+    DROP CONSTRAINT IF EXISTS chk_color_partner_code_key_not_blank,
+    DROP CONSTRAINT IF EXISTS chk_color_partner_code_name,
+    DROP CONSTRAINT IF EXISTS chk_color_partner_code_role;
+
+ALTER TABLE production.color_partner_code
+    ADD CONSTRAINT chk_color_partner_code_key
+        CHECK (external_code_key = upper(btrim(external_code))),
+    ADD CONSTRAINT chk_color_partner_code_display
+        CHECK (external_code = btrim(external_code) AND external_code <> ''),
+    ADD CONSTRAINT chk_color_partner_code_key_not_blank
+        CHECK (external_code_key <> ''),
+    ADD CONSTRAINT chk_color_partner_code_name
+        CHECK (
+            external_name IS NULL
+            OR (external_name = btrim(external_name) AND external_name <> '')
+        ),
+    ADD CONSTRAINT chk_color_partner_code_role
+        CHECK (role IN ('CUSTOMER', 'SUPPLIER'));
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_color_partner_code_active_primary
+    ON production.color_partner_code (tenant_id, color_partner_ref_id)
+    WHERE is_active AND is_primary;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_color_partner_code_active_lookup
+    ON production.color_partner_code (tenant_id, partner_id, role, external_code_key)
+    WHERE is_active;
+
+CREATE INDEX IF NOT EXISTS idx_color_partner_ref_color
+    ON production.color_partner_ref (tenant_id, color_id);
+
+CREATE INDEX IF NOT EXISTS idx_color_partner_code_ref
+    ON production.color_partner_code (tenant_id, color_partner_ref_id);
+
+ALTER TABLE production.color_partner_ref ENABLE ROW LEVEL SECURITY;
+ALTER TABLE production.color_partner_ref FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rls_tenant_isolation ON production.color_partner_ref;
+CREATE POLICY rls_tenant_isolation ON production.color_partner_ref
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+ALTER TABLE production.color_partner_code ENABLE ROW LEVEL SECURITY;
+ALTER TABLE production.color_partner_code FORCE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS rls_tenant_isolation ON production.color_partner_code;
+CREATE POLICY rls_tenant_isolation ON production.color_partner_code
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE
+      ON production.color_partner_ref, production.color_partner_code TO fabric_app;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_system') THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE
+      ON production.color_partner_ref, production.color_partner_code TO fabric_system;
+  END IF;
+END $$;

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -380,6 +380,24 @@ class ConstitutionArchTest {
     }
 
     @Test
+    @DisplayName("Rule 6.4: Color partner aliases have no independently injectable repository")
+    void colorPartnerCodesMustOnlyBeWrittenThroughTheirAggregateRoot() {
+      ArchRule rule =
+          classes()
+              .that()
+              .resideInAPackage(
+                  "com.fabricmanagement.production.masterdata.color.infra.repository..")
+              .and()
+              .areAssignableTo(org.springframework.data.repository.Repository.class)
+              .should()
+              .haveSimpleNameNotContaining("ColorPartnerCode")
+              .as(
+                  "Rule 6.4: ColorPartnerCode is an aggregate child and must not expose its own repository");
+
+      rule.check(allClasses);
+    }
+
+    @Test
     @DisplayName("Rule 6.2: Domain Events must end with 'Event' suffix")
     void domainEventsShouldEndWithEvent() {
       ArchRule rule =

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/TenantIsolationIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/TenantIsolationIT.java
@@ -59,6 +59,10 @@ class TenantIsolationIT {
   private static final UUID TENANT_B = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
   private static final String STRICT_PARTNER_UID = "TEST-A-STRICT-TP";
   private static final String STRICT_REGISTRY_UID = "TEST-A-STRICT-REG";
+  private static final UUID COLOR_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000001");
+  private static final UUID COLOR_B = UUID.fromString("bbbbbbbb-0000-4000-8000-000000000002");
+  private static final UUID COLOR_REF_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000011");
+  private static final UUID COLOR_REF_B = UUID.fromString("bbbbbbbb-0000-4000-8000-000000000012");
 
   @Container
   @SuppressWarnings("resource")
@@ -175,6 +179,61 @@ class TenantIsolationIT {
               + "AND NOT EXISTS (SELECT 1 FROM common_company.common_trading_partner WHERE uid = '"
               + STRICT_PARTNER_UID
               + "')");
+
+      stmt.execute(
+          "INSERT INTO production.color "
+              + "(id, tenant_id, uid, code, name, color_type, color_family, standard_status, "
+              + "is_active, created_at, updated_at, version) VALUES "
+              + "('"
+              + COLOR_A
+              + "', '"
+              + TENANT_A
+              + "', 'TEST-A-COLOR', 'RLS-COLOR-A', "
+              + "'RLS Color A', 'DYED', 'BLUE', 'DRAFT', true, now(), now(), 0), "
+              + "('"
+              + COLOR_B
+              + "', '"
+              + TENANT_B
+              + "', 'TEST-B-COLOR', 'RLS-COLOR-B', "
+              + "'RLS Color B', 'DYED', 'BLUE', 'DRAFT', true, now(), now(), 0) "
+              + "ON CONFLICT (id) DO NOTHING");
+      stmt.execute(
+          "INSERT INTO production.color_partner_ref "
+              + "(id, tenant_id, uid, color_id, partner_id, role, is_active, created_at, updated_at, version) VALUES "
+              + "('"
+              + COLOR_REF_A
+              + "', '"
+              + TENANT_A
+              + "', 'TEST-A-COLOR-REF', '"
+              + COLOR_A
+              + "', gen_random_uuid(), 'CUSTOMER', true, now(), now(), 0), "
+              + "('"
+              + COLOR_REF_B
+              + "', '"
+              + TENANT_B
+              + "', 'TEST-B-COLOR-REF', '"
+              + COLOR_B
+              + "', gen_random_uuid(), 'CUSTOMER', true, now(), now(), 0) "
+              + "ON CONFLICT (id) DO NOTHING");
+      stmt.execute(
+          "INSERT INTO production.color_partner_code "
+              + "(id, tenant_id, uid, color_partner_ref_id, partner_id, role, external_code, "
+              + "external_code_key, is_primary, is_active, created_at, updated_at, version) "
+              + "SELECT gen_random_uuid(), ref.tenant_id, ref.uid || '-CODE', ref.id, ref.partner_id, "
+              + "ref.role, CASE WHEN ref.tenant_id = '"
+              + TENANT_A
+              + "' THEN 'RLS-A' ELSE 'RLS-B' END, "
+              + "CASE WHEN ref.tenant_id = '"
+              + TENANT_A
+              + "' THEN 'RLS-A' ELSE 'RLS-B' END, "
+              + "true, true, now(), now(), 0 FROM production.color_partner_ref ref "
+              + "WHERE ref.id IN ('"
+              + COLOR_REF_A
+              + "', '"
+              + COLOR_REF_B
+              + "') "
+              + "AND NOT EXISTS (SELECT 1 FROM production.color_partner_code code "
+              + "WHERE code.color_partner_ref_id = ref.id)");
 
       stmt.close();
     }
@@ -326,5 +385,51 @@ class TenantIsolationIT {
             TENANT_B);
 
     assertThat(count).isEqualTo(2);
+  }
+
+  @Test
+  @Order(7)
+  @DisplayName("Color partner refs and codes are isolated through the NOBYPASSRLS runtime role")
+  void colorPartnerRefsUseRealRlsIsolation() throws Exception {
+    try (Connection tenantA = getAppConnection(TENANT_A)) {
+      ResultSet refs =
+          tenantA.createStatement().executeQuery("SELECT id FROM production.color_partner_ref");
+      List<UUID> refIds = new ArrayList<>();
+      while (refs.next()) {
+        refIds.add(refs.getObject(1, UUID.class));
+      }
+      assertThat(refIds).contains(COLOR_REF_A).doesNotContain(COLOR_REF_B);
+
+      ResultSet codes =
+          tenantA
+              .createStatement()
+              .executeQuery("SELECT external_code FROM production.color_partner_code");
+      List<String> externalCodes = new ArrayList<>();
+      while (codes.next()) {
+        externalCodes.add(codes.getString(1));
+      }
+      assertThat(externalCodes).contains("RLS-A").doesNotContain("RLS-B");
+    }
+  }
+
+  @Test
+  @Order(8)
+  @DisplayName("Color partner ref WITH CHECK rejects a cross-tenant write")
+  void colorPartnerRefWithCheckRejectsCrossTenantWrite() throws Exception {
+    try (Connection tenantA = getAppConnection(TENANT_A)) {
+      assertThatThrownBy(
+              () ->
+                  tenantA
+                      .createStatement()
+                      .execute(
+                          "INSERT INTO production.color_partner_ref "
+                              + "(id, tenant_id, color_id, partner_id, role, is_active, created_at, updated_at, version) "
+                              + "VALUES (gen_random_uuid(), '"
+                              + TENANT_B
+                              + "', '"
+                              + COLOR_B
+                              + "', gen_random_uuid(), 'CUSTOMER', true, now(), now(), 0)"))
+          .hasMessageContaining("row-level security");
+    }
   }
 }

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
@@ -216,6 +216,12 @@ class PurgeSchemaCoverageIT extends AbstractIntegrationTest {
         "notification.user_notification_preference",
         "Seed-user notification preferences are deleted by demo_seed CTE.");
     tables.put(
+        "production.color_partner_code",
+        "Partner color aliases are deleted by dedicated product-reference cleanup.");
+    tables.put(
+        "production.color_partner_ref",
+        "Partner color relationships are deleted by dedicated product-reference cleanup.");
+    tables.put(
         "production.color",
         "Product reference data is deleted by dedicated product-reference cleanup.");
     tables.put(

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -176,6 +176,8 @@ class TenantTransactionalPurgeServiceTest {
             "sales.quote",
             "procurement.purchase_order",
             "production.prod_product",
+            "production.color_partner_code",
+            "production.color_partner_ref",
             "production.color",
             "production.production_execution_batch_override_log",
             "sales_ord.sales_order_line_processed_shipments",
@@ -260,6 +262,10 @@ class TenantTransactionalPurgeServiceTest {
         .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"));
     assertThat(indexOf(sql, "DELETE FROM production.quality_grade WHERE tenant_id = ?"))
         .isLessThan(indexOf(sql, "DELETE FROM production.prod_product WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.color_partner_code WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.color_partner_ref WHERE tenant_id = ?"));
+    assertThat(indexOf(sql, "DELETE FROM production.color_partner_ref WHERE tenant_id = ?"))
+        .isLessThan(indexOf(sql, "DELETE FROM production.color WHERE tenant_id = ?"));
     assertThat(indexOf(sql, "DELETE FROM production.color WHERE tenant_id = ?"))
         .isLessThan(indexOf(sql, "DELETE FROM production.prod_product WHERE tenant_id = ?"));
     assertThat(indexOf(sql, "DELETE FROM production.prod_fiber_certification WHERE tenant_id = ?"))

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/api/ColorPartnerRefControllerTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/api/ColorPartnerRefControllerTest.java
@@ -1,0 +1,266 @@
+package com.fabricmanagement.production.masterdata.color.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.masterdata.color.app.ColorPartnerRefQueryService;
+import com.fabricmanagement.production.masterdata.color.app.ColorPartnerRefService;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerReverseResolutionDto;
+import com.fabricmanagement.production.masterdata.color.dto.CreateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.mapper.ColorMapper;
+import com.fabricmanagement.production.masterdata.color.mapper.ColorPartnerRefMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ColorPartnerRefController.class)
+@EnableMethodSecurity
+class ColorPartnerRefControllerTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-4111-8111-111111111111");
+  private static final UUID COLOR_ID = UUID.fromString("22222222-2222-4222-8222-222222222222");
+  private static final UUID PARTNER_ID = UUID.fromString("33333333-3333-4333-8333-333333333333");
+  private static final UUID REF_ID = UUID.fromString("44444444-4444-4444-8444-444444444444");
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private ColorPartnerRefService colorPartnerRefService;
+  @MockBean private ColorPartnerRefQueryService colorPartnerRefQueryService;
+  @MockBean private ColorPartnerRefMapper colorPartnerRefMapper;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  private final ColorPartnerRefMapper delegateMapper =
+      Mappers.getMapper(ColorPartnerRefMapper.class);
+  private final ColorMapper colorMapper = Mappers.getMapper(ColorMapper.class);
+
+  @BeforeEach
+  void useRealMapper() {
+    when(colorPartnerRefMapper.toDto(any(ColorPartnerRef.class)))
+        .thenAnswer(
+            invocation -> delegateMapper.toDto(invocation.getArgument(0, ColorPartnerRef.class)));
+    when(colorPartnerRefMapper.toDto(any(ColorPartnerCode.class)))
+        .thenAnswer(
+            invocation -> delegateMapper.toDto(invocation.getArgument(0, ColorPartnerCode.class)));
+  }
+
+  @Test
+  @WithMockUser
+  void readPermissionAllowsLookupsButDoesNotAllowMutations() throws Exception {
+    allow("read");
+    Color color = Color.create(TENANT_ID, "NAVY-001", "Navy", "#1F2A44");
+    color.setId(COLOR_ID);
+    when(colorPartnerRefQueryService.resolve(PARTNER_ID, PartnerRole.CUSTOMER, "ALIAS"))
+        .thenReturn(
+            new ColorPartnerReverseResolutionDto(
+                colorMapper.toDto(color), "ALIAS", null, false, "PRIMARY", REF_ID));
+
+    mockMvc
+        .perform(
+            get("/api/v1/production/color-partner-refs/resolve")
+                .param("partnerId", PARTNER_ID.toString())
+                .param("role", "CUSTOMER")
+                .param("externalCode", "ALIAS"))
+        .andExpect(status().isOk());
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateBody()))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void reverseAliasHitReturnsTheCompleteD6Shape() throws Exception {
+    allow("read");
+    Color color = Color.create(TENANT_ID, "NAVY-001", "Navy", "#1F2A44");
+    color.setId(COLOR_ID);
+    when(colorPartnerRefQueryService.resolve(PARTNER_ID, PartnerRole.CUSTOMER, "ss24-nvy"))
+        .thenReturn(
+            new ColorPartnerReverseResolutionDto(
+                colorMapper.toDto(color), "SS24-NVY", "Old navy", false, "SS26-NVY-07", REF_ID));
+
+    mockMvc
+        .perform(
+            get("/api/v1/production/color-partner-refs/resolve")
+                .param("partnerId", PARTNER_ID.toString())
+                .param("role", "CUSTOMER")
+                .param("externalCode", "ss24-nvy"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.color.id").value(COLOR_ID.toString()))
+        .andExpect(jsonPath("$.data.matchedExternalCode").value("SS24-NVY"))
+        .andExpect(jsonPath("$.data.matchedExternalName").value("Old navy"))
+        .andExpect(jsonPath("$.data.matchedIsPrimary").value(false))
+        .andExpect(jsonPath("$.data.primaryExternalCode").value("SS26-NVY-07"))
+        .andExpect(jsonPath("$.data.colorPartnerRefId").value(REF_ID.toString()));
+  }
+
+  @Test
+  @WithMockUser
+  void writePermissionAllowsCreationAndDuplicateCodeIsConflict() throws Exception {
+    allow("write");
+    when(colorPartnerRefService.create(eq(COLOR_ID), any(CreateColorPartnerRefRequest.class)))
+        .thenReturn(ref());
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateBody()))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.codes[0].externalCode").value("SS26-NVY-07"))
+        .andExpect(jsonPath("$.data.codes[0].primary").value(true));
+
+    when(colorPartnerRefService.create(eq(COLOR_ID), any(CreateColorPartnerRefRequest.class)))
+        .thenThrow(ColorPartnerRefDomainException.duplicateCode("SS26-NVY-07"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateBody()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("PRODUCTION_COLOR_PARTNER_CODE_DUPLICATE"));
+  }
+
+  @Test
+  @WithMockUser
+  void malformedCommandsUseTheCanonical422ValidationResponse() throws Exception {
+    allow("write");
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"partnerId":null,"role":null,"deltaETolerance":0,
+                     "initialPrimaryCode":{"externalCode":"","externalName":" padded "}}
+                    """))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @WithMockUser
+  void tolerancePrecisionAndScaleViolationsAreRejectedBeforePersistence() throws Exception {
+    allow("write");
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"partnerId":"%s","role":"CUSTOMER","deltaETolerance":100,
+                     "initialPrimaryCode":{"externalCode":"SS26-NVY-07"}}
+                    """
+                        .formatted(PARTNER_ID)))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"partnerId":"%s","role":"CUSTOMER","deltaETolerance":1.234,
+                     "initialPrimaryCode":{"externalCode":"SS26-NVY-07"}}
+                    """
+                        .formatted(PARTNER_ID)))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+  }
+
+  @Test
+  @WithMockUser
+  void forwardWithoutAnActivePrimaryIsNotFound() throws Exception {
+    allow("read");
+    when(colorPartnerRefQueryService.forward(COLOR_ID, PARTNER_ID, PartnerRole.SUPPLIER))
+        .thenThrow(new NotFoundException("No active primary partner color code found"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/production/color-partner-refs/forward")
+                .param("colorId", COLOR_ID.toString())
+                .param("partnerId", PARTNER_ID.toString())
+                .param("role", "SUPPLIER"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @WithMockUser
+  void staleMutationIsMappedToConflict() throws Exception {
+    allow("write");
+    when(colorPartnerRefService.create(eq(COLOR_ID), any(CreateColorPartnerRefRequest.class)))
+        .thenThrow(new ObjectOptimisticLockingFailureException(ColorPartnerRef.class, REF_ID));
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/colors/{colorId}/partner-refs", COLOR_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(validCreateBody()))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("OPTIMISTIC_LOCK"));
+  }
+
+  private void allow(String action) {
+    when(authEvaluator.can(any(Authentication.class), eq("colors"), eq(action))).thenReturn(true);
+  }
+
+  private ColorPartnerRef ref() {
+    ColorPartnerRef ref =
+        ColorPartnerRef.create(
+            TENANT_ID, COLOR_ID, PARTNER_ID, PartnerRole.CUSTOMER, null, "SS26-NVY-07", "Navy");
+    ref.setId(REF_ID);
+    ref.getCodes().getFirst().setId(UUID.randomUUID());
+    return ref;
+  }
+
+  private String validCreateBody() {
+    return """
+        {"partnerId":"%s","role":"CUSTOMER",
+         "initialPrimaryCode":{"externalCode":"SS26-NVY-07","externalName":"Navy"}}
+        """
+        .formatted(PARTNER_ID);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefConstraintIT.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefConstraintIT.java
@@ -1,0 +1,238 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ColorPartnerRefConstraintIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.flyway.url", postgres::getJdbcUrl);
+    registry.add("spring.flyway.user", postgres::getUsername);
+    registry.add("spring.flyway.password", postgres::getPassword);
+    registry.add("spring.flyway.enabled", () -> "true");
+  }
+
+  private UUID tenantA;
+  private UUID tenantB;
+  private UUID colorA1;
+  private UUID colorA2;
+  private UUID colorB;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    tenantA = UUID.randomUUID();
+    tenantB = UUID.randomUUID();
+    colorA1 = insertColor(tenantA, "A1");
+    colorA2 = insertColor(tenantA, "A2");
+    colorB = insertColor(tenantB, "B1");
+  }
+
+  @Test
+  void databasePinsTenantIdentityNormalizationPrimaryAndReusableActiveKeys() throws Exception {
+    UUID partner = UUID.randomUUID();
+
+    assertThatThrownBy(() -> insertRef(tenantA, colorB, partner, "CUSTOMER"))
+        .hasMessageContaining("fk_color_partner_ref_color");
+
+    UUID ref1 = insertRef(tenantA, colorA1, partner, "CUSTOMER");
+    UUID ref2 = insertRef(tenantA, colorA2, partner, "CUSTOMER");
+    UUID primary =
+        insertCode(tenantA, ref1, partner, "CUSTOMER", "Display-1", "DISPLAY-1", true, true);
+
+    assertThatThrownBy(
+            () ->
+                insertCode(
+                    tenantA, ref1, partner, "CUSTOMER", "Display-2", "WRONG-KEY", false, true))
+        .hasMessageContaining("chk_color_partner_code_key");
+
+    assertThatThrownBy(
+            () ->
+                insertCode(
+                    tenantA, ref1, UUID.randomUUID(), "CUSTOMER", "DRIFT", "DRIFT", false, true))
+        .hasMessageContaining("fk_color_partner_code_ref");
+
+    assertThatThrownBy(
+            () -> insertCode(tenantA, ref1, partner, "CUSTOMER", "SECOND", "SECOND", true, true))
+        .hasMessageContaining("uq_color_partner_code_active_primary");
+
+    assertThatThrownBy(
+            () ->
+                insertCode(
+                    tenantA, ref2, partner, "CUSTOMER", "display-1", "DISPLAY-1", true, true))
+        .hasMessageContaining("uq_color_partner_code_active_lookup");
+
+    update(
+        "UPDATE production.color_partner_code SET is_active = false, is_primary = false WHERE id = ?",
+        primary);
+    assertThatCode(
+            () ->
+                insertCode(
+                    tenantA, ref2, partner, "CUSTOMER", "display-1", "DISPLAY-1", true, true))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void cascadeDeactivateReleasesAKeyAndDemoteFlushPromoteWorksWithThePartialIndex()
+      throws Exception {
+    UUID switchPartner = UUID.randomUUID();
+    UUID switchRef = insertRef(tenantA, colorA1, switchPartner, "SUPPLIER");
+    UUID oldPrimary =
+        insertCode(tenantA, switchRef, switchPartner, "SUPPLIER", "OLD", "OLD", true, true);
+    UUID target =
+        insertCode(tenantA, switchRef, switchPartner, "SUPPLIER", "NEW", "NEW", false, true);
+
+    try (Connection connection = connection()) {
+      connection.setAutoCommit(false);
+      try (PreparedStatement demote =
+              connection.prepareStatement(
+                  "UPDATE production.color_partner_code SET is_primary = false WHERE id = ?");
+          PreparedStatement promote =
+              connection.prepareStatement(
+                  "UPDATE production.color_partner_code SET is_primary = true WHERE id = ?")) {
+        demote.setObject(1, oldPrimary);
+        demote.executeUpdate();
+        promote.setObject(1, target);
+        promote.executeUpdate();
+        connection.commit();
+      }
+    }
+
+    UUID reusablePartner = UUID.randomUUID();
+    UUID sourceRef = insertRef(tenantA, colorA1, reusablePartner, "CUSTOMER");
+    insertCode(tenantA, sourceRef, reusablePartner, "CUSTOMER", "REUSE", "REUSE", true, true);
+    update(
+        "UPDATE production.color_partner_code SET is_active = false, is_primary = false "
+            + "WHERE color_partner_ref_id = ?",
+        sourceRef);
+    update("UPDATE production.color_partner_ref SET is_active = false WHERE id = ?", sourceRef);
+
+    UUID destinationRef = insertRef(tenantA, colorA2, reusablePartner, "CUSTOMER");
+    assertThatCode(
+            () ->
+                insertCode(
+                    tenantA,
+                    destinationRef,
+                    reusablePartner,
+                    "CUSTOMER",
+                    "REUSE",
+                    "REUSE",
+                    true,
+                    true))
+        .doesNotThrowAnyException();
+  }
+
+  private UUID insertColor(UUID tenantId, String suffix) throws Exception {
+    UUID id = UUID.randomUUID();
+    try (Connection connection = connection();
+        PreparedStatement statement =
+            connection.prepareStatement(
+                "INSERT INTO production.color "
+                    + "(id, tenant_id, created_at, updated_at, is_active, version, code, name, "
+                    + "color_type, color_family, standard_status) "
+                    + "VALUES (?, ?, now(), now(), true, 0, ?, ?, 'DYED', 'BLUE', 'DRAFT')")) {
+      statement.setObject(1, id);
+      statement.setObject(2, tenantId);
+      statement.setString(
+          3, "CONSTRAINT-" + suffix + "-" + id.toString().substring(0, 8).toUpperCase());
+      statement.setString(4, "Constraint " + suffix);
+      statement.executeUpdate();
+    }
+    return id;
+  }
+
+  private UUID insertRef(UUID tenantId, UUID colorId, UUID partnerId, String role)
+      throws Exception {
+    UUID id = UUID.randomUUID();
+    try (Connection connection = connection();
+        PreparedStatement statement =
+            connection.prepareStatement(
+                "INSERT INTO production.color_partner_ref "
+                    + "(id, tenant_id, created_at, updated_at, is_active, version, color_id, partner_id, role) "
+                    + "VALUES (?, ?, now(), now(), true, 0, ?, ?, ?)")) {
+      statement.setObject(1, id);
+      statement.setObject(2, tenantId);
+      statement.setObject(3, colorId);
+      statement.setObject(4, partnerId);
+      statement.setString(5, role);
+      statement.executeUpdate();
+    }
+    return id;
+  }
+
+  private UUID insertCode(
+      UUID tenantId,
+      UUID refId,
+      UUID partnerId,
+      String role,
+      String display,
+      String key,
+      boolean primary,
+      boolean active)
+      throws Exception {
+    UUID id = UUID.randomUUID();
+    try (Connection connection = connection();
+        PreparedStatement statement =
+            connection.prepareStatement(
+                "INSERT INTO production.color_partner_code "
+                    + "(id, tenant_id, created_at, updated_at, is_active, version, color_partner_ref_id, "
+                    + "partner_id, role, external_code, external_code_key, is_primary) "
+                    + "VALUES (?, ?, now(), now(), ?, 0, ?, ?, ?, ?, ?, ?)")) {
+      statement.setObject(1, id);
+      statement.setObject(2, tenantId);
+      statement.setBoolean(3, active);
+      statement.setObject(4, refId);
+      statement.setObject(5, partnerId);
+      statement.setString(6, role);
+      statement.setString(7, display);
+      statement.setString(8, key);
+      statement.setBoolean(9, primary);
+      statement.executeUpdate();
+    }
+    return id;
+  }
+
+  private void update(String sql, UUID id) throws Exception {
+    try (Connection connection = connection();
+        PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.setObject(1, id);
+      statement.executeUpdate();
+    }
+  }
+
+  private Connection connection() throws Exception {
+    return DriverManager.getConnection(
+        postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefLockingIT.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefLockingIT.java
@@ -1,0 +1,266 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorPartnerRefRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.OptimisticLockException;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.hibernate.StaleObjectStateException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ColorPartnerRefLockingIT {
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.flyway.url", postgres::getJdbcUrl);
+    registry.add("spring.flyway.user", postgres::getUsername);
+    registry.add("spring.flyway.password", postgres::getPassword);
+    registry.add("spring.flyway.enabled", () -> "true");
+  }
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+  @Autowired private ColorPartnerRefRepository repository;
+  @Autowired private TransactionTemplate transactionTemplate;
+  @Autowired private PlatformTransactionManager transactionManager;
+  @Autowired private EntityManager entityManager;
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void childOnlyPrimarySwitchIncrementsTheForcedLockedRootVersion() {
+    UUID tenantId = UUID.randomUUID();
+    UUID colorId = UUID.randomUUID();
+    UUID partnerId = UUID.randomUUID();
+    UUID refId = UUID.randomUUID();
+    UUID oldPrimaryId = UUID.randomUUID();
+    UUID targetId = UUID.randomUUID();
+    insertFixture(tenantId, colorId, partnerId, refId, oldPrimaryId, targetId);
+    TenantContext.setCurrentTenantId(tenantId);
+
+    Long before =
+        jdbcTemplate.queryForObject(
+            "SELECT version FROM production.color_partner_ref WHERE id = ?", Long.class, refId);
+
+    transactionTemplate.executeWithoutResult(
+        ignored -> {
+          ColorPartnerRef ref =
+              repository.findForMutationByTenantIdAndId(tenantId, refId).orElseThrow();
+          ref.preparePrimarySwitch(targetId);
+          entityManager.flush();
+          ref.completePrimarySwitch(targetId);
+          repository.save(ref);
+        });
+
+    Long after =
+        jdbcTemplate.queryForObject(
+            "SELECT version FROM production.color_partner_ref WHERE id = ?", Long.class, refId);
+    Boolean targetIsPrimary =
+        jdbcTemplate.queryForObject(
+            "SELECT is_primary FROM production.color_partner_code WHERE id = ?",
+            Boolean.class,
+            targetId);
+
+    assertThat(after).isEqualTo(before + 1);
+    assertThat(targetIsPrimary).isTrue();
+  }
+
+  @Test
+  void staleConcurrentChildMutationLosesWithAnOptimisticLockFailure() throws Exception {
+    UUID tenantId = UUID.randomUUID();
+    UUID colorId = UUID.randomUUID();
+    UUID partnerId = UUID.randomUUID();
+    UUID refId = UUID.randomUUID();
+    UUID oldPrimaryId = UUID.randomUUID();
+    UUID aliasId = UUID.randomUUID();
+    insertFixture(tenantId, colorId, partnerId, refId, oldPrimaryId, aliasId);
+
+    CountDownLatch staleWriterLoaded = new CountDownLatch(1);
+    CountDownLatch winningWriterCommitted = new CountDownLatch(1);
+    ExecutorService writers = Executors.newFixedThreadPool(2);
+    try {
+      var first =
+          writers.submit(
+              () -> {
+                Throwable failure =
+                    winningCodeNameUpdate(
+                        tenantId, refId, aliasId, "Writer one", staleWriterLoaded);
+                winningWriterCommitted.countDown();
+                return failure;
+              });
+      var second =
+          writers.submit(
+              () ->
+                  staleCodeNameUpdate(
+                      tenantId,
+                      refId,
+                      aliasId,
+                      "Writer two",
+                      staleWriterLoaded,
+                      winningWriterCommitted));
+
+      Throwable winningFailure = first.get(20, TimeUnit.SECONDS);
+      Throwable staleFailure = second.get(20, TimeUnit.SECONDS);
+
+      assertThat(winningFailure).isNull();
+      assertThat(staleFailure).isNotNull();
+      assertThat(hasOptimisticLockCause(staleFailure)).isTrue();
+      assertThat(
+              jdbcTemplate.queryForObject(
+                  "SELECT version FROM production.color_partner_ref WHERE id = ?",
+                  Long.class,
+                  refId))
+          .isEqualTo(1L);
+    } finally {
+      writers.shutdownNow();
+    }
+  }
+
+  private Throwable winningCodeNameUpdate(
+      UUID tenantId, UUID refId, UUID codeId, String name, CountDownLatch staleWriterLoaded) {
+    TransactionTemplate writer = new TransactionTemplate(transactionManager);
+    writer.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    try {
+      TenantContext.setCurrentTenantId(tenantId);
+      writer.executeWithoutResult(
+          ignored -> {
+            ColorPartnerRef ref =
+                repository.findForMutationByTenantIdAndId(tenantId, refId).orElseThrow();
+            await(staleWriterLoaded);
+            ref.updateCodeName(codeId, name);
+            repository.save(ref);
+          });
+      return null;
+    } catch (Throwable failure) {
+      return failure;
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  private Throwable staleCodeNameUpdate(
+      UUID tenantId,
+      UUID refId,
+      UUID codeId,
+      String name,
+      CountDownLatch staleWriterLoaded,
+      CountDownLatch winningWriterCommitted) {
+    TransactionTemplate writer = new TransactionTemplate(transactionManager);
+    writer.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+    try {
+      TenantContext.setCurrentTenantId(tenantId);
+      writer.executeWithoutResult(
+          ignored -> {
+            ColorPartnerRef ref =
+                repository.findForMutationByTenantIdAndId(tenantId, refId).orElseThrow();
+            staleWriterLoaded.countDown();
+            await(winningWriterCommitted);
+            ref.updateCodeName(codeId, name);
+            repository.save(ref);
+          });
+      return null;
+    } catch (Throwable failure) {
+      return failure;
+    } finally {
+      TenantContext.clear();
+    }
+  }
+
+  private void await(CountDownLatch latch) {
+    try {
+      if (!latch.await(10, TimeUnit.SECONDS)) {
+        throw new IllegalStateException("Concurrent writer coordination timed out");
+      }
+    } catch (InterruptedException exception) {
+      Thread.currentThread().interrupt();
+      throw new IllegalStateException("Concurrent writer coordination was interrupted", exception);
+    }
+  }
+
+  private boolean hasOptimisticLockCause(Throwable failure) {
+    Throwable current = failure;
+    while (current != null) {
+      if (current instanceof ObjectOptimisticLockingFailureException
+          || current instanceof OptimisticLockException
+          || current instanceof StaleObjectStateException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
+  }
+
+  private void insertFixture(
+      UUID tenantId, UUID colorId, UUID partnerId, UUID refId, UUID oldPrimaryId, UUID targetId) {
+    jdbcTemplate.update(
+        "INSERT INTO production.color "
+            + "(id, tenant_id, code, name, color_type, color_family, standard_status, "
+            + "is_active, created_at, updated_at, version) "
+            + "VALUES (?, ?, ?, 'Locking color', 'DYED', 'BLUE', 'DRAFT', true, now(), now(), 0)",
+        colorId,
+        tenantId,
+        "LOCK-" + colorId.toString().substring(0, 8).toUpperCase());
+    jdbcTemplate.update(
+        "INSERT INTO production.color_partner_ref "
+            + "(id, tenant_id, color_id, partner_id, role, is_active, created_at, updated_at, version) "
+            + "VALUES (?, ?, ?, ?, 'SUPPLIER', true, now(), now(), 0)",
+        refId,
+        tenantId,
+        colorId,
+        partnerId);
+    jdbcTemplate.update(
+        "INSERT INTO production.color_partner_code "
+            + "(id, tenant_id, color_partner_ref_id, partner_id, role, external_code, "
+            + "external_code_key, is_primary, is_active, created_at, updated_at, version) "
+            + "VALUES (?, ?, ?, ?, 'SUPPLIER', 'OLD', 'OLD', true, true, now(), now(), 0), "
+            + "(?, ?, ?, ?, 'SUPPLIER', 'NEW', 'NEW', false, true, now(), now(), 0)",
+        oldPrimaryId,
+        tenantId,
+        refId,
+        partnerId,
+        targetId,
+        tenantId,
+        refId,
+        partnerId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefQueryServiceTest.java
@@ -1,0 +1,99 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorPartnerRefRepository;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
+import com.fabricmanagement.production.masterdata.color.mapper.ColorMapper;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ColorPartnerRefQueryServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID COLOR_ID = UUID.randomUUID();
+  private static final UUID PARTNER_ID = UUID.randomUUID();
+
+  @Mock private ColorPartnerRefRepository refRepository;
+  @Mock private ColorRepository colorRepository;
+  @Mock private TradingPartnerQueryPort tradingPartnerQueryPort;
+  @Mock private ColorMapper colorMapper;
+
+  private ColorPartnerRefQueryService queryService;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    queryService =
+        new ColorPartnerRefQueryService(
+            refRepository, colorRepository, tradingPartnerQueryPort, colorMapper);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void listPagesRootsInTheDatabaseThenFetchesCodesForOnlyThatPage() {
+    PageRequest pageable = PageRequest.of(1, 2);
+    Color color = Color.create(TENANT_ID, "NAVY", "Navy", "#1F2A44");
+    color.setId(COLOR_ID);
+    ColorPartnerRef first = ref(UUID.randomUUID(), "FIRST");
+    ColorPartnerRef second = ref(UUID.randomUUID(), "SECOND");
+    when(colorRepository.findByTenantIdAndId(TENANT_ID, COLOR_ID)).thenReturn(Optional.of(color));
+    when(refRepository.findByTenantIdAndColorId(TENANT_ID, COLOR_ID, pageable))
+        .thenReturn(new PageImpl<>(List.of(first, second), pageable, 7));
+    when(refRepository.findWithCodesByTenantIdAndIdIn(
+            TENANT_ID, List.of(first.getId(), second.getId())))
+        .thenReturn(List.of(second, first));
+
+    var result = queryService.list(COLOR_ID, pageable);
+
+    assertThat(result.getContent()).containsExactly(first, second);
+    assertThat(result.getTotalElements()).isEqualTo(7);
+    verify(refRepository)
+        .findWithCodesByTenantIdAndIdIn(TENANT_ID, List.of(first.getId(), second.getId()));
+  }
+
+  @Test
+  void emptyRootPageDoesNotIssueTheCollectionFetchQuery() {
+    PageRequest pageable = PageRequest.of(0, 20);
+    Color color = Color.create(TENANT_ID, "EMPTY", "Empty", null);
+    color.setId(COLOR_ID);
+    when(colorRepository.findByTenantIdAndId(TENANT_ID, COLOR_ID)).thenReturn(Optional.of(color));
+    when(refRepository.findByTenantIdAndColorId(TENANT_ID, COLOR_ID, pageable))
+        .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+    assertThat(queryService.list(COLOR_ID, pageable)).isEmpty();
+    verify(refRepository, never()).findWithCodesByTenantIdAndIdIn(any(), any());
+  }
+
+  private ColorPartnerRef ref(UUID id, String externalCode) {
+    ColorPartnerRef ref =
+        ColorPartnerRef.create(
+            TENANT_ID, COLOR_ID, PARTNER_ID, PartnerRole.CUSTOMER, null, externalCode, null);
+    ref.setId(id);
+    ref.primaryCode().setId(UUID.randomUUID());
+    return ref;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefServiceTest.java
@@ -1,0 +1,192 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import com.fabricmanagement.production.masterdata.color.dto.AddColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerCodeInput;
+import com.fabricmanagement.production.masterdata.color.dto.CreateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ReactivateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorPartnerRefRepository;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
+import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ColorPartnerRefServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID COLOR_ID = UUID.randomUUID();
+  private static final UUID PARTNER_ID = UUID.randomUUID();
+  private static final UUID REF_ID = UUID.randomUUID();
+
+  @Mock private ColorPartnerRefRepository refRepository;
+  @Mock private ColorRepository colorRepository;
+  @Mock private TradingPartnerQueryPort partnerQueryPort;
+  @Mock private EntityManager entityManager;
+
+  private ColorPartnerRefService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    service =
+        new ColorPartnerRefService(refRepository, colorRepository, partnerQueryPort, entityManager);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void creationRequiresAnActiveColorAndCompatiblePartnerAndPersistsOnePrimary() {
+    when(colorRepository.findByTenantIdAndIdAndIsActiveTrue(TENANT_ID, COLOR_ID))
+        .thenReturn(Optional.of(color()));
+    when(partnerQueryPort.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .thenReturn(true);
+    when(refRepository.save(any(ColorPartnerRef.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    ColorPartnerRef created = service.create(COLOR_ID, createRequest());
+
+    assertThat(created.getCodes()).singleElement().matches(ColorPartnerCode::isPrimary);
+    verify(refRepository).save(created);
+  }
+
+  @Test
+  void missingInactiveOrIncompatiblePartnerBlocksCreationAndOtherMutations() {
+    when(colorRepository.findByTenantIdAndIdAndIsActiveTrue(TENANT_ID, COLOR_ID))
+        .thenReturn(Optional.of(color()));
+    when(partnerQueryPort.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .thenReturn(false);
+
+    assertThatThrownBy(() -> service.create(COLOR_ID, createRequest()))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(409);
+
+    ColorPartnerRef ref = ref();
+    when(refRepository.findForMutationByTenantIdAndId(TENANT_ID, REF_ID))
+        .thenReturn(Optional.of(ref));
+    assertThatThrownBy(
+            () ->
+                service.update(COLOR_ID, REF_ID, new UpdateColorPartnerRefRequest(BigDecimal.ONE)))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(
+            () -> service.addCode(COLOR_ID, REF_ID, new AddColorPartnerCodeRequest("ALIAS", null)))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+  }
+
+  @Test
+  void addingCodeFlushesTheManagedAggregateBeforeReturningTheChild() {
+    ColorPartnerRef ref = ref();
+    when(refRepository.findForMutationByTenantIdAndId(TENANT_ID, REF_ID))
+        .thenReturn(Optional.of(ref));
+    when(colorRepository.findByTenantIdAndIdAndIsActiveTrue(TENANT_ID, COLOR_ID))
+        .thenReturn(Optional.of(color()));
+    when(partnerQueryPort.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .thenReturn(true);
+
+    ColorPartnerCode added =
+        service.addCode(COLOR_ID, REF_ID, new AddColorPartnerCodeRequest("ALIAS", null));
+
+    assertThat(added.getExternalCode()).isEqualTo("ALIAS");
+    verify(entityManager).flush();
+    verify(refRepository, never()).save(ref);
+  }
+
+  @Test
+  void deactivationCleanupDoesNotRequireAnActiveColorOrPartner() {
+    ColorPartnerRef ref = ref();
+    when(refRepository.findForMutationByTenantIdAndId(TENANT_ID, REF_ID))
+        .thenReturn(Optional.of(ref));
+    when(refRepository.save(ref)).thenReturn(ref);
+
+    ColorPartnerRef deactivated = service.deactivate(COLOR_ID, REF_ID);
+
+    assertThat(deactivated.getIsActive()).isFalse();
+    verify(colorRepository, never()).findByTenantIdAndIdAndIsActiveTrue(any(), any());
+    verify(partnerQueryPort, never()).isActiveAndCompatible(any(), any(), any());
+  }
+
+  @Test
+  void reactivationRequiresPartnerValidationAndExactlyOneAvailableCode() {
+    ColorPartnerRef ref = ref();
+    ColorPartnerCode primary = ref.primaryCode();
+    ref.deactivate();
+    when(refRepository.findForMutationByTenantIdAndId(TENANT_ID, REF_ID))
+        .thenReturn(Optional.of(ref));
+    when(colorRepository.findByTenantIdAndIdAndIsActiveTrue(TENANT_ID, COLOR_ID))
+        .thenReturn(Optional.of(color()));
+    when(partnerQueryPort.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .thenReturn(true);
+    when(refRepository.save(ref)).thenReturn(ref);
+
+    ColorPartnerRef reactivated =
+        service.reactivate(
+            COLOR_ID, REF_ID, new ReactivateColorPartnerRefRequest(primary.getId(), null));
+
+    assertThat(reactivated.getIsActive()).isTrue();
+    assertThat(reactivated.primaryCode()).isSameAs(primary);
+  }
+
+  @Test
+  void primarySwitchFlushesBetweenDemotionAndPromotion() {
+    ColorPartnerRef ref = ref();
+    ColorPartnerCode alias = ref.addCode("ALIAS", null);
+    alias.setId(UUID.randomUUID());
+    when(refRepository.findForMutationByTenantIdAndId(TENANT_ID, REF_ID))
+        .thenReturn(Optional.of(ref));
+    when(colorRepository.findByTenantIdAndIdAndIsActiveTrue(TENANT_ID, COLOR_ID))
+        .thenReturn(Optional.of(color()));
+    when(partnerQueryPort.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .thenReturn(true);
+    when(refRepository.save(ref)).thenReturn(ref);
+
+    service.makePrimary(COLOR_ID, REF_ID, alias.getId());
+
+    verify(entityManager).flush();
+    assertThat(ref.primaryCode()).isSameAs(alias);
+  }
+
+  private CreateColorPartnerRefRequest createRequest() {
+    return new CreateColorPartnerRefRequest(
+        PARTNER_ID, PartnerRole.CUSTOMER, null, new ColorPartnerCodeInput("SS26-NVY-07", null));
+  }
+
+  private Color color() {
+    Color color = Color.create(TENANT_ID, "NAVY-001", "Navy", "#1F2A44");
+    color.setId(COLOR_ID);
+    return color;
+  }
+
+  private ColorPartnerRef ref() {
+    ColorPartnerRef ref =
+        ColorPartnerRef.create(
+            TENANT_ID, COLOR_ID, PARTNER_ID, PartnerRole.CUSTOMER, null, "PRIMARY", null);
+    ref.setId(REF_ID);
+    ref.primaryCode().setId(UUID.randomUUID());
+    return ref;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefTenantIsolationIT.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/ColorPartnerRefTenantIsolationIT.java
@@ -1,0 +1,193 @@
+package com.fabricmanagement.production.masterdata.color.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.masterdata.color.app.port.TradingPartnerQueryPort;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerCode;
+import com.fabricmanagement.production.masterdata.color.domain.ColorPartnerRef;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import com.fabricmanagement.production.masterdata.color.dto.AddColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ColorPartnerCodeInput;
+import com.fabricmanagement.production.masterdata.color.dto.CreateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.ReactivateColorPartnerRefRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerCodeRequest;
+import com.fabricmanagement.production.masterdata.color.dto.UpdateColorPartnerRefRequest;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+class ColorPartnerRefTenantIsolationIT {
+
+  private static final UUID TENANT_A = UUID.fromString("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1");
+  private static final UUID TENANT_B = UUID.fromString("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb2");
+
+  @Container
+  @SuppressWarnings("resource")
+  static PostgreSQLContainer<?> postgres =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("fabric_test")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @DynamicPropertySource
+  static void registerPgProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", postgres::getJdbcUrl);
+    registry.add("spring.datasource.username", postgres::getUsername);
+    registry.add("spring.datasource.password", postgres::getPassword);
+    registry.add("spring.flyway.url", postgres::getJdbcUrl);
+    registry.add("spring.flyway.user", postgres::getUsername);
+    registry.add("spring.flyway.password", postgres::getPassword);
+    registry.add("spring.flyway.enabled", () -> "true");
+  }
+
+  @Autowired private ColorService colorService;
+  @Autowired private ColorPartnerRefService refService;
+  @Autowired private ColorPartnerRefQueryService queryService;
+
+  @MockBean private TradingPartnerQueryPort tradingPartnerQueryPort;
+
+  private UUID partnerId;
+
+  @BeforeEach
+  void setUp() {
+    partnerId = UUID.randomUUID();
+    when(tradingPartnerQueryPort.isActiveAndCompatible(any(), any(), any())).thenReturn(true);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void tenantBSeesNoTenantAListLookupOrMutationSurface() {
+    TenantContext.setCurrentTenantId(TENANT_A);
+    Color color = colorService.create("TENANT-A-NAVY", "Tenant A navy", "#1F2A44");
+    ColorPartnerRef ref = refService.create(color.getId(), createRequest("A-CODE"));
+    UUID codeId = ref.primaryCode().getId();
+
+    TenantContext.setCurrentTenantId(TENANT_B);
+
+    assertThatThrownBy(() -> queryService.list(color.getId(), PageRequest.of(0, 20)))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> queryService.resolve(partnerId, PartnerRole.CUSTOMER, "A-CODE"))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> queryService.forward(color.getId(), partnerId, PartnerRole.CUSTOMER))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(
+            () ->
+                refService.update(
+                    color.getId(), ref.getId(), new UpdateColorPartnerRefRequest(BigDecimal.ONE)))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> refService.deactivateCode(color.getId(), ref.getId(), codeId))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> refService.deactivate(color.getId(), ref.getId()))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void inactiveColorBlocksLookupsAndNonDeactivationWritesWithoutReleasingMappings() {
+    TenantContext.setCurrentTenantId(TENANT_A);
+    Color color = colorService.create("LIFECYCLE-NAVY", "Lifecycle navy", "#1F2A44");
+    ColorPartnerRef ref = refService.create(color.getId(), createRequest("PRIMARY"));
+    ColorPartnerCode alias =
+        refService.addCode(
+            color.getId(), ref.getId(), new AddColorPartnerCodeRequest("ALIAS", null));
+    UUID aliasId = alias.getId();
+    assertThat(aliasId).isNotNull();
+
+    colorService.deactivate(color.getId());
+
+    assertThatThrownBy(() -> queryService.resolve(partnerId, PartnerRole.CUSTOMER, "ALIAS"))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(() -> queryService.forward(color.getId(), partnerId, PartnerRole.CUSTOMER))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(
+            () ->
+                refService.update(
+                    color.getId(), ref.getId(), new UpdateColorPartnerRefRequest(BigDecimal.ONE)))
+        .isInstanceOf(NotFoundException.class);
+    assertThatThrownBy(
+            () ->
+                refService.updateCode(
+                    color.getId(),
+                    ref.getId(),
+                    aliasId,
+                    new UpdateColorPartnerCodeRequest("Renamed")))
+        .isInstanceOf(NotFoundException.class);
+
+    ColorPartnerRef inactive = refService.deactivate(color.getId(), ref.getId());
+    assertThat(inactive.getCodes()).allMatch(code -> !Boolean.TRUE.equals(code.getIsActive()));
+    assertThatThrownBy(
+            () ->
+                refService.reactivate(
+                    color.getId(),
+                    ref.getId(),
+                    new ReactivateColorPartnerRefRequest(aliasId, null)))
+        .isInstanceOf(NotFoundException.class);
+
+    colorService.activate(color.getId());
+    refService.reactivate(
+        color.getId(), ref.getId(), new ReactivateColorPartnerRefRequest(aliasId, null));
+
+    assertThat(queryService.resolve(partnerId, PartnerRole.CUSTOMER, "ALIAS").color().id())
+        .isEqualTo(color.getId());
+  }
+
+  @Test
+  void inactiveReferenceRejectsEveryMutationExceptReactivation() {
+    TenantContext.setCurrentTenantId(TENANT_A);
+    Color color = colorService.create("REF-LIFECYCLE", "Reference lifecycle", "#1F2A44");
+    ColorPartnerRef ref = refService.create(color.getId(), createRequest("PRIMARY"));
+    UUID primaryId = ref.primaryCode().getId();
+    refService.deactivate(color.getId(), ref.getId());
+
+    assertThatThrownBy(
+            () ->
+                refService.addCode(
+                    color.getId(), ref.getId(), new AddColorPartnerCodeRequest("ALIAS", null)))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(
+            () ->
+                refService.update(
+                    color.getId(), ref.getId(), new UpdateColorPartnerRefRequest(null)))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(() -> refService.deactivate(color.getId(), ref.getId()))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+
+    ColorPartnerRef reactivated =
+        refService.reactivate(
+            color.getId(), ref.getId(), new ReactivateColorPartnerRefRequest(primaryId, null));
+    assertThat(reactivated.getIsActive()).isTrue();
+  }
+
+  private CreateColorPartnerRefRequest createRequest(String externalCode) {
+    return new CreateColorPartnerRefRequest(
+        partnerId, PartnerRole.CUSTOMER, null, new ColorPartnerCodeInput(externalCode, null));
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/app/adapter/TradingPartnerQueryAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/app/adapter/TradingPartnerQueryAdapterTest.java
@@ -1,0 +1,83 @@
+package com.fabricmanagement.production.masterdata.color.app.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerQueryService;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerQueryService.PartnerClassification;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerStatus;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.production.masterdata.color.domain.PartnerRole;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TradingPartnerQueryAdapterTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID PARTNER_ID = UUID.randomUUID();
+
+  @Mock private TradingPartnerQueryService queryService;
+
+  private TradingPartnerQueryAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    adapter = new TradingPartnerQueryAdapter(queryService);
+  }
+
+  @ParameterizedTest
+  @MethodSource("compatibilityMatrix")
+  void enforcesTheLockedRoleCompatibilityMatrix(
+      PartnerRole role, PartnerType type, boolean expected) {
+    when(queryService.findClassification(TENANT_ID, PARTNER_ID))
+        .thenReturn(Optional.of(new PartnerClassification(type, PartnerStatus.ACTIVE, true)));
+
+    assertThat(adapter.isActiveAndCompatible(TENANT_ID, PARTNER_ID, role)).isEqualTo(expected);
+  }
+
+  @Test
+  void rejectsMissingInactiveSoftDeletedAndCrossTenantPartners() {
+    when(queryService.findClassification(TENANT_ID, PARTNER_ID)).thenReturn(Optional.empty());
+    assertThat(adapter.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .isFalse();
+
+    when(queryService.findClassification(TENANT_ID, PARTNER_ID))
+        .thenReturn(
+            Optional.of(
+                new PartnerClassification(PartnerType.CUSTOMER, PartnerStatus.SUSPENDED, true)));
+    assertThat(adapter.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .isFalse();
+
+    when(queryService.findClassification(TENANT_ID, PARTNER_ID))
+        .thenReturn(
+            Optional.of(
+                new PartnerClassification(PartnerType.CUSTOMER, PartnerStatus.ACTIVE, false)));
+    assertThat(adapter.isActiveAndCompatible(TENANT_ID, PARTNER_ID, PartnerRole.CUSTOMER))
+        .isFalse();
+  }
+
+  private static Stream<Arguments> compatibilityMatrix() {
+    return Stream.of(
+        Arguments.of(PartnerRole.CUSTOMER, PartnerType.CUSTOMER, true),
+        Arguments.of(PartnerRole.CUSTOMER, PartnerType.BOTH, true),
+        Arguments.of(PartnerRole.CUSTOMER, PartnerType.SUPPLIER, false),
+        Arguments.of(PartnerRole.CUSTOMER, PartnerType.SUBCONTRACTOR, false),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.SUPPLIER, true),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.BOTH, true),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.SUBCONTRACTOR, true),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.SERVICE_PROVIDER, false),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.SISTER_COMPANY, false),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.SUBSIDIARY, false),
+        Arguments.of(PartnerRole.SUPPLIER, PartnerType.PARENT_COMPANY, false));
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerRefTest.java
+++ b/src/test/java/com/fabricmanagement/production/masterdata/color/domain/ColorPartnerRefTest.java
@@ -1,0 +1,160 @@
+package com.fabricmanagement.production.masterdata.color.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fabricmanagement.production.masterdata.color.domain.exception.ColorPartnerRefDomainException;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ColorPartnerRefTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("11111111-1111-4111-8111-111111111111");
+  private static final UUID COLOR_ID = UUID.fromString("22222222-2222-4222-8222-222222222222");
+  private static final UUID PARTNER_ID = UUID.fromString("33333333-3333-4333-8333-333333333333");
+
+  @Test
+  void creationNormalizesTheFirstCodeAndMakesItPrimary() {
+    ColorPartnerRef ref = ref(" ss26-nvy-07 ");
+
+    assertThat(ref.getCodes()).hasSize(1);
+    assertThat(ref.primaryCode().getExternalCode()).isEqualTo("ss26-nvy-07");
+    assertThat(ref.primaryCode().getExternalCodeKey()).isEqualTo("SS26-NVY-07");
+    assertThat(ref.primaryCode().isPrimary()).isTrue();
+    assertThat(ref.primaryCode().getIsActive()).isTrue();
+  }
+
+  @Test
+  void duplicateActiveKeyIsRejectedInsideTheAggregate() {
+    ColorPartnerRef ref = ref("SS26-NVY-07");
+
+    assertThatThrownBy(() -> ref.addCode(" ss26-nvy-07 ", null))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void activePrimaryCannotBeDeactivatedDirectly() {
+    ColorPartnerRef ref = ref("PRIMARY");
+    ColorPartnerCode primary = ref.primaryCode();
+    primary.setId(UUID.randomUUID());
+
+    assertThatThrownBy(() -> ref.deactivateCode(primary.getId()))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void primarySwitchUsesPreparedTargetAndLeavesExactlyOnePrimary() {
+    ColorPartnerRef ref = ref("PRIMARY");
+    ColorPartnerCode oldPrimary = ref.primaryCode();
+    oldPrimary.setId(UUID.randomUUID());
+    ColorPartnerCode alias = ref.addCode("ALIAS", "Season alias");
+    alias.setId(UUID.randomUUID());
+
+    ref.preparePrimarySwitch(alias.getId());
+    assertThat(ref.getCodes()).noneMatch(ColorPartnerCode::isPrimary);
+    ref.completePrimarySwitch(alias.getId());
+
+    assertThat(ref.primaryCode()).isSameAs(alias);
+    assertThat(oldPrimary.isPrimary()).isFalse();
+    assertThat(ref.getCodes().stream().filter(ColorPartnerCode::isPrimary)).hasSize(1);
+  }
+
+  @Test
+  void completingAnUnpreparedPrimarySwitchIsRejected() {
+    ColorPartnerRef ref = ref("PRIMARY");
+    ColorPartnerCode primary = ref.primaryCode();
+    primary.setId(UUID.randomUUID());
+
+    assertThatThrownBy(() -> ref.completePrimarySwitch(primary.getId()))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(409);
+  }
+
+  @Test
+  void deactivationCascadesAndInactiveAggregateRejectsEveryOtherMutation() {
+    ColorPartnerRef ref = ref("PRIMARY");
+    ColorPartnerCode alias = ref.addCode("ALIAS", null);
+    alias.setId(UUID.randomUUID());
+
+    ref.deactivate();
+
+    assertThat(ref.getIsActive()).isFalse();
+    assertThat(ref.getCodes()).allMatch(code -> !Boolean.TRUE.equals(code.getIsActive()));
+    assertThatThrownBy(() -> ref.addCode("NEW", null))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(() -> ref.updateTolerance(BigDecimal.ONE))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(ref::deactivate).isInstanceOf(ColorPartnerRefDomainException.class);
+  }
+
+  @Test
+  void existingCodeReactivationRevivesOnlyTheSelectedPrimary() {
+    ColorPartnerRef ref = ref("OLD-PRIMARY");
+    ColorPartnerCode oldPrimary = ref.primaryCode();
+    oldPrimary.setId(UUID.randomUUID());
+    ColorPartnerCode alias = ref.addCode("SELECTED", null);
+    alias.setId(UUID.randomUUID());
+    ref.deactivate();
+
+    ref.reactivateWithExistingCode(alias.getId());
+
+    assertThat(ref.getIsActive()).isTrue();
+    assertThat(alias.getIsActive()).isTrue();
+    assertThat(alias.isPrimary()).isTrue();
+    assertThat(oldPrimary.getIsActive()).isFalse();
+    assertThat(oldPrimary.isPrimary()).isFalse();
+  }
+
+  @Test
+  void newCodeReactivationDoesNotReviveOldAliases() {
+    ColorPartnerRef ref = ref("OLD-PRIMARY");
+    ColorPartnerCode oldPrimary = ref.primaryCode();
+    oldPrimary.setId(UUID.randomUUID());
+    ref.deactivate();
+
+    ColorPartnerCode replacement = ref.reactivateWithNewCode(" new-code ", "New name");
+
+    assertThat(replacement.getExternalCode()).isEqualTo("new-code");
+    assertThat(replacement.getExternalCodeKey()).isEqualTo("NEW-CODE");
+    assertThat(replacement.isPrimary()).isTrue();
+    assertThat(oldPrimary.getIsActive()).isFalse();
+  }
+
+  @Test
+  void toleranceAcceptsNullOrPositiveAndRejectsZeroOrNegative() {
+    ColorPartnerRef ref = ref("PRIMARY");
+
+    ref.updateTolerance(new BigDecimal("1.25"));
+    assertThat(ref.getDeltaETolerance()).isEqualByComparingTo("1.25");
+    ref.updateTolerance(null);
+    assertThat(ref.getDeltaETolerance()).isNull();
+    assertThatThrownBy(() -> ref.updateTolerance(BigDecimal.ZERO))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(422);
+    assertThatThrownBy(() -> ref.updateTolerance(new BigDecimal("-0.01")))
+        .isInstanceOf(ColorPartnerRefDomainException.class);
+    assertThatThrownBy(() -> ref.updateTolerance(new BigDecimal("100.00")))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(422);
+    assertThatThrownBy(() -> ref.updateTolerance(new BigDecimal("1.234")))
+        .isInstanceOf(ColorPartnerRefDomainException.class)
+        .extracting("httpStatus")
+        .isEqualTo(422);
+  }
+
+  private ColorPartnerRef ref(String code) {
+    ColorPartnerRef ref =
+        ColorPartnerRef.create(
+            TENANT_ID, COLOR_ID, PARTNER_ID, PartnerRole.CUSTOMER, null, code, null);
+    ref.setId(UUID.randomUUID());
+    return ref;
+  }
+}


### PR DESCRIPTION
Implements the ADR-0009 locked design: color_partner_ref aggregate root with color_partner_code alias children.

- composite FK (tenant_id, ref_id, partner_id, role) pins denormalized child columns; partial unique indexes enforce single active primary and active-only external code reuse per partner+role
- double-barrier canonicalization: external_code_key = upper(btrim()) checked in domain and DB
- OPTIMISTIC_FORCE_INCREMENT root locking for all alias mutations; two-phase primary switch; cascade deactivate; reactivation requires an explicit valid primary code (old aliases stay inactive)
- production-owned TradingPartnerQueryPort with CUSTOMER/SUPPLIER compatibility matrix (BOTH, SUBCONTRACTOR mapped)
- reverse (any active alias) and forward (active primary only) resolution endpoints under colors:read; mutations under colors:write
- RLS enable+force with tenant policy, role grants, tenant purge coverage, arch rule forbidding a child repository
- unit, controller, constraint, locking, and NOBYPASSRLS tenant isolation tests