### PR TITLE
fix(color): declare create response as 201 in the openapi contract

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -29748,12 +29748,12 @@ paths:
               $ref: "#/components/schemas/CreateColorRequest"
         required: true
       responses:
-        "200":
+        "201":
           content:
             '*/*':
               schema:
                 $ref: "#/components/schemas/ApiResponseColorDto"
-          description: OK
+          description: Created
         "400":
           content:
             application/problem+json:

--- a/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorController.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/color/api/ColorController.java
@@ -81,6 +81,9 @@ public class ColorController {
   @PostMapping
   @PreAuthorize("@auth.can(authentication, 'colors', 'write')")
   @Operation(operationId = "createColor", summary = "Create a color card")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "201",
+      description = "Created")
   public ResponseEntity<ApiResponse<ColorDto>> create(
       @Valid @RequestBody CreateColorRequest request) {
     return ResponseEntity.status(HttpStatus.CREATED)


### PR DESCRIPTION
ColorController#create already returned 201 Created at runtime; the exported spec said 200. Add the swagger @ApiResponse fully-qualified (its simple name collides with the house ApiResponse envelope import) and re-export api/openapi.yaml via OpenApiExportIT with UPDATE_OPENAPI=true.

Contract diff is exactly the createColor response block: 200 -> 201.