### PR TITLE
feat(production): cut batch colour over from EAV to color_id per ADR-…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -27786,7 +27786,8 @@ paths:
       tags:
       - Batch
     post:
-      description: Adds a dynamic attribute to the batch.
+      description: Adds a dynamic attribute to the batch. Legacy color-family attributes
+        are rejected with LEGACY_COLOR_ATTRIBUTE_WRITE.
       operationId: addAttribute
       parameters:
       - in: path
@@ -27840,7 +27841,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
-          description: Conflict
+          description: Legacy color-family attributes must use batch.colorId (LEGACY_COLOR_ATTRIBUTE_WRITE)
         "422":
           content:
             application/problem+json:
@@ -27864,7 +27865,8 @@ paths:
       - Batch
   /api/v1/production/batches/{id}/attributes/{attributeId}:
     delete:
-      description: Removes a dynamic attribute from the batch.
+      description: Removes a dynamic attribute from the batch. Legacy color-family
+        attributes are rejected with LEGACY_COLOR_ATTRIBUTE_WRITE.
       operationId: deleteAttribute
       parameters:
       - in: path
@@ -27914,7 +27916,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
-          description: Conflict
+          description: Legacy color-family attributes must use batch.colorId (LEGACY_COLOR_ATTRIBUTE_WRITE)
         "422":
           content:
             application/problem+json:
@@ -28334,6 +28336,85 @@ paths:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
       summary: Update batch certification
+      tags:
+      - Batch
+  /api/v1/production/batches/{id}/color:
+    patch:
+      description: Assigns an active color card from the current tenant. A null colorId
+        clears the assignment.
+      operationId: updateBatchColor
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateBatchColorRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseBatchDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Batch or active tenant color card not found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Assign or clear a batch color
       tags:
       - Batch
   /api/v1/production/batches/{id}/consume:
@@ -49222,6 +49303,12 @@ components:
           type: string
           description: Internal unique batch code/lot number
           example: B-2026-001
+        colorId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Assigned tenant color-card ID; null means unassigned
         composition:
           type: object
           additionalProperties:
@@ -50602,6 +50689,12 @@ components:
           description: Internal unique batch code/lot number
           example: B-2026-001
           minLength: 1
+        colorId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Optional active tenant color-card ID; null means unassigned
         composition:
           type: object
           additionalProperties:
@@ -60427,6 +60520,16 @@ components:
           format: date
       required:
       - changeReason
+    UpdateBatchColorRequest:
+      type: object
+      description: Request to assign or clear a batch color card
+      properties:
+        colorId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Active tenant color-card ID; null clears the batch color
     UpdateColorPartnerCodeRequest:
       type: object
       description: Full mutable state of a partner code; its code identity is immutable

--- a/dependabot.yml.new
+++ b/dependabot.yml.new
@@ -1,0 +1,83 @@
+version: 2
+
+updates:
+  - package-ecosystem: maven
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      maven-minor-and-patch:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "org.springframework.cloud:spring-cloud-dependencies"
+        update-types:
+          - minor
+          - patch
+    # Spring Cloud uses CalVer release trains: 2025.1 requires Spring Boot 4.x.
+    # Keep the project on the Boot 3.5-compatible 2025.0 train until a coordinated upgrade.
+    #
+    # Major bumps of the infrastructure spine are DELIBERATE upgrades with their own
+    # tickets and full IT runs, never drive-by dependabot merges (decision 2026-07-18):
+    # - Flyway: migrations are the product's spine (see ADR-0010 cutover work)
+    # - JobRunr: upgrade belongs inside the parked BUG-jobrunr investigation
+    # - checkstyle / logstash-logback-encoder: tooling majors, batch deliberately
+    ignore:
+      - dependency-name: "org.springframework.cloud:spring-cloud-dependencies"
+        versions:
+          - "[2025.1,)"
+      - dependency-name: "org.flywaydb:*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "org.jobrunr:*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.puppycrawl.tools:checkstyle"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "net.logstash.logback:logstash-logback-encoder"
+        update-types:
+          - "version-update:semver-major"
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:15"
+      timezone: Europe/London
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "chore(ci)"
+
+  - package-ecosystem: docker
+    directory: "/"
+    target-branch: main
+    schedule:
+      interval: monthly
+      time: "06:30"
+      timezone: Europe/London
+    open-pull-requests-limit: 3
+    # The project is pinned to Java 21 LTS. JDK/JRE image major bumps (temurin 25/26)
+    # are a platform decision, not a dependency patch (decision 2026-07-18).
+    ignore:
+      - dependency-name: "eclipse-temurin"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "maven"
+        update-types:
+          - "version-update:semver-major"
+    commit-message:
+      prefix: "chore(container)"

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
@@ -20,10 +20,8 @@ import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.dto.CreateInternalUserRequest;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
-import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
 import com.fabricmanagement.production.execution.batch.app.BatchService;
 import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
-import com.fabricmanagement.production.execution.batch.dto.AddBatchAttributeRequest;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
 import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
 import com.fabricmanagement.production.execution.batch.dto.ReserveRequest;
@@ -38,7 +36,6 @@ import com.fabricmanagement.production.masterdata.color.domain.ColorType;
 import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
-import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
@@ -110,7 +107,6 @@ public class SalesQuoteDemoSeeder {
 
   private static final String CURRENCY = "GBP";
   private static final String QUOTE_MODULE_TYPE = "FABRIC";
-  private static final String COLOUR_ATTRIBUTE_CODE = "COLOR";
   private static final String GRADING_REASON = "Initial grading (demo seed)";
   private static final String GABARDINE_LIST_PRICE = "6.80";
   private static final String GABARDINE_OFFERED_PRICE = "6.50";
@@ -121,7 +117,6 @@ public class SalesQuoteDemoSeeder {
   private final ColorService colorService;
   private final BatchService batchService;
   private final StockUnitService stockUnitService;
-  private final BatchAttributeService batchAttributeService;
   private final SalesProductService salesProductService;
   private final DiscountPolicyService discountPolicyService;
   private final ExchangeRateService exchangeRateService;
@@ -165,8 +160,6 @@ public class SalesQuoteDemoSeeder {
       // Rust deliberately gets NO stock — the picker's passive-but-selectable colour case.
       ensureColour("RUST-04", "Rust", "#B7410E");
 
-      ProductAttributeDto colourAxis = ensureColourAxisAttribute();
-
       ProductDto gabardine = productFacade.createProduct(product(ProductType.FABRIC, "M"));
       ProductDto combedYarn = productFacade.createProduct(product(ProductType.YARN, "KG"));
       ProductDto rawCotton = productFacade.createProduct(product(ProductType.FIBER, "KG"));
@@ -187,9 +180,13 @@ public class SalesQuoteDemoSeeder {
       // surfaces for piece-backed length lots.
       BatchDto lot24011 =
           saleableBatch(
-              gabardine, "LOT-24011", "2000", BATCH_UNIT_METRES, "Main Navy dye lot, spring run");
+              gabardine,
+              "LOT-24011",
+              "2000",
+              BATCH_UNIT_METRES,
+              navy.getId(),
+              "Main Navy dye lot, spring run");
       addRolls(lot24011.getId(), "24011", 16, "125", "36.800", fabricGrades.first().getId());
-      attachColour(lot24011.getId(), colourAxis, navy);
 
       BatchDto lot24012 =
           saleableBatch(
@@ -197,17 +194,21 @@ public class SalesQuoteDemoSeeder {
               "LOT-24012",
               "3000",
               BATCH_UNIT_METRES,
+              navy.getId(),
               "Second Navy dye lot — shade may vary");
       addRolls(lot24012.getId(), "24012", 24, "125", "36.800", fabricGrades.first().getId());
-      attachColour(lot24012.getId(), colourAxis, navy);
 
       BatchDto lot23087 =
           saleableBatch(
-              gabardine, "LOT-23087", "290", BATCH_UNIT_METRES, "Remnant lot — close it out");
+              gabardine,
+              "LOT-23087",
+              "290",
+              BATCH_UNIT_METRES,
+              navy.getId(),
+              "Remnant lot — close it out");
       addRoll(lot23087.getId(), "23087", 1, "100", "29.500", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 2, "95", "28.000", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 3, "95", "28.000", fabricGrades.first().getId());
-      attachColour(lot23087.getId(), colourAxis, navy);
 
       BatchDto lot24020 =
           saleableBatch(
@@ -215,24 +216,33 @@ public class SalesQuoteDemoSeeder {
               "LOT-24020",
               "450",
               BATCH_UNIT_METRES,
+              ecru.getId(),
               "Second Quality Ecru — bulk, no pieces");
-      attachColour(lot24020.getId(), colourAxis, ecru);
 
       BatchDto lot24031 =
-          saleableBatch(combedYarn, "LOT-24031", "1200", "KG", "Combed yarn, prepared for dyeing");
+          saleableBatch(
+              combedYarn,
+              "LOT-24031",
+              "1200",
+              "KG",
+              pfd.getId(),
+              "Combed yarn, prepared for dyeing");
       addCartons(lot24031.getId(), "24031", 48, "25.000", yarnGrades.first().getId());
-      attachColour(lot24031.getId(), colourAxis, pfd);
 
       // Raw cotton skips the colour axis entirely — fibre cascade has no Colour step.
-      saleableBatch(rawCotton, "LOT-24040", "5000", "KG", "Raw cotton, bulk store");
+      saleableBatch(rawCotton, "LOT-24040", "5000", "KG", null, "Raw cotton, bulk store");
 
       // Waste-grade stock exists but must stay invisible to the picker (negative test).
       BatchDto lot23050 =
           saleableBatch(
-              gabardine, "LOT-23050", "120", BATCH_UNIT_METRES, "Waste grade — not saleable");
+              gabardine,
+              "LOT-23050",
+              "120",
+              BATCH_UNIT_METRES,
+              navy.getId(),
+              "Waste grade — not saleable");
       addRoll(lot23050.getId(), "23050", 1, "60", "17.700", fabricGrades.waste().getId());
       addRoll(lot23050.getId(), "23050", 2, "60", "17.700", fabricGrades.waste().getId());
-      attachColour(lot23050.getId(), colourAxis, navy);
 
       // ── Actors ──
       TradingPartnerDto albion = createAlbionCustomer(tenantId);
@@ -347,23 +357,6 @@ public class SalesQuoteDemoSeeder {
         .orElseGet(() -> colorService.create(spec));
   }
 
-  /**
-   * The lot picker resolves a lot's colour from a {@code BatchAttribute} whose {@code
-   * ProductAttribute} code is COLOR (see ProductionSalesLotQueryService). ProductAttribute is
-   * read-only reference data with no create endpoint, so the seeder registers the colour axis
-   * through {@link ProductFacade#ensureAttribute}, whose lookup is tenant-scoped and
-   * create-if-missing.
-   */
-  private ProductAttributeDto ensureColourAxisAttribute() {
-    return productFacade.ensureAttribute(
-        COLOUR_ATTRIBUTE_CODE,
-        "Colour",
-        "VARIANT",
-        "ALL",
-        "Colour card reference for dyed lots",
-        100);
-  }
-
   private CreateProductRequest product(ProductType productType, String unit) {
     return CreateProductRequest.builder().productType(productType).unit(unit).build();
   }
@@ -399,13 +392,19 @@ public class SalesQuoteDemoSeeder {
   // ── Lot helpers ─────────────────────────────────────────────────────────────
 
   private BatchDto saleableBatch(
-      ProductDto product, String batchCode, String quantity, String unit, String remarks) {
+      ProductDto product,
+      String batchCode,
+      String quantity,
+      String unit,
+      UUID colorId,
+      String remarks) {
     BatchDto batch =
         batchService.create(
             CreateBatchRequest.builder()
                 .productId(product.getId())
                 .productType(product.getProductType())
                 .batchCode(batchCode)
+                .colorId(colorId)
                 .quantity(new BigDecimal(quantity))
                 .unit(unit)
                 .sourceType(BatchSourceType.INITIAL_STOCK)
@@ -477,11 +476,6 @@ public class SalesQuoteDemoSeeder {
 
   private String barcode(String lotDigits, int index) {
     return String.format("PM-%s-%02d", lotDigits, index);
-  }
-
-  private void attachColour(UUID batchId, ProductAttributeDto colourAxis, Color colour) {
-    batchAttributeService.add(
-        batchId, new AddBatchAttributeRequest(colourAxis.id(), colour.getId().toString()));
   }
 
   // ── Actor helpers ───────────────────────────────────────────────────────────

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -109,6 +109,7 @@ public class TenantTransactionalPurgeService {
           "production.prod_recipe_component",
           "production.prod_recipe",
           "production.production_quality_fiber_test_result",
+          "production.production_execution_batch_color_archive",
           "production.production_execution_batch_attribute",
           "production.production_execution_batch_certification",
           "production.production_execution_batch_reservation",

--- a/src/main/java/com/fabricmanagement/production/execution/batch/api/controller/BatchController.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/api/controller/BatchController.java
@@ -54,6 +54,21 @@ public class BatchController {
     return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(batch));
   }
 
+  @PatchMapping("/{id}/color")
+  @Operation(
+      operationId = "updateBatchColor",
+      summary = "Assign or clear a batch color",
+      description =
+          "Assigns an active color card from the current tenant. A null colorId clears the assignment.")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "404",
+      description = "Batch or active tenant color card not found")
+  @PreAuthorize("@auth.can(authentication, 'products', 'write')")
+  public ResponseEntity<ApiResponse<BatchDto>> updateBatchColor(
+      @PathVariable UUID id, @Valid @RequestBody UpdateBatchColorRequest request) {
+    return ResponseEntity.ok(ApiResponse.success(batchService.updateColor(id, request.colorId())));
+  }
+
   @GetMapping
   @Operation(summary = "Get All Batches", description = "Retrieves a list of all active batches.")
   @PreAuthorize("@auth.can(authentication, 'products', 'read')")
@@ -366,7 +381,12 @@ public class BatchController {
   @PostMapping("/{id}/attributes")
   @Operation(
       summary = "Add Batch Attribute",
-      description = "Adds a dynamic attribute to the batch.")
+      description =
+          "Adds a dynamic attribute to the batch. Legacy color-family attributes are rejected with LEGACY_COLOR_ATTRIBUTE_WRITE.")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "409",
+      description =
+          "Legacy color-family attributes must use batch.colorId (LEGACY_COLOR_ATTRIBUTE_WRITE)")
   @PreAuthorize("@auth.can(authentication, 'products', 'write')")
   public ResponseEntity<ApiResponse<BatchAttributeDto>> addAttribute(
       @PathVariable UUID id, @Valid @RequestBody AddBatchAttributeRequest request) {
@@ -377,7 +397,12 @@ public class BatchController {
   @DeleteMapping("/{id}/attributes/{attributeId}")
   @Operation(
       summary = "Delete Batch Attribute",
-      description = "Removes a dynamic attribute from the batch.")
+      description =
+          "Removes a dynamic attribute from the batch. Legacy color-family attributes are rejected with LEGACY_COLOR_ATTRIBUTE_WRITE.")
+  @io.swagger.v3.oas.annotations.responses.ApiResponse(
+      responseCode = "409",
+      description =
+          "Legacy color-family attributes must use batch.colorId (LEGACY_COLOR_ATTRIBUTE_WRITE)")
   @PreAuthorize("@auth.can(authentication, 'products', 'write')")
   public ResponseEntity<Void> deleteAttribute(
       @PathVariable UUID id, @PathVariable UUID attributeId) {

--- a/src/main/java/com/fabricmanagement/production/execution/batch/api/query/ProductionSalesLotQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/api/query/ProductionSalesLotQueryService.java
@@ -2,10 +2,8 @@ package com.fabricmanagement.production.execution.batch.api.query;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
-import com.fabricmanagement.production.execution.batch.domain.BatchAttribute;
 import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
-import com.fabricmanagement.production.execution.batch.infra.repository.BatchAttributeRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchLotQuantityIntentRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchReservationRepository;
@@ -14,15 +12,12 @@ import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatu
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitSoftHoldRepository;
 import com.fabricmanagement.production.execution.workorder.infra.repository.WorkOrderRepository;
-import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryService;
-import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryService.ColorReference;
 import com.fabricmanagement.production.masterdata.qualitygrade.api.query.QualityGradeQueryService;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -43,17 +38,12 @@ public class ProductionSalesLotQueryService {
       Set.of(BatchStatus.AVAILABLE, BatchStatus.RESERVED);
   private static final Set<StockUnitStatus> SELECTABLE_PIECE_STATUSES =
       Set.of(StockUnitStatus.AVAILABLE, StockUnitStatus.PARTIAL);
-  private static final Set<String> COLOUR_ATTRIBUTE_CODES =
-      Set.of("COLOR", "COLOUR", "COLOR_ID", "COLOUR_ID", "SHADE");
-
   private final BatchRepository batchRepository;
   private final BatchReservationRepository reservationRepository;
   private final BatchLotQuantityIntentRepository lotIntentRepository;
   private final StockUnitRepository stockUnitRepository;
   private final StockUnitSoftHoldRepository softHoldRepository;
-  private final BatchAttributeRepository batchAttributeRepository;
   private final QualityGradeQueryService qualityGradeQueryService;
-  private final ColorQueryService colorQueryService;
   private final WorkOrderRepository workOrderRepository;
   private final PrimaryMeasureResolver primaryMeasureResolver;
 
@@ -112,7 +102,7 @@ public class ProductionSalesLotQueryService {
                 Collectors.groupingBy(
                     BatchLotIntentView::batchId,
                     Collectors.mapping(BatchLotIntentView::intent, Collectors.toList())));
-    Map<UUID, LotColourReference> coloursByBatch = resolveColoursByBatch(batchIds);
+    Map<UUID, LotColourReference> coloursByBatch = resolveColoursByBatch(tenantId, batchIds);
 
     return batches.stream()
         .map(
@@ -247,35 +237,18 @@ public class ProductionSalesLotQueryService {
                     ref.id(), ref.code(), ref.name(), ref.saleable(), ref.active()));
   }
 
-  private Map<UUID, LotColourReference> resolveColoursByBatch(List<UUID> batchIds) {
-    return batchAttributeRepository
-        .findActiveColourAttributesByBatchIds(batchIds, COLOUR_ATTRIBUTE_CODES)
-        .stream()
-        .map(attr -> new BatchColour(attr.getBatch().getId(), toColourReference(attr)))
-        .filter(entry -> entry.colour() != null)
+  private Map<UUID, LotColourReference> resolveColoursByBatch(UUID tenantId, List<UUID> batchIds) {
+    return batchRepository.findColorReferencesByBatchIds(tenantId, batchIds).stream()
         .collect(
-            Collectors.toMap(BatchColour::batchId, BatchColour::colour, (left, right) -> left));
-  }
-
-  private LotColourReference toColourReference(BatchAttribute attribute) {
-    String rawValue = attribute.getValue();
-    if (rawValue == null || rawValue.isBlank()) {
-      return null;
-    }
-    String trimmed = rawValue.trim();
-    Optional<ColorReference> resolved = resolveColourCard(trimmed);
-    return resolved
-        .map(ref -> new LotColourReference(ref.id(), ref.code(), ref.name(), ref.colorHex(), null))
-        .orElseGet(() -> new LotColourReference(null, null, null, null, trimmed));
-  }
-
-  private Optional<ColorReference> resolveColourCard(String rawValue) {
-    try {
-      return colorQueryService.findReferenceById(UUID.fromString(rawValue));
-    } catch (IllegalArgumentException ignored) {
-      String code = rawValue.toUpperCase(Locale.ROOT);
-      return colorQueryService.findReferenceByCode(code);
-    }
+            Collectors.toMap(
+                BatchRepository.BatchColorProjection::getBatchId,
+                projection ->
+                    new LotColourReference(
+                        projection.getColorId(),
+                        projection.getColorCode(),
+                        projection.getColorName(),
+                        projection.getColorHex(),
+                        null)));
   }
 
   public record ProductionSalesLotReference(
@@ -322,8 +295,6 @@ public class ProductionSalesLotQueryService {
 
   public record LotColourReference(
       UUID id, String code, String name, String colorHex, String colourLabel) {}
-
-  private record BatchColour(UUID batchId, LotColourReference colour) {}
 
   private record BatchLotIntentView(UUID batchId, ProductionSalesLotIntentReference intent) {
     private static BatchLotIntentView from(

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchAttributeService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchAttributeService.java
@@ -12,6 +12,8 @@ import com.fabricmanagement.production.execution.batch.infra.repository.BatchRep
 import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class BatchAttributeService {
+
+  static final String LEGACY_COLOR_ATTRIBUTE_WRITE = "LEGACY_COLOR_ATTRIBUTE_WRITE";
+  static final Set<String> LEGACY_COLOR_ATTRIBUTE_CODES =
+      Set.of("COLOR", "COLOUR", "COLOR_ID", "COLOUR_ID", "SHADE");
 
   private final BatchAttributeRepository attributeRepository;
   private final BatchRepository batchRepository;
@@ -55,6 +61,8 @@ public class BatchAttributeService {
             .filter(a -> tenantId.equals(a.getTenantId()))
             .orElseThrow(
                 () -> new NotFoundException("Attribute not found: " + request.attributeId()));
+
+    rejectLegacyColorMutation(tenantId, batch, attribute);
 
     if (attributeRepository
         .findByBatch_IdAndAttribute_Id(batch.getId(), attribute.getId())
@@ -96,8 +104,34 @@ public class BatchAttributeService {
                     new NotFoundException(
                         "Batch attribute not found: " + attributeId + " for batch " + batchId));
 
+    rejectLegacyColorMutation(tenantId, batch, entity.getAttribute());
+
     entity.delete();
     attributeRepository.save(entity);
     log.info("Deleted batch attribute: batch={}, attr={}", batch.getBatchCode(), attributeId);
+  }
+
+  /**
+   * Guards every generic attribute mutation against the legacy color family. Any future generic
+   * update path must invoke this method before mutating or persisting the attribute.
+   */
+  private void rejectLegacyColorMutation(UUID tenantId, Batch batch, ProductAttribute attribute) {
+    String rawCode = attribute.getAttributeCode();
+    String normalizedCode = rawCode == null ? "" : rawCode.trim().toUpperCase(Locale.ROOT);
+    if (!LEGACY_COLOR_ATTRIBUTE_CODES.contains(normalizedCode)) {
+      return;
+    }
+
+    log.warn(
+        "Rejected legacy color attribute mutation: tenantId={}, batchId={}, batchCode={}, attributeCode={}",
+        tenantId,
+        batch.getId(),
+        batch.getBatchCode(),
+        rawCode);
+    throw new BatchDomainException(
+        "Legacy color attributes are read-only after the batch color cutover",
+        LEGACY_COLOR_ATTRIBUTE_WRITE,
+        409,
+        new Object[] {rawCode});
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
@@ -131,7 +131,8 @@ public class BatchOperationsService {
                 request.getRemarks(),
                 new HashMap<>(),
                 request.getSourceType(),
-                request.getSourceId()));
+                request.getSourceId(),
+                null));
     childBatch.setStatus(BatchStatus.AVAILABLE);
     Batch savedChild = batchRepository.save(childBatch);
 
@@ -293,7 +294,8 @@ public class BatchOperationsService {
                     ? new HashMap<>(sourceBatch.getAttributes())
                     : new HashMap<>(),
                 sourceBatch.getSourceType(),
-                sourceBatch.getSourceId()));
+                sourceBatch.getSourceId(),
+                sourceBatch.getColorId()));
     childBatch.setParentBatchId(sourceBatch.getId());
     childBatch.setStatus(BatchStatus.AVAILABLE);
     Batch savedChild = batchRepository.save(childBatch);
@@ -409,7 +411,8 @@ public class BatchOperationsService {
                     ? new HashMap<>(sourceBatch.getAttributes())
                     : new HashMap<>(),
                 sourceBatch.getSourceType(),
-                sourceBatch.getSourceId()));
+                sourceBatch.getSourceId(),
+                sourceBatch.getColorId()));
     childBatch.setParentBatchId(sourceBatch.getId());
     childBatch.setStatus(BatchStatus.AVAILABLE);
     Batch savedChild = batchRepository.save(childBatch);

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
@@ -15,6 +15,7 @@ import com.fabricmanagement.production.execution.batch.dto.*;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchCertificationRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchReservationRepository;
+import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryService;
 import com.fabricmanagement.production.masterdata.fiber.domain.Fiber;
 import com.fabricmanagement.production.masterdata.fiber.domain.FiberQualityStandard;
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberQualityStandardRepository;
@@ -48,6 +49,7 @@ public class BatchService {
   private final BatchCertificationRepository batchCertificationRepository;
   private final FiberRepository fiberRepository;
   private final FiberQualityStandardRepository qualityStandardRepository;
+  private final ColorQueryService colorQueryService;
   private final ApplicationEventPublisher applicationEventPublisher;
 
   @Value("${batch.certification.enforce-on-reserve:true}")
@@ -74,6 +76,7 @@ public class BatchService {
     }
 
     UUID qualityStandardId = resolveQualityStandardId(request);
+    UUID colorId = requireActiveColor(request.getColorId());
 
     Batch batch =
         Batch.create(
@@ -92,7 +95,8 @@ public class BatchService {
                 request.getRemarks(),
                 attributes,
                 request.getSourceType(),
-                request.getSourceId()));
+                request.getSourceId(),
+                colorId));
 
     batch = batchRepository.save(batch);
 
@@ -103,6 +107,28 @@ public class BatchService {
     log.info("Created batch: id={}, batchCode={}", batch.getId(), batch.getBatchCode());
 
     return toBatchDto(batch);
+  }
+
+  @Transactional
+  public BatchDto updateColor(UUID batchId, UUID colorId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    Batch batch =
+        batchRepository
+            .findByIdAndTenantId(batchId, tenantId)
+            .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
+
+    batch.assignColor(requireActiveColor(colorId));
+    return toBatchDto(batchRepository.save(batch));
+  }
+
+  private UUID requireActiveColor(UUID colorId) {
+    if (colorId == null) {
+      return null;
+    }
+    return colorQueryService
+        .findActiveReferenceById(colorId)
+        .map(ColorQueryService.ColorReference::id)
+        .orElseThrow(() -> new NotFoundException("Active color not found: " + colorId));
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
@@ -57,6 +57,9 @@ public class Batch extends BaseEntity {
   @Column(name = "product_id", nullable = false)
   private UUID productId;
 
+  @Column(name = "color_id")
+  private UUID colorId;
+
   @Enumerated(EnumType.STRING)
   @Column(name = "product_type", nullable = false)
   private ProductType productType;
@@ -145,6 +148,7 @@ public class Batch extends BaseEntity {
     Batch batch = new Batch();
     batch.setTenantId(cmd.tenantId());
     batch.setProductId(cmd.productId());
+    batch.setColorId(cmd.colorId());
     batch.setProductType(cmd.productType());
     batch.setBatchCode(cmd.batchCode());
     batch.setSupplierBatchCode(cmd.supplierBatchCode());
@@ -211,7 +215,13 @@ public class Batch extends BaseEntity {
             remarks,
             attributes,
             null,
+            null,
             null));
+  }
+
+  /** Assign or clear the tenant color-card identity for this batch. */
+  public void assignColor(UUID colorId) {
+    this.colorId = colorId;
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/CreateBatchCommand.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/CreateBatchCommand.java
@@ -30,7 +30,8 @@ public record CreateBatchCommand(
     String remarks,
     Map<String, Object> attributes,
     BatchSourceType sourceType,
-    UUID sourceId) {
+    UUID sourceId,
+    UUID colorId) {
 
   /**
    * Compact constructor — validates required fields eagerly.

--- a/src/main/java/com/fabricmanagement/production/execution/batch/dto/BatchDto.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/dto/BatchDto.java
@@ -35,6 +35,9 @@ public class BatchDto {
   @Schema(description = "ID of the parent product this batch belongs to")
   private UUID productId;
 
+  @Schema(description = "Assigned tenant color-card ID; null means unassigned", nullable = true)
+  private UUID colorId;
+
   @Schema(description = "Type of the product (FIBER, YARN, FABRIC)")
   private ProductType productType;
 
@@ -130,6 +133,7 @@ public class BatchDto {
             .tenantId(entity.getTenantId())
             .uid(entity.getUid())
             .productId(entity.getProductId())
+            .colorId(entity.getColorId())
             .productType(entity.getProductType())
             .attributes(entity.getAttributes())
             .fiberSpecs(

--- a/src/main/java/com/fabricmanagement/production/execution/batch/dto/CreateBatchRequest.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/dto/CreateBatchRequest.java
@@ -34,6 +34,11 @@ public class CreateBatchRequest {
       requiredMode = Schema.RequiredMode.REQUIRED)
   private UUID productId;
 
+  @Schema(
+      description = "Optional active tenant color-card ID; null means unassigned",
+      nullable = true)
+  private UUID colorId;
+
   @NotNull(message = "Product type is required")
   @Schema(
       description = "Type of the product (FIBER, YARN, FABRIC)",

--- a/src/main/java/com/fabricmanagement/production/execution/batch/dto/UpdateBatchColorRequest.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/dto/UpdateBatchColorRequest.java
@@ -1,0 +1,11 @@
+package com.fabricmanagement.production.execution.batch.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+@Schema(description = "Request to assign or clear a batch color card")
+public record UpdateBatchColorRequest(
+    @Schema(
+            description = "Active tenant color-card ID; null clears the batch color",
+            nullable = true)
+        UUID colorId) {}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchAttributeRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchAttributeRepository.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -19,19 +17,4 @@ public interface BatchAttributeRepository extends JpaRepository<BatchAttribute, 
   Optional<BatchAttribute> findByBatch_IdAndAttribute_Id(UUID batchId, UUID attributeId);
 
   Optional<BatchAttribute> findByIdAndBatch_IdAndTenantId(UUID id, UUID batchId, UUID tenantId);
-
-  @Query(
-      """
-      SELECT ba
-      FROM BatchAttribute ba
-      JOIN FETCH ba.batch b
-      JOIN FETCH ba.attribute a
-      WHERE b.id IN :batchIds
-        AND ba.isActive = true
-        AND a.isActive = true
-        AND UPPER(a.attributeCode) IN :attributeCodes
-      """)
-  List<BatchAttribute> findActiveColourAttributesByBatchIds(
-      @Param("batchIds") List<UUID> batchIds,
-      @Param("attributeCodes") java.util.Set<String> attributeCodes);
 }

--- a/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
@@ -67,6 +67,21 @@ public interface BatchRepository extends JpaRepository<Batch, UUID> {
 
   List<Batch> findByTenantIdAndStatusIn(UUID tenantId, Collection<BatchStatus> statuses);
 
+  @Query(
+      """
+      SELECT b.id AS batchId,
+             c.id AS colorId,
+             c.code AS colorCode,
+             c.name AS colorName,
+             c.colorHex AS colorHex
+      FROM Batch b
+      JOIN Color c ON c.id = b.colorId AND c.tenantId = b.tenantId
+      WHERE b.tenantId = :tenantId
+        AND b.id IN :batchIds
+      """)
+  List<BatchColorProjection> findColorReferencesByBatchIds(
+      @Param("tenantId") UUID tenantId, @Param("batchIds") Collection<UUID> batchIds);
+
   List<Batch> findByTenantIdAndProductIdAndStatusIn(
       UUID tenantId, UUID productId, Collection<BatchStatus> statuses);
 
@@ -106,4 +121,16 @@ public interface BatchRepository extends JpaRepository<Batch, UUID> {
    */
   boolean existsByTenantIdAndProductIdAndStatusIn(
       UUID tenantId, UUID productId, Collection<BatchStatus> statuses);
+
+  interface BatchColorProjection {
+    UUID getBatchId();
+
+    UUID getColorId();
+
+    String getColorCode();
+
+    String getColorName();
+
+    String getColorHex();
+  }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/workorder/app/ProductionLotService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/workorder/app/ProductionLotService.java
@@ -74,8 +74,8 @@ public class ProductionLotService {
                 request.remarks(),
                 new HashMap<>(), // attributes
                 BatchSourceType.INTERNAL_PRODUCTION,
-                workOrderId // sourceId defines the 1:N relationship
-                ));
+                workOrderId, // sourceId defines the 1:N relationship
+                null)); // New production lots have no inferred color identity
 
     lot.setStatus(BatchStatus.AVAILABLE);
     Batch saved;

--- a/src/main/resources/db/migration/V20260718120000__batch_color_cutover.sql
+++ b/src/main/resources/db/migration/V20260718120000__batch_color_cutover.sql
@@ -1,0 +1,391 @@
+-- BE-3 / ADR-0010: hard cutover of batch colour from EAV attributes to batch.color_id.
+-- This migration is intentionally transactional. Do not split it or mark it non-transactional.
+
+DO $$
+DECLARE
+    has_color_column BOOLEAN;
+    offending_batch_ids UUID[];
+BEGIN
+    SELECT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'production'
+          AND table_name = 'production_execution_batch'
+          AND column_name = 'color_id'
+    ) INTO has_color_column;
+
+    IF has_color_column THEN
+        EXECUTE $sql$
+            SELECT array_agg(id)
+            FROM (
+                SELECT id
+                FROM production.production_execution_batch
+                WHERE color_id IS NOT NULL
+                ORDER BY id
+                LIMIT 20
+            ) offending
+        $sql$ INTO offending_batch_ids;
+
+        IF offending_batch_ids IS NOT NULL THEN
+            RAISE EXCEPTION
+                'BE-3 preflight #6: pre-existing non-NULL batch.color_id values found; offending batch ids: %',
+                offending_batch_ids;
+        END IF;
+    END IF;
+END $$;
+
+ALTER TABLE production.production_execution_batch
+    ADD COLUMN IF NOT EXISTS color_id UUID;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'fk_exec_batch_tenant_color'
+          AND conrelid = 'production.production_execution_batch'::regclass
+    ) THEN
+        ALTER TABLE production.production_execution_batch
+            ADD CONSTRAINT fk_exec_batch_tenant_color
+            FOREIGN KEY (tenant_id, color_id)
+            REFERENCES production.color (tenant_id, id)
+            ON DELETE RESTRICT;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_exec_batch_tenant_color
+    ON production.production_execution_batch (tenant_id, color_id);
+
+CREATE INDEX IF NOT EXISTS idx_exec_batch_tenant_product_color
+    ON production.production_execution_batch (tenant_id, product_id, color_id);
+
+CREATE TABLE IF NOT EXISTS production.production_execution_batch_color_archive (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    source_row_id UUID NOT NULL,
+    batch_id UUID NOT NULL,
+    attribute_definition_id UUID NOT NULL,
+    attribute_code VARCHAR(50) NOT NULL,
+    attribute_value TEXT,
+    resolved_color_id UUID NOT NULL,
+    prev_is_active BOOLEAN NOT NULL,
+    prev_deleted_at TIMESTAMPTZ,
+    prev_created_at TIMESTAMP NOT NULL,
+    prev_created_by UUID,
+    prev_updated_at TIMESTAMP NOT NULL,
+    prev_updated_by UUID,
+    prev_version BIGINT NOT NULL,
+    cutover_version VARCHAR(50) NOT NULL,
+    cutover_at TIMESTAMPTZ NOT NULL,
+    CONSTRAINT fk_batch_color_archive_tenant
+        FOREIGN KEY (tenant_id)
+        REFERENCES common_tenant.common_tenant(id)
+        ON DELETE RESTRICT,
+    CONSTRAINT uq_batch_color_archive_source
+        UNIQUE (tenant_id, source_row_id)
+);
+
+CREATE INDEX idx_batch_color_archive_tenant
+    ON production.production_execution_batch_color_archive (tenant_id);
+
+ALTER TABLE production.production_execution_batch_color_archive ENABLE ROW LEVEL SECURITY;
+ALTER TABLE production.production_execution_batch_color_archive FORCE ROW LEVEL SECURITY;
+CREATE POLICY rls_tenant_isolation
+    ON production.production_execution_batch_color_archive
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN
+        REVOKE INSERT, UPDATE, DELETE
+            ON production.production_execution_batch_color_archive FROM fabric_app;
+        GRANT SELECT
+            ON production.production_execution_batch_color_archive TO fabric_app;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_system') THEN
+        REVOKE INSERT, UPDATE
+            ON production.production_execution_batch_color_archive FROM fabric_system;
+        GRANT SELECT, DELETE
+            ON production.production_execution_batch_color_archive TO fabric_system;
+    END IF;
+END $$;
+
+-- #1: every tenant boundary in the source chain must agree. A UUID that names another
+-- tenant's color is a tenant mismatch, not an ordinary unresolved UUID.
+DO $$
+DECLARE
+    offending_source_ids UUID[];
+BEGIN
+    SELECT array_agg(source_row_id)
+    INTO offending_source_ids
+    FROM (
+        SELECT ba.id AS source_row_id
+        FROM production.production_execution_batch_attribute ba
+        JOIN production.production_execution_batch b ON b.id = ba.batch_id
+        JOIN production.prod_product_attribute pa ON pa.id = ba.attribute_id
+        LEFT JOIN production.color foreign_color
+          ON CASE
+               WHEN btrim(ba.value) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+               THEN foreign_color.id = btrim(ba.value)::uuid
+               ELSE FALSE
+             END
+         AND foreign_color.tenant_id <> ba.tenant_id
+        WHERE ba.is_active = TRUE
+          AND pa.is_active = TRUE
+          AND upper(btrim(pa.attribute_code)) IN
+              ('COLOR', 'COLOUR', 'COLOR_ID', 'COLOUR_ID', 'SHADE')
+          AND (
+              ba.tenant_id <> b.tenant_id
+              OR ba.tenant_id <> pa.tenant_id
+              OR foreign_color.id IS NOT NULL
+          )
+        ORDER BY ba.id
+        LIMIT 20
+    ) offending;
+
+    IF offending_source_ids IS NOT NULL THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #1: tenant mismatch in legacy color chain; offending source row ids: %',
+            offending_source_ids;
+    END IF;
+END $$;
+
+-- #2: a recognised active attribute must carry a non-blank value.
+DO $$
+DECLARE
+    offending_source_ids UUID[];
+BEGIN
+    SELECT array_agg(source_row_id)
+    INTO offending_source_ids
+    FROM (
+        SELECT ba.id AS source_row_id
+        FROM production.production_execution_batch_attribute ba
+        JOIN production.prod_product_attribute pa ON pa.id = ba.attribute_id
+        WHERE ba.is_active = TRUE
+          AND pa.is_active = TRUE
+          AND upper(btrim(pa.attribute_code)) IN
+              ('COLOR', 'COLOUR', 'COLOR_ID', 'COLOUR_ID', 'SHADE')
+          AND (ba.value IS NULL OR btrim(ba.value) = '')
+        ORDER BY ba.id
+        LIMIT 20
+    ) offending;
+
+    IF offending_source_ids IS NOT NULL THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #2: NULL or blank legacy color value; offending source row ids: %',
+            offending_source_ids;
+    END IF;
+END $$;
+
+CREATE TEMP TABLE batch_color_cutover_resolution ON COMMIT DROP AS
+SELECT
+    ba.id AS source_row_id,
+    ba.tenant_id,
+    ba.batch_id,
+    ba.attribute_id AS attribute_definition_id,
+    pa.attribute_code,
+    ba.value AS attribute_value,
+    ba.is_active AS prev_is_active,
+    ba.deleted_at AS prev_deleted_at,
+    ba.created_at AS prev_created_at,
+    ba.created_by AS prev_created_by,
+    ba.updated_at AS prev_updated_at,
+    ba.updated_by AS prev_updated_by,
+    ba.version AS prev_version,
+    btrim(ba.value) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        AS uuid_shaped,
+    CASE
+        WHEN btrim(ba.value) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        THEN (
+            SELECT count(*)
+            FROM production.color c
+            WHERE c.tenant_id = ba.tenant_id
+              AND c.id = btrim(ba.value)::uuid
+        )
+        ELSE 0
+    END AS uuid_match_count,
+    CASE
+        WHEN btrim(ba.value) !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        THEN (
+            SELECT count(*)
+            FROM production.color c
+            WHERE c.tenant_id = ba.tenant_id
+              AND c.code = upper(btrim(ba.value))
+        )
+        ELSE 0
+    END AS code_match_count,
+    CASE
+        WHEN btrim(ba.value) ~* '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+        THEN (
+            SELECT c.id
+            FROM production.color c
+            WHERE c.tenant_id = ba.tenant_id
+              AND c.id = btrim(ba.value)::uuid
+        )
+        ELSE (
+            SELECT c.id
+            FROM production.color c
+            WHERE c.tenant_id = ba.tenant_id
+              AND c.code = upper(btrim(ba.value))
+        )
+    END AS resolved_color_id
+FROM production.production_execution_batch_attribute ba
+JOIN production.production_execution_batch b ON b.id = ba.batch_id
+JOIN production.prod_product_attribute pa ON pa.id = ba.attribute_id
+WHERE ba.is_active = TRUE
+  AND pa.is_active = TRUE
+  AND upper(btrim(pa.attribute_code)) IN
+      ('COLOR', 'COLOUR', 'COLOR_ID', 'COLOUR_ID', 'SHADE');
+
+-- #3: once a value is UUID-shaped, canonical code fallback is forbidden.
+DO $$
+DECLARE
+    offending_source_ids UUID[];
+BEGIN
+    SELECT array_agg(source_row_id)
+    INTO offending_source_ids
+    FROM (
+        SELECT source_row_id
+        FROM batch_color_cutover_resolution
+        WHERE uuid_shaped = TRUE
+          AND uuid_match_count <> 1
+        ORDER BY source_row_id
+        LIMIT 20
+    ) offending;
+
+    IF offending_source_ids IS NOT NULL THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #3: UUID legacy color value did not resolve exactly once; offending source row ids: %',
+            offending_source_ids;
+    END IF;
+END $$;
+
+-- #4: non-UUID values resolve only through the tenant's canonical color.code.
+DO $$
+DECLARE
+    offending_source_ids UUID[];
+BEGIN
+    SELECT array_agg(source_row_id)
+    INTO offending_source_ids
+    FROM (
+        SELECT source_row_id
+        FROM batch_color_cutover_resolution
+        WHERE uuid_shaped = FALSE
+          AND code_match_count <> 1
+        ORDER BY source_row_id
+        LIMIT 20
+    ) offending;
+
+    IF offending_source_ids IS NOT NULL THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #4: canonical color code did not resolve exactly once; offending source row ids: %',
+            offending_source_ids;
+    END IF;
+END $$;
+
+-- #5: multiple recognised attributes are allowed only when they agree on one card.
+DO $$
+DECLARE
+    offending_batch_ids UUID[];
+BEGIN
+    SELECT array_agg(batch_id)
+    INTO offending_batch_ids
+    FROM (
+        SELECT batch_id
+        FROM batch_color_cutover_resolution
+        GROUP BY batch_id
+        HAVING count(DISTINCT resolved_color_id) > 1
+        ORDER BY batch_id
+        LIMIT 20
+    ) offending;
+
+    IF offending_batch_ids IS NOT NULL THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #5: legacy color attributes disagree; offending batch ids: %',
+            offending_batch_ids;
+    END IF;
+END $$;
+
+UPDATE production.production_execution_batch b
+SET color_id = resolved.resolved_color_id
+FROM (
+    SELECT batch_id, (array_agg(resolved_color_id))[1] AS resolved_color_id
+    FROM batch_color_cutover_resolution
+    GROUP BY batch_id
+) resolved
+WHERE b.id = resolved.batch_id;
+
+-- #7: defensive terminal parity after the backfill.
+DO $$
+DECLARE
+    source_count BIGINT;
+    resolved_count BIGINT;
+    parity_count BIGINT;
+BEGIN
+    SELECT count(*), count(resolved_color_id)
+    INTO source_count, resolved_count
+    FROM batch_color_cutover_resolution;
+
+    SELECT count(*)
+    INTO parity_count
+    FROM batch_color_cutover_resolution r
+    JOIN production.production_execution_batch b
+      ON b.id = r.batch_id
+     AND b.tenant_id = r.tenant_id
+     AND b.color_id = r.resolved_color_id;
+
+    IF source_count <> resolved_count OR source_count <> parity_count THEN
+        RAISE EXCEPTION
+            'BE-3 preflight #7: terminal parity failed (source=%, resolved=%, batch-parity=%)',
+            source_count, resolved_count, parity_count;
+    END IF;
+END $$;
+
+INSERT INTO production.production_execution_batch_color_archive (
+    tenant_id,
+    source_row_id,
+    batch_id,
+    attribute_definition_id,
+    attribute_code,
+    attribute_value,
+    resolved_color_id,
+    prev_is_active,
+    prev_deleted_at,
+    prev_created_at,
+    prev_created_by,
+    prev_updated_at,
+    prev_updated_by,
+    prev_version,
+    cutover_version,
+    cutover_at
+)
+SELECT
+    tenant_id,
+    source_row_id,
+    batch_id,
+    attribute_definition_id,
+    attribute_code,
+    attribute_value,
+    resolved_color_id,
+    prev_is_active,
+    prev_deleted_at,
+    prev_created_at,
+    prev_created_by,
+    prev_updated_at,
+    prev_updated_by,
+    prev_version,
+    'V20260718120000',
+    CURRENT_TIMESTAMP
+FROM batch_color_cutover_resolution;
+
+UPDATE production.production_execution_batch_attribute ba
+SET is_active = FALSE,
+    deleted_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP,
+    version = ba.version + 1
+FROM batch_color_cutover_resolution resolved
+WHERE ba.id = resolved.source_row_id
+  AND ba.tenant_id = resolved.tenant_id;

--- a/src/main/resources/db/rollback/V20260718120000_ROLLBACK__batch_color_cutover.sql
+++ b/src/main/resources/db/rollback/V20260718120000_ROLLBACK__batch_color_cutover.sql
@@ -1,0 +1,30 @@
+-- ADR-0010 compensating rollback. Valid only inside the maintenance window before writes reopen.
+-- DDL deliberately remains in place so the old binary can validate against the additive schema.
+
+BEGIN;
+
+UPDATE production.production_execution_batch_attribute source
+SET is_active = archive.prev_is_active,
+    deleted_at = archive.prev_deleted_at,
+    created_at = archive.prev_created_at,
+    created_by = archive.prev_created_by,
+    updated_at = archive.prev_updated_at,
+    updated_by = archive.prev_updated_by,
+    version = archive.prev_version
+FROM production.production_execution_batch_color_archive archive
+WHERE source.tenant_id = archive.tenant_id
+  AND source.id = archive.source_row_id
+  AND archive.cutover_version = 'V20260718120000';
+
+-- Clear EVERY non-NULL color_id, not only archived batches: preflight #6 guaranteed no value
+-- existed before the cutover, so any value present now was written by the cutover or by
+-- in-window smoke tests (create/PATCH). Leaving smoke-test values behind would make a later
+-- re-attempt migration fail its own preflight #6. Clearing all is lossless by construction.
+UPDATE production.production_execution_batch
+SET color_id = NULL
+WHERE color_id IS NOT NULL;
+
+DELETE FROM production.production_execution_batch_color_archive
+WHERE cutover_version = 'V20260718120000';
+
+COMMIT;

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
@@ -27,7 +27,6 @@ import com.fabricmanagement.platform.user.domain.User;
 import com.fabricmanagement.platform.user.dto.CreateInternalUserRequest;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.platform.user.infra.repository.UserRepository;
-import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
 import com.fabricmanagement.production.execution.batch.app.BatchService;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
 import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
@@ -41,7 +40,6 @@ import com.fabricmanagement.production.masterdata.color.domain.ColorType;
 import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.dto.CreateProductRequest;
-import com.fabricmanagement.production.masterdata.product.dto.ProductAttributeDto;
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
@@ -87,7 +85,6 @@ class SalesQuoteDemoSeederTest {
   @Mock private ColorService colorService;
   @Mock private BatchService batchService;
   @Mock private StockUnitService stockUnitService;
-  @Mock private BatchAttributeService batchAttributeService;
   @Mock private SalesProductService salesProductService;
   @Mock private DiscountPolicyService discountPolicyService;
   @Mock private ExchangeRateService exchangeRateService;
@@ -114,7 +111,6 @@ class SalesQuoteDemoSeederTest {
             colorService,
             batchService,
             stockUnitService,
-            batchAttributeService,
             salesProductService,
             discountPolicyService,
             exchangeRateService,
@@ -184,8 +180,15 @@ class SalesQuoteDemoSeederTest {
         .extracting(CreateBatchRequest::getUnit)
         .allMatch(List.of("KG", "MT", "PIECE")::contains);
 
-    // The colour axis rides through the tenant-scoped app-layer ensure, not a repository write.
-    verify(productFacade, times(1)).ensureAttribute(eq("COLOR"), any(), any(), any(), any(), any());
+    assertThat(batchCaptor.getAllValues())
+        .extracting(CreateBatchRequest::getColorId)
+        .filteredOn(java.util.Objects::nonNull)
+        .hasSize(6);
+    assertThat(batchCaptor.getAllValues())
+        .filteredOn(request -> "LOT-24040".equals(request.getBatchCode()))
+        .singleElement()
+        .extracting(CreateBatchRequest::getColorId)
+        .isNull();
 
     // 16 + 24 + 3 rolls, 48 yarn cartons, 2 waste rolls — each graded through the service.
     verify(stockUnitService, times(93))
@@ -348,17 +351,6 @@ class SalesQuoteDemoSeederTest {
               colour.setId(UUID.randomUUID());
               return colour;
             });
-
-    when(productFacade.ensureAttribute(eq("COLOR"), any(), any(), any(), any(), any()))
-        .thenAnswer(
-            invocation ->
-                ProductAttributeDto.builder()
-                    .id(UUID.randomUUID())
-                    .attributeCode(invocation.getArgument(0))
-                    .attributeName(invocation.getArgument(1))
-                    .attributeGroup(invocation.getArgument(2))
-                    .productScope(invocation.getArgument(3))
-                    .build());
 
     when(productFacade.createProduct(any(CreateProductRequest.class)))
         .thenAnswer(

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -82,6 +82,7 @@ class TenantTransactionalPurgeServiceTest {
             "sales.quote",
             "procurement.purchase_order",
             "production.prod_product",
+            "production.production_execution_batch_color_archive",
             "production.stock_unit_soft_hold",
             "iwm.warehouse_location",
             "finance.finance_invoice",
@@ -106,6 +107,11 @@ class TenantTransactionalPurgeServiceTest {
     verify(jdbc)
         .update(
             contains("DELETE FROM production.stock_unit_soft_hold WHERE tenant_id = ?"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains(
+                "DELETE FROM production.production_execution_batch_color_archive WHERE tenant_id = ?"),
             eq(TENANT_ID));
     verify(jdbc)
         .update(
@@ -279,6 +285,14 @@ class TenantTransactionalPurgeServiceTest {
         .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber_iso_code WHERE tenant_id = ?"));
     assertThat(indexOf(sql, "DELETE FROM production.prod_fiber WHERE tenant_id = ?"))
         .isLessThan(indexOf(sql, "DELETE FROM production.prod_fiber_category WHERE tenant_id = ?"));
+  }
+
+  @Test
+  void shouldDeleteBatchColorArchiveBeforeLegacyBatchAttributes() {
+    List<String> tables = TenantTransactionalPurgeService.tenantScopedDeleteTables();
+
+    assertThat(tables.indexOf("production.production_execution_batch_color_archive"))
+        .isLessThan(tables.indexOf("production.production_execution_batch_attribute"));
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/WalkingSkeletonIT.java
+++ b/src/test/java/com/fabricmanagement/production/WalkingSkeletonIT.java
@@ -316,6 +316,7 @@ class WalkingSkeletonIT {
                 null,
                 null,
                 BatchSourceType.INITIAL_STOCK,
+                null,
                 null));
     rawBatch1.transitionStatus(BatchStatus.AVAILABLE, adminUserId);
     rawBatch1 = batchRepository.save(rawBatch1);
@@ -353,6 +354,7 @@ class WalkingSkeletonIT {
                 null,
                 null,
                 BatchSourceType.INITIAL_STOCK,
+                null,
                 null));
     rawBatch2.transitionStatus(BatchStatus.AVAILABLE, adminUserId);
     rawBatch2 = batchRepository.save(rawBatch2);

--- a/src/test/java/com/fabricmanagement/production/execution/batch/api/controller/BatchControllerColorTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/api/controller/BatchControllerColorTest.java
@@ -1,0 +1,137 @@
+package com.fabricmanagement.production.execution.batch.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.app.BatchAttributeService;
+import com.fabricmanagement.production.execution.batch.app.BatchCertificationService;
+import com.fabricmanagement.production.execution.batch.app.BatchOperationsService;
+import com.fabricmanagement.production.execution.batch.app.BatchService;
+import com.fabricmanagement.production.execution.batch.domain.exception.BatchDomainException;
+import com.fabricmanagement.production.execution.batch.dto.AddBatchAttributeRequest;
+import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BatchController.class)
+@EnableMethodSecurity
+class BatchControllerColorTest {
+
+  private static final UUID BATCH_ID = UUID.randomUUID();
+  private static final UUID COLOR_ID = UUID.randomUUID();
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private BatchService batchService;
+  @MockBean private BatchOperationsService batchOperationsService;
+  @MockBean private BatchCertificationService batchCertificationService;
+  @MockBean private BatchAttributeService batchAttributeService;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  @Test
+  @WithMockUser
+  void patchAssignsAndClearsColorBehindProductsWritePermission() throws Exception {
+    allowWrite(true);
+    when(batchService.updateColor(BATCH_ID, COLOR_ID))
+        .thenReturn(BatchDto.builder().id(BATCH_ID).colorId(COLOR_ID).build());
+    when(batchService.updateColor(BATCH_ID, null))
+        .thenReturn(BatchDto.builder().id(BATCH_ID).colorId(null).build());
+
+    mockMvc
+        .perform(
+            patch("/api/v1/production/batches/{id}/color", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"colorId\":\"" + COLOR_ID + "\"}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.colorId").value(COLOR_ID.toString()));
+
+    mockMvc
+        .perform(
+            patch("/api/v1/production/batches/{id}/color", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"colorId\":null}"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.colorId").isEmpty());
+  }
+
+  @Test
+  @WithMockUser
+  void patchRejectsReadOnlyCaller() throws Exception {
+    allowWrite(false);
+
+    mockMvc
+        .perform(
+            patch("/api/v1/production/batches/{id}/color", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"colorId\":null}"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void patchMapsUnknownInactiveOrCrossTenantColorToNotFound() throws Exception {
+    allowWrite(true);
+    when(batchService.updateColor(BATCH_ID, COLOR_ID))
+        .thenThrow(new NotFoundException("Active color not found: " + COLOR_ID));
+
+    mockMvc
+        .perform(
+            patch("/api/v1/production/batches/{id}/color", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"colorId\":\"" + COLOR_ID + "\"}"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+  }
+
+  @Test
+  @WithMockUser
+  void legacyColorGuardCodeSurfacesThroughCanonicalExceptionHandler() throws Exception {
+    allowWrite(true);
+    when(batchAttributeService.add(eq(BATCH_ID), any(AddBatchAttributeRequest.class)))
+        .thenThrow(
+            new BatchDomainException(
+                "Legacy color attributes are read-only after the batch color cutover",
+                "LEGACY_COLOR_ATTRIBUTE_WRITE",
+                409));
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/batches/{id}/attributes", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"attributeId\":\"" + UUID.randomUUID() + "\",\"value\":\"x\"}"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.code").value("LEGACY_COLOR_ATTRIBUTE_WRITE"));
+  }
+
+  private void allowWrite(boolean allowed) {
+    when(authEvaluator.can(any(Authentication.class), eq("products"), eq("write")))
+        .thenReturn(allowed);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/api/query/ProductionSalesLotQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/api/query/ProductionSalesLotQueryServiceTest.java
@@ -1,0 +1,121 @@
+package com.fabricmanagement.production.execution.batch.api.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchLotQuantityIntentRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchReservationRepository;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitSoftHoldRepository;
+import com.fabricmanagement.production.execution.workorder.infra.repository.WorkOrderRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.qualitygrade.api.query.QualityGradeQueryService;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionSalesLotQueryServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+
+  @Mock private BatchRepository batchRepository;
+  @Mock private BatchReservationRepository reservationRepository;
+  @Mock private BatchLotQuantityIntentRepository lotIntentRepository;
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private StockUnitSoftHoldRepository softHoldRepository;
+  @Mock private QualityGradeQueryService qualityGradeQueryService;
+  @Mock private WorkOrderRepository workOrderRepository;
+  @Mock private PrimaryMeasureResolver primaryMeasureResolver;
+
+  private ProductionSalesLotQueryService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    service =
+        new ProductionSalesLotQueryService(
+            batchRepository,
+            reservationRepository,
+            lotIntentRepository,
+            stockUnitRepository,
+            softHoldRepository,
+            qualityGradeQueryService,
+            workOrderRepository,
+            primaryMeasureResolver);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void listSaleableLots_resolvesColorsWithOneBulkJoinAndLeavesNullColorUnmapped() {
+    Batch colored = batch("LOT-COLOR", UUID.randomUUID());
+    Batch uncolored = batch("LOT-NULL", null);
+    List<UUID> batchIds = List.of(colored.getId(), uncolored.getId());
+    BatchRepository.BatchColorProjection projection =
+        mock(BatchRepository.BatchColorProjection.class);
+    when(projection.getBatchId()).thenReturn(colored.getId());
+    when(projection.getColorId()).thenReturn(colored.getColorId());
+    when(projection.getColorCode()).thenReturn("NAVY-01");
+    when(projection.getColorName()).thenReturn("Navy");
+    when(projection.getColorHex()).thenReturn("#1F2A44");
+
+    when(batchRepository.findByTenantIdAndStatusIn(eq(TENANT_ID), any()))
+        .thenReturn(List.of(colored, uncolored));
+    when(stockUnitRepository.findByTenantIdAndBatchIdInAndIsActiveTrue(TENANT_ID, batchIds))
+        .thenReturn(List.of());
+    when(softHoldRepository.countActiveByStockUnitIds(TENANT_ID, List.of())).thenReturn(Map.of());
+    when(lotIntentRepository.sumActiveByBatchIds(TENANT_ID, batchIds, null)).thenReturn(Map.of());
+    when(reservationRepository.sumActiveRemainingByBatchIds(TENANT_ID, batchIds))
+        .thenReturn(Map.of());
+    when(lotIntentRepository.findActiveByBatchIds(TENANT_ID, batchIds, null)).thenReturn(List.of());
+    when(batchRepository.findColorReferencesByBatchIds(TENANT_ID, batchIds))
+        .thenReturn(List.of(projection));
+    when(primaryMeasureResolver.resolve(any(), any())).thenReturn(PrimaryMeasure.WEIGHT);
+
+    var lots = service.listSaleableLots();
+
+    assertThat(lots).hasSize(2);
+    assertThat(lots.get(0).colour().id()).isEqualTo(colored.getColorId());
+    assertThat(lots.get(0).colour().code()).isEqualTo("NAVY-01");
+    assertThat(lots.get(1).colour()).isNull();
+    verify(batchRepository).findColorReferencesByBatchIds(TENANT_ID, batchIds);
+  }
+
+  private Batch batch(String code, UUID colorId) {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(ProductType.FABRIC)
+            .colorId(colorId)
+            .batchCode(code)
+            .quantity(new BigDecimal("10"))
+            .unit("KG")
+            .status(BatchStatus.AVAILABLE)
+            .sourceType(BatchSourceType.INITIAL_STOCK)
+            .build();
+    batch.setId(UUID.randomUUID());
+    batch.setTenantId(TENANT_ID);
+    batch.setIsActive(true);
+    return batch;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchAttributeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchAttributeServiceTest.java
@@ -1,0 +1,133 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchAttribute;
+import com.fabricmanagement.production.execution.batch.domain.exception.BatchDomainException;
+import com.fabricmanagement.production.execution.batch.dto.AddBatchAttributeRequest;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchAttributeRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.masterdata.product.domain.reference.ProductAttribute;
+import com.fabricmanagement.production.masterdata.product.infra.repository.ProductAttributeRepository;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BatchAttributeServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+  private static final UUID ATTRIBUTE_ID = UUID.randomUUID();
+  private static final UUID BATCH_ATTRIBUTE_ID = UUID.randomUUID();
+
+  @Mock private BatchAttributeRepository attributeRepository;
+  @Mock private BatchRepository batchRepository;
+  @Mock private ProductAttributeRepository productAttributeRepository;
+
+  private BatchAttributeService service;
+  private Batch batch;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    service =
+        new BatchAttributeService(attributeRepository, batchRepository, productAttributeRepository);
+    batch = Batch.builder().batchCode("LOT-1").build();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @ParameterizedTest
+  @MethodSource("legacyCodes")
+  void add_rejectsEveryLegacyColorCode(String attributeCode) {
+    ProductAttribute attribute = attribute(attributeCode);
+    when(productAttributeRepository.findById(ATTRIBUTE_ID)).thenReturn(Optional.of(attribute));
+
+    assertLegacyWriteRejected(
+        () -> service.add(BATCH_ID, new AddBatchAttributeRequest(ATTRIBUTE_ID, "value")));
+
+    verify(attributeRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @MethodSource("legacyCodes")
+  void delete_rejectsEveryLegacyColorCode(String attributeCode) {
+    BatchAttribute entity =
+        BatchAttribute.builder()
+            .batch(batch)
+            .attribute(attribute(attributeCode))
+            .value("value")
+            .build();
+    entity.setId(BATCH_ATTRIBUTE_ID);
+    entity.setTenantId(TENANT_ID);
+    when(attributeRepository.findByIdAndBatch_IdAndTenantId(
+            BATCH_ATTRIBUTE_ID, BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(entity));
+
+    assertLegacyWriteRejected(() -> service.delete(BATCH_ID, BATCH_ATTRIBUTE_ID));
+
+    verify(attributeRepository, never()).save(any());
+  }
+
+  @Test
+  void add_allowsNonColorAttribute() {
+    ProductAttribute attribute = attribute("ORGANIC");
+    when(productAttributeRepository.findById(ATTRIBUTE_ID)).thenReturn(Optional.of(attribute));
+    when(attributeRepository.findByBatch_IdAndAttribute_Id(BATCH_ID, ATTRIBUTE_ID))
+        .thenReturn(Optional.empty());
+    when(attributeRepository.save(any(BatchAttribute.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    assertThatCode(() -> service.add(BATCH_ID, new AddBatchAttributeRequest(ATTRIBUTE_ID, "true")))
+        .doesNotThrowAnyException();
+
+    verify(attributeRepository).save(any(BatchAttribute.class));
+  }
+
+  private void assertLegacyWriteRejected(
+      org.assertj.core.api.ThrowableAssert.ThrowingCallable call) {
+    assertThatThrownBy(call)
+        .isInstanceOf(BatchDomainException.class)
+        .extracting("errorCode", "httpStatus")
+        .containsExactly(BatchAttributeService.LEGACY_COLOR_ATTRIBUTE_WRITE, 409);
+  }
+
+  private ProductAttribute attribute(String code) {
+    ProductAttribute attribute = ProductAttribute.builder().attributeCode(code).build();
+    attribute.setId(ATTRIBUTE_ID);
+    attribute.setTenantId(TENANT_ID);
+    return attribute;
+  }
+
+  private static Stream<Arguments> legacyCodes() {
+    return Stream.of(
+        Arguments.of(" color "),
+        Arguments.of("COLOUR"),
+        Arguments.of("COLOR_ID"),
+        Arguments.of("COLOUR_ID"),
+        Arguments.of("Shade"));
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchColorArchiveSecurityIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchColorArchiveSecurityIT.java
@@ -1,0 +1,126 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class BatchColorArchiveSecurityIT {
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("batch_color_archive_security")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @BeforeAll
+  static void migrateAndSeed() throws SQLException {
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          "CREATE ROLE fabric_app LOGIN NOSUPERUSER NOCREATEDB NOBYPASSRLS PASSWORD 'app_test'");
+      statement.execute(
+          "CREATE ROLE fabric_system LOGIN NOSUPERUSER NOCREATEDB BYPASSRLS PASSWORD 'system_test'");
+    }
+
+    Flyway.configure()
+        .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+        .locations("classpath:db/migration")
+        .schemas("common_tenant")
+        .defaultSchema("common_tenant")
+        .load()
+        .migrate();
+
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          INSERT INTO common_tenant.common_tenant (id, uid, slug, name, status)
+          VALUES
+            ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'ARCHIVE-A', 'archive-a', 'Archive A', 'ACTIVE'),
+            ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'ARCHIVE-B', 'archive-b', 'Archive B', 'ACTIVE')
+          """);
+      statement.execute(
+          """
+          INSERT INTO production.production_execution_batch_color_archive
+            (tenant_id, source_row_id, batch_id, attribute_definition_id, attribute_code,
+             attribute_value, resolved_color_id, prev_is_active, prev_created_at,
+             prev_updated_at, prev_version, cutover_version, cutover_at)
+          VALUES
+            ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', gen_random_uuid(), gen_random_uuid(),
+             gen_random_uuid(), 'COLOR', 'NAVY-01', gen_random_uuid(), true, now(), now(), 0,
+             'V20260718120000', now()),
+            ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', gen_random_uuid(), gen_random_uuid(),
+             gen_random_uuid(), 'COLOR', 'NAVY-01', gen_random_uuid(), true, now(), now(), 0,
+             'V20260718120000', now())
+          """);
+    }
+  }
+
+  @Test
+  void fabricAppSelectIsTenantIsolatedThroughRealRls() throws SQLException {
+    try (Connection connection = appConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute("SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'");
+      try (ResultSet result =
+          statement.executeQuery(
+              "SELECT count(*) FROM production.production_execution_batch_color_archive")) {
+        result.next();
+        assertThat(result.getLong(1)).isEqualTo(1);
+      }
+    }
+  }
+
+  @Test
+  void fabricAppCannotInsertUpdateOrDeleteArchiveRows() {
+    assertPrivilegeDenied(
+        """
+        INSERT INTO production.production_execution_batch_color_archive
+          (tenant_id, source_row_id, batch_id, attribute_definition_id, attribute_code,
+           attribute_value, resolved_color_id, prev_is_active, prev_created_at,
+           prev_updated_at, prev_version, cutover_version, cutover_at)
+        VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', gen_random_uuid(), gen_random_uuid(),
+          gen_random_uuid(), 'COLOR', 'NAVY-01', gen_random_uuid(), true, now(), now(), 0,
+          'V20260718120000', now())
+        """);
+    assertPrivilegeDenied(
+        "UPDATE production.production_execution_batch_color_archive SET attribute_value = 'X'");
+    assertPrivilegeDenied("DELETE FROM production.production_execution_batch_color_archive");
+  }
+
+  private static void assertPrivilegeDenied(String sql) {
+    assertThatThrownBy(
+            () -> {
+              try (Connection connection = appConnection();
+                  Statement statement = connection.createStatement()) {
+                statement.execute(
+                    "SET app.current_tenant = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'");
+                statement.execute(sql);
+              }
+            })
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("permission denied");
+  }
+
+  private static Connection ownerConnection() throws SQLException {
+    return DriverManager.getConnection(
+        POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+  }
+
+  private static Connection appConnection() throws SQLException {
+    return DriverManager.getConnection(POSTGRES.getJdbcUrl(), "fabric_app", "app_test");
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchColorCutoverSqlTestSupport.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchColorCutoverSqlTestSupport.java
@@ -1,0 +1,228 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.UUID;
+import org.flywaydb.core.Flyway;
+import org.springframework.core.io.ClassPathResource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+abstract class BatchColorCutoverSqlTestSupport {
+
+  static final String CUTOVER_SCRIPT = "db/migration/V20260718120000__batch_color_cutover.sql";
+  static final String ROLLBACK_SCRIPT =
+      "db/rollback/V20260718120000_ROLLBACK__batch_color_cutover.sql";
+  static final UUID TENANT_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+  static final UUID TENANT_B = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+  static final UUID PRODUCT_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000001");
+  static final UUID PRODUCT_B = UUID.fromString("bbbbbbbb-0000-4000-8000-000000000001");
+  static final UUID NAVY_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000011");
+  static final UUID ECRU_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000012");
+  static final UUID OLD_A = UUID.fromString("aaaaaaaa-0000-4000-8000-000000000013");
+  static final UUID NAVY_B = UUID.fromString("bbbbbbbb-0000-4000-8000-000000000011");
+
+  protected final PostgreSQLContainer<?> postgres;
+
+  BatchColorCutoverSqlTestSupport(PostgreSQLContainer<?> postgres) {
+    this.postgres = postgres;
+  }
+
+  void resetToPreCutover() throws SQLException {
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      List<String> schemas =
+          List.of(
+              "common_ai",
+              "common_approval",
+              "common_audit",
+              "common_auth",
+              "common_communication",
+              "common_company",
+              "common_infrastructure",
+              "common_policy",
+              "common_tenant",
+              "common_user",
+              "costing",
+              "finance",
+              "flowboard",
+              "human",
+              "i18n",
+              "iwm",
+              "logistics",
+              "notification",
+              "procurement",
+              "production",
+              "sales",
+              "sales_ord");
+      for (String schema : schemas) {
+        statement.execute("DROP SCHEMA IF EXISTS " + schema + " CASCADE");
+      }
+      statement.execute("DROP SCHEMA public CASCADE");
+      statement.execute("CREATE SCHEMA public");
+    }
+
+    Flyway.configure()
+        .dataSource(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())
+        .locations("classpath:db/migration")
+        .schemas("common_tenant")
+        .defaultSchema("common_tenant")
+        .target("20260717120000")
+        .load()
+        .migrate();
+  }
+
+  void seedFoundation() throws SQLException {
+    execute(
+        """
+        INSERT INTO common_tenant.common_tenant (id, uid, slug, name, status)
+        VALUES
+          ('%s', 'TENANT-A', 'tenant-a', 'Tenant A', 'ACTIVE'),
+          ('%s', 'TENANT-B', 'tenant-b', 'Tenant B', 'ACTIVE');
+
+        INSERT INTO production.prod_product
+          (id, tenant_id, uid, product_type, unit)
+        VALUES
+          ('%s', '%s', 'PRODUCT-A', 'FABRIC', 'MT'),
+          ('%s', '%s', 'PRODUCT-B', 'FABRIC', 'MT');
+
+        INSERT INTO production.color
+          (id, uid, created_at, updated_at, tenant_id, is_active, version, code, name)
+        VALUES
+          ('%s', 'COLOR-NAVY-A', now(), now(), '%s', true, 0, 'NAVY-01', 'Navy'),
+          ('%s', 'COLOR-ECRU-A', now(), now(), '%s', true, 0, 'ECRU-02', 'Ecru'),
+          ('%s', 'COLOR-OLD-A', now(), now(), '%s', false, 0, 'OLD-03', 'Old blue'),
+          ('%s', 'COLOR-NAVY-B', now(), now(), '%s', true, 0, 'NAVY-01', 'Navy');
+        """
+            .formatted(
+                TENANT_A, TENANT_B, PRODUCT_A, TENANT_A, PRODUCT_B, TENANT_B, NAVY_A, TENANT_A,
+                ECRU_A, TENANT_A, OLD_A, TENANT_A, NAVY_B, TENANT_B));
+  }
+
+  UUID insertAttribute(UUID tenantId, String code, String suffix) throws SQLException {
+    UUID id = UUID.randomUUID();
+    execute(
+        """
+        INSERT INTO production.prod_product_attribute
+          (id, tenant_id, uid, attribute_code, attribute_name)
+        VALUES ('%s', '%s', 'ATTR-%s', '%s', 'Colour');
+        """
+            .formatted(id, tenantId, suffix, code.replace("'", "''")));
+    return id;
+  }
+
+  UUID insertBatch(UUID tenantId, UUID productId, String suffix) throws SQLException {
+    UUID id = UUID.randomUUID();
+    execute(
+        """
+        INSERT INTO production.production_execution_batch
+          (id, tenant_id, uid, product_id, product_type, batch_code, quantity,
+           reserved_quantity, consumed_quantity, waste_quantity, unit, status)
+        VALUES
+          ('%s', '%s', 'BATCH-%s', '%s', 'FABRIC', 'LOT-%s', 10, 0, 0, 0, 'MT', 'AVAILABLE');
+        """
+            .formatted(id, tenantId, suffix, productId, suffix));
+    return id;
+  }
+
+  UUID insertBatchAttribute(
+      UUID tenantId, UUID batchId, UUID attributeId, String value, String suffix)
+      throws SQLException {
+    UUID id = UUID.randomUUID();
+    String sqlValue = value == null ? "NULL" : "'" + value.replace("'", "''") + "'";
+    execute(
+        """
+        INSERT INTO production.production_execution_batch_attribute
+          (id, tenant_id, uid, batch_id, attribute_id, value, is_active,
+           created_at, created_by, updated_at, updated_by, version)
+        VALUES
+          ('%s', '%s', 'BA-%s', '%s', '%s', %s, true,
+           '2026-07-01 10:00:00', NULL, '2026-07-02 11:00:00', NULL, 7);
+        """
+            .formatted(id, tenantId, suffix, batchId, attributeId, sqlValue));
+    return id;
+  }
+
+  void applyScript(String path) throws SQLException {
+    if (CUTOVER_SCRIPT.equals(path)) {
+      Flyway.configure()
+          .dataSource(postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword())
+          .locations("classpath:db/migration")
+          .schemas("common_tenant")
+          .defaultSchema("common_tenant")
+          .target("20260718120000")
+          .load()
+          .migrate();
+      return;
+    }
+
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(readClasspathScript(path));
+    }
+  }
+
+  private String readClasspathScript(String path) {
+    try (var input = new ClassPathResource(path).getInputStream()) {
+      return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+    } catch (IOException exception) {
+      throw new IllegalStateException("Could not read SQL script: " + path, exception);
+    }
+  }
+
+  void execute(String sql) throws SQLException {
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    }
+  }
+
+  Connection ownerConnection() throws SQLException {
+    return DriverManager.getConnection(
+        postgres.getJdbcUrl(), postgres.getUsername(), postgres.getPassword());
+  }
+
+  boolean columnExists(String tableName, String columnName) throws SQLException {
+    try (Connection connection = ownerConnection();
+        var statement =
+            connection.prepareStatement(
+                """
+                SELECT EXISTS (
+                  SELECT 1 FROM information_schema.columns
+                  WHERE table_schema = 'production' AND table_name = ? AND column_name = ?
+                )
+                """)) {
+      statement.setString(1, tableName);
+      statement.setString(2, columnName);
+      try (var result = statement.executeQuery()) {
+        result.next();
+        return result.getBoolean(1);
+      }
+    }
+  }
+
+  boolean tableExists(String tableName) throws SQLException {
+    try (Connection connection = ownerConnection();
+        var statement =
+            connection.prepareStatement("SELECT to_regclass('production.' || ?) IS NOT NULL")) {
+      statement.setString(1, tableName);
+      try (var result = statement.executeQuery()) {
+        result.next();
+        return result.getBoolean(1);
+      }
+    }
+  }
+
+  long count(String sql) throws SQLException {
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement();
+        var result = statement.executeQuery(sql)) {
+      result.next();
+      return result.getLong(1);
+    }
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
@@ -1,0 +1,129 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
+import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.dto.PartialAcceptanceSplitRequest;
+import com.fabricmanagement.production.execution.batch.dto.SplitBatchRequest;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchOverrideLogRepository;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.lineage.app.BatchLineageService;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class BatchOperationsServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID SOURCE_ID = UUID.randomUUID();
+  private static final UUID COLOR_ID = UUID.randomUUID();
+
+  @Mock private BatchService batchService;
+  @Mock private BatchRepository batchRepository;
+  @Mock private BatchOverrideLogRepository overrideLogRepository;
+  @Mock private BatchCodeGenerator batchCodeGenerator;
+  @Mock private BatchLineageService batchLineageService;
+  @Mock private WarehouseLocationPort warehouseLocationPort;
+  @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+  private BatchOperationsService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(UUID.randomUUID());
+    service =
+        new BatchOperationsService(
+            batchService,
+            batchRepository,
+            overrideLogRepository,
+            batchCodeGenerator,
+            batchLineageService,
+            warehouseLocationPort,
+            applicationEventPublisher);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void splitBatch_inheritsSourceColor() {
+    Batch source = sourceBatch();
+    when(batchRepository.findByIdAndTenantId(SOURCE_ID, TENANT_ID)).thenReturn(Optional.of(source));
+    when(batchCodeGenerator.generateSplitCode(SOURCE_ID, "LOT-1")).thenReturn("LOT-1-S1");
+    when(batchRepository.save(any(Batch.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(batchService.toBatchDto(any(Batch.class))).thenReturn(BatchDto.builder().build());
+
+    service.splitBatch(
+        SOURCE_ID,
+        SplitBatchRequest.builder()
+            .acceptedQuantity(new BigDecimal("4"))
+            .reason("Accepted portion")
+            .rejectedStatus(BatchStatus.RETURNED)
+            .build());
+
+    assertThat(savedChild().getColorId()).isEqualTo(COLOR_ID);
+  }
+
+  @Test
+  void splitPartialAcceptance_inheritsSourceColor() {
+    Batch source = sourceBatch();
+    when(batchRepository.findByIdAndTenantId(SOURCE_ID, TENANT_ID)).thenReturn(Optional.of(source));
+    when(batchCodeGenerator.generateSplitCode(SOURCE_ID, "LOT-1")).thenReturn("LOT-1-S1");
+    when(batchRepository.save(any(Batch.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+    when(batchService.toBatchDto(any(Batch.class))).thenReturn(BatchDto.builder().build());
+
+    service.splitPartialAcceptance(
+        SOURCE_ID,
+        PartialAcceptanceSplitRequest.builder()
+            .acceptedQuantity(new BigDecimal("4"))
+            .reason("Accepted portion")
+            .rejectedStatus(BatchStatus.QC_REJECTED)
+            .build());
+
+    assertThat(savedChild().getColorId()).isEqualTo(COLOR_ID);
+  }
+
+  private Batch savedChild() {
+    ArgumentCaptor<Batch> captor = ArgumentCaptor.forClass(Batch.class);
+    org.mockito.Mockito.verify(batchRepository, org.mockito.Mockito.times(2))
+        .save(captor.capture());
+    return captor.getAllValues().get(1);
+  }
+
+  private Batch sourceBatch() {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(ProductType.FABRIC)
+            .colorId(COLOR_ID)
+            .batchCode("LOT-1")
+            .quantity(new BigDecimal("10"))
+            .unit("MT")
+            .status(BatchStatus.QUARANTINE)
+            .build();
+    batch.setId(SOURCE_ID);
+    batch.setTenantId(TENANT_ID);
+    return batch;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
@@ -12,9 +12,12 @@ import com.fabricmanagement.common.infrastructure.web.exception.NotFoundExceptio
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.dto.CreateBatchRequest;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchCertificationRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchReservationRepository;
+import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryService;
+import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryService.ColorReference;
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberQualityStandardRepository;
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
@@ -41,6 +44,7 @@ class BatchServiceTest {
   @Mock private BatchCertificationRepository batchCertificationRepository;
   @Mock private FiberRepository fiberRepository;
   @Mock private FiberQualityStandardRepository qualityStandardRepository;
+  @Mock private ColorQueryService colorQueryService;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
 
   @InjectMocks private BatchService batchService;
@@ -76,6 +80,71 @@ class BatchServiceTest {
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining(BATCH_ID.toString());
     verify(batchRepository, never()).save(any());
+  }
+
+  @Test
+  void updateColor_assignsActiveTenantColor() {
+    UUID colorId = UUID.randomUUID();
+    Batch batch = pendingQcBatch();
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+    when(colorQueryService.findActiveReferenceById(colorId))
+        .thenReturn(Optional.of(new ColorReference(colorId, "NAVY-01", "Navy", "#1F2A44", true)));
+    when(batchRepository.save(batch)).thenReturn(batch);
+
+    BatchDto result = batchService.updateColor(BATCH_ID, colorId);
+
+    assertThat(batch.getColorId()).isEqualTo(colorId);
+    assertThat(result.getColorId()).isEqualTo(colorId);
+  }
+
+  @Test
+  void updateColor_clearsColorWithoutLookup() {
+    Batch batch = pendingQcBatch();
+    batch.setColorId(UUID.randomUUID());
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+    when(batchRepository.save(batch)).thenReturn(batch);
+
+    BatchDto result = batchService.updateColor(BATCH_ID, null);
+
+    assertThat(batch.getColorId()).isNull();
+    assertThat(result.getColorId()).isNull();
+    verify(colorQueryService, never()).findActiveReferenceById(any());
+  }
+
+  @Test
+  void updateColor_rejectsInactiveUnknownOrCrossTenantColorAsNotFound() {
+    UUID colorId = UUID.randomUUID();
+    Batch batch = pendingQcBatch();
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+    when(colorQueryService.findActiveReferenceById(colorId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> batchService.updateColor(BATCH_ID, colorId))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining(colorId.toString());
+
+    verify(batchRepository, never()).save(any());
+  }
+
+  @Test
+  void create_acceptsActiveTenantColorAndExposesItInDto() {
+    UUID colorId = UUID.randomUUID();
+    when(colorQueryService.findActiveReferenceById(colorId))
+        .thenReturn(Optional.of(new ColorReference(colorId, "NAVY-01", "Navy", "#1F2A44", true)));
+    when(batchRepository.save(any(Batch.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    BatchDto result =
+        batchService.create(
+            CreateBatchRequest.builder()
+                .productId(UUID.randomUUID())
+                .productType(ProductType.FABRIC)
+                .colorId(colorId)
+                .batchCode("LOT-COLOR")
+                .quantity(BigDecimal.ONE)
+                .unit("KG")
+                .build());
+
+    assertThat(result.getColorId()).isEqualTo(colorId);
   }
 
   private Batch pendingQcBatch() {

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/ColorCutoverMigrationIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/ColorCutoverMigrationIT.java
@@ -1,0 +1,185 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class ColorCutoverMigrationIT extends BatchColorCutoverSqlTestSupport {
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("batch_color_cutover")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  ColorCutoverMigrationIT() {
+    super(POSTGRES);
+  }
+
+  @BeforeEach
+  void setUpSchema() throws SQLException {
+    resetToPreCutover();
+    seedFoundation();
+  }
+
+  @Test
+  void migratesUuidCodeSynonymsPaddedCodesInactiveCardsAndMultipleTenants() throws SQLException {
+    UUID color = insertAttribute(TENANT_A, "COLOR", "COLOR");
+    UUID colour = insertAttribute(TENANT_A, "COLOUR", "COLOUR");
+    UUID padded = insertAttribute(TENANT_A, " COLOR ", "PADDED");
+    UUID colorId = insertAttribute(TENANT_A, "COLOR_ID", "COLOR-ID");
+    UUID shade = insertAttribute(TENANT_B, "SHADE", "SHADE");
+
+    UUID uuidBatch = insertBatch(TENANT_A, PRODUCT_A, "UUID");
+    UUID codeBatch = insertBatch(TENANT_A, PRODUCT_A, "CODE");
+    UUID sameCardBatch = insertBatch(TENANT_A, PRODUCT_A, "SAME");
+    UUID paddedBatch = insertBatch(TENANT_A, PRODUCT_A, "PADDED");
+    UUID inactiveBatch = insertBatch(TENANT_A, PRODUCT_A, "INACTIVE");
+    UUID tenantBBatch = insertBatch(TENANT_B, PRODUCT_B, "TENANT-B");
+
+    insertBatchAttribute(TENANT_A, uuidBatch, color, NAVY_A.toString(), "UUID");
+    insertBatchAttribute(TENANT_A, codeBatch, colour, "ECRU-02", "CODE");
+    insertBatchAttribute(TENANT_A, sameCardBatch, color, "NAVY-01", "SAME-1");
+    insertBatchAttribute(TENANT_A, sameCardBatch, colour, NAVY_A.toString(), "SAME-2");
+    insertBatchAttribute(TENANT_A, paddedBatch, padded, "NAVY-01", "PADDED");
+    insertBatchAttribute(TENANT_A, inactiveBatch, colorId, "OLD-03", "INACTIVE");
+    insertBatchAttribute(TENANT_B, tenantBBatch, shade, "NAVY-01", "TENANT-B");
+
+    applyScript(CUTOVER_SCRIPT);
+
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch WHERE color_id IS NOT NULL"))
+        .isEqualTo(6);
+    assertThat(count("SELECT count(*) FROM production.production_execution_batch_color_archive"))
+        .isEqualTo(7);
+    assertThat(
+            count(
+                """
+                SELECT count(*)
+                FROM production.production_execution_batch_color_archive archive
+                JOIN production.production_execution_batch batch
+                  ON batch.tenant_id = archive.tenant_id
+                 AND batch.id = archive.batch_id
+                 AND batch.color_id = archive.resolved_color_id
+                """))
+        .isEqualTo(7);
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch_attribute WHERE is_active = false AND deleted_at IS NOT NULL"))
+        .isEqualTo(7);
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch_attribute WHERE is_active = true"))
+        .isZero();
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch_color_archive WHERE resolved_color_id = '"
+                    + OLD_A
+                    + "'"))
+        .isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @EnumSource(PreflightFailure.class)
+  void preflightFailuresRollbackMigrationOwnedDdl(PreflightFailure failure) throws SQLException {
+    failure.seed(this);
+
+    assertThatThrownBy(() -> applyScript(CUTOVER_SCRIPT))
+        .hasMessageContaining("preflight #" + failure.number);
+
+    assertThat(columnExists("production_execution_batch", "color_id")).isFalse();
+    assertThat(tableExists("production_execution_batch_color_archive")).isFalse();
+  }
+
+  @Test
+  void preExistingNonNullColumnFailsWithoutRemovingOrChangingIt() throws SQLException {
+    UUID batchId = insertBatch(TENANT_A, PRODUCT_A, "PREEXISTING");
+    UUID unexpectedColor = UUID.randomUUID();
+    execute("ALTER TABLE production.production_execution_batch ADD COLUMN color_id UUID");
+    execute(
+        "UPDATE production.production_execution_batch SET color_id = '"
+            + unexpectedColor
+            + "' WHERE id = '"
+            + batchId
+            + "'");
+
+    assertThatThrownBy(() -> applyScript(CUTOVER_SCRIPT)).hasMessageContaining("preflight #6");
+
+    assertThat(columnExists("production_execution_batch", "color_id")).isTrue();
+    assertThat(tableExists("production_execution_batch_color_archive")).isFalse();
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch WHERE id = '"
+                    + batchId
+                    + "' AND color_id = '"
+                    + unexpectedColor
+                    + "'"))
+        .isEqualTo(1);
+  }
+
+  private enum PreflightFailure {
+    TENANT_MISMATCH(1) {
+      @Override
+      void seed(ColorCutoverMigrationIT test) throws SQLException {
+        UUID attribute = test.insertAttribute(TENANT_B, "COLOR", "MISMATCH");
+        UUID batch = test.insertBatch(TENANT_A, PRODUCT_A, "MISMATCH");
+        test.insertBatchAttribute(TENANT_A, batch, attribute, "NAVY-01", "MISMATCH");
+      }
+    },
+    BLANK_VALUE(2) {
+      @Override
+      void seed(ColorCutoverMigrationIT test) throws SQLException {
+        UUID attribute = test.insertAttribute(TENANT_A, "COLOR", "BLANK");
+        UUID batch = test.insertBatch(TENANT_A, PRODUCT_A, "BLANK");
+        test.insertBatchAttribute(TENANT_A, batch, attribute, "   ", "BLANK");
+      }
+    },
+    UNKNOWN_UUID(3) {
+      @Override
+      void seed(ColorCutoverMigrationIT test) throws SQLException {
+        UUID attribute = test.insertAttribute(TENANT_A, "COLOR", "UUID");
+        UUID batch = test.insertBatch(TENANT_A, PRODUCT_A, "UUID");
+        test.insertBatchAttribute(TENANT_A, batch, attribute, UUID.randomUUID().toString(), "UUID");
+      }
+    },
+    UNKNOWN_CODE(4) {
+      @Override
+      void seed(ColorCutoverMigrationIT test) throws SQLException {
+        UUID attribute = test.insertAttribute(TENANT_A, "COLOR", "CODE");
+        UUID batch = test.insertBatch(TENANT_A, PRODUCT_A, "CODE");
+        test.insertBatchAttribute(TENANT_A, batch, attribute, "MISSING", "CODE");
+      }
+    },
+    CONFLICT(5) {
+      @Override
+      void seed(ColorCutoverMigrationIT test) throws SQLException {
+        UUID color = test.insertAttribute(TENANT_A, "COLOR", "CONFLICT-1");
+        UUID colour = test.insertAttribute(TENANT_A, "COLOUR", "CONFLICT-2");
+        UUID batch = test.insertBatch(TENANT_A, PRODUCT_A, "CONFLICT");
+        test.insertBatchAttribute(TENANT_A, batch, color, "NAVY-01", "CONFLICT-1");
+        test.insertBatchAttribute(TENANT_A, batch, colour, "ECRU-02", "CONFLICT-2");
+      }
+    };
+
+    private final int number;
+
+    PreflightFailure(int number) {
+      this.number = number;
+    }
+
+    abstract void seed(ColorCutoverMigrationIT test) throws SQLException;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/ColorCutoverRollbackRehearsalIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/ColorCutoverRollbackRehearsalIT.java
@@ -1,0 +1,71 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.SQLException;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class ColorCutoverRollbackRehearsalIT extends BatchColorCutoverSqlTestSupport {
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("batch_color_rollback")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  ColorCutoverRollbackRehearsalIT() {
+    super(POSTGRES);
+  }
+
+  @BeforeEach
+  void setUpSchema() throws SQLException {
+    resetToPreCutover();
+    seedFoundation();
+  }
+
+  @Test
+  void restoresLegacyRowsByteForByteClearsColorAndConsumesArchive() throws SQLException {
+    UUID attribute = insertAttribute(TENANT_A, "COLOR", "ROLLBACK");
+    UUID batch = insertBatch(TENANT_A, PRODUCT_A, "ROLLBACK");
+    UUID source = insertBatchAttribute(TENANT_A, batch, attribute, NAVY_A.toString(), "ROLLBACK");
+
+    applyScript(CUTOVER_SCRIPT);
+    applyScript(ROLLBACK_SCRIPT);
+
+    assertThat(
+            count(
+                """
+                SELECT count(*)
+                FROM production.production_execution_batch_attribute
+                WHERE id = '%s'
+                  AND tenant_id = '%s'
+                  AND is_active = true
+                  AND deleted_at IS NULL
+                  AND created_at = '2026-07-01 10:00:00'
+                  AND created_by IS NULL
+                  AND updated_at = '2026-07-02 11:00:00'
+                  AND updated_by IS NULL
+                  AND version = 7
+                """
+                    .formatted(source, TENANT_A)))
+        .isEqualTo(1);
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.production_execution_batch WHERE id = '"
+                    + batch
+                    + "' AND color_id IS NULL"))
+        .isEqualTo(1);
+    assertThat(count("SELECT count(*) FROM production.production_execution_batch_color_archive"))
+        .isZero();
+    assertThat(columnExists("production_execution_batch", "color_id")).isTrue();
+    assertThat(tableExists("production_execution_batch_color_archive")).isTrue();
+  }
+}


### PR DESCRIPTION
…0010

Hard cutover of batch colour from the five-synonym EAV family to a real batch.color_id column, implementing ADR-0010 rev 3 end to end:

- one transactional migration V20260718120000: pre-existing-column guard (information_schema + dynamic SQL), nullable color_id with tenant-safe composite FK and both indexes, tenant-safe archive table (ENABLE+FORCE RLS, fabric_app revoked to SELECT-only, fabric_system SELECT/DELETE), preflight #1-#7 as fail-fast DO blocks with offending ids, canonical- only backfill honouring the UUID-no-fallback rule, archive snapshot with resolved_color_id, EAV soft-delete
- compensating rollback script (UPDATE restore of full prior state, clears every non-NULL color_id, consumes archive rows, leaves DDL) with a repeatable rehearsal IT proving byte-equivalence
- runtime writer guard: generic add/delete reject the five legacy codes with coded 409 LEGACY_COLOR_ATTRIBUTE_WRITE; single-sourced constant
- batch create accepts optional colorId; new PATCH /batches/{id}/color assigns an active same-tenant card or clears with null, 404 otherwise; BatchDto exposes colorId
- split and partial-acceptance children inherit the source colour; blend and new production lots default to NULL per D12
- reader switched to a bulk JOIN projection (no per-batch lookup); EAV colour resolution and its repository method deleted
- seeder assigns colour on batch create; archive registered in tenant purge order before the batch-attribute entry; OpenAPI regenerated

Refs: ADR-0010, docs/production/tickets/BE-3-color-cutover.md