### PR TITLE
feat(production): QC-SAFE-1 — block scalar split on piece-backed batc…

### DIFF
--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
@@ -16,6 +16,7 @@ import com.fabricmanagement.production.execution.batch.infra.repository.BatchOve
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.lineage.app.BatchLineageService;
 import com.fabricmanagement.production.execution.lineage.dto.CreateBatchLineageRequest;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -57,6 +58,7 @@ public class BatchOperationsService {
   private final BatchOverrideLogRepository overrideLogRepository;
   private final BatchCodeGenerator batchCodeGenerator;
   private final BatchLineageService batchLineageService;
+  private final StockUnitRepository stockUnitRepository;
   private final WarehouseLocationPort warehouseLocationPort;
   private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -248,6 +250,7 @@ public class BatchOperationsService {
           "Split only allowed for PENDING_QC, QUARANTINE, or QC_REJECTED. Current: "
               + sourceBatch.getStatus());
     }
+    assertScalarSplitAllowed(tenantId, sourceBatch);
 
     BatchStatus rejectedStatus =
         request.getRejectedStatus() != null ? request.getRejectedStatus() : BatchStatus.RETURNED;
@@ -351,6 +354,7 @@ public class BatchOperationsService {
           "Partial acceptance split only allowed for PENDING_QC, QUARANTINE, or QC_REJECTED. Current: "
               + sourceBatch.getStatus());
     }
+    assertScalarSplitAllowed(tenantId, sourceBatch);
 
     BatchStatus rejectedStatus =
         request.getRejectedStatus() != null ? request.getRejectedStatus() : BatchStatus.QC_REJECTED;
@@ -580,5 +584,16 @@ public class BatchOperationsService {
     return batchRepository
         .findByIdAndTenantId(id, tenantId)
         .orElseThrow(() -> new NotFoundException("Batch not found: " + id));
+  }
+
+  private void assertScalarSplitAllowed(UUID tenantId, Batch batch) {
+    if (stockUnitRepository.existsByTenantIdAndBatchIdAndIsActiveTrue(tenantId, batch.getId())) {
+      throw new BatchDomainException(
+          "Piece-backed batch "
+              + batch.getBatchCode()
+              + " cannot be split by quantity; select the physical stock units to accept",
+          "BATCH_SPLIT_PIECE_BACKED",
+          422);
+    }
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitReconciliationService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitReconciliationService.java
@@ -3,8 +3,10 @@ package com.fabricmanagement.production.execution.stockunit.app;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.production.execution.batch.app.BatchPrimaryMeasureService;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.PrimaryMeasure;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import java.math.BigDecimal;
@@ -27,7 +29,9 @@ import org.springframework.stereotype.Service;
  * </pre>
  *
  * Both sides represent "total weight that has entered the system and has not yet been written off"
- * — reserved weight is still physically present and must be counted on both sides.
+ * — reserved weight is still physically present and must be counted on both sides. Length-based and
+ * unsupported primary measures are skipped because {@code currentWeight} is always a weight-axis
+ * value.
  */
 @Slf4j
 @Service
@@ -37,6 +41,7 @@ public class StockUnitReconciliationService {
   private final TenantQueryPort tenantQueryPort;
   private final BatchRepository batchRepository;
   private final StockUnitRepository stockUnitRepository;
+  private final BatchPrimaryMeasureService primaryMeasureService;
 
   @Value("${application.stockunit.reconciliation-auto-fix:false}")
   private boolean autoFix;
@@ -73,8 +78,14 @@ public class StockUnitReconciliationService {
     }
 
     int discrepancyCount = 0;
+    int measureSkipCount = 0;
 
     for (Batch batch : activeBatches) {
+      if (!isWeightBased(batch)) {
+        measureSkipCount++;
+        continue;
+      }
+
       BigDecimal physicalSum =
           stockUnitRepository.sumCurrentWeightByBatchId(
               tenantId,
@@ -126,11 +137,38 @@ public class StockUnitReconciliationService {
 
     if (discrepancyCount > 0) {
       log.warn(
-          "Reconciliation completed for tenant {} with {} discrepancies found.",
+          "Reconciliation completed for tenant {} with {} discrepancies and {} measure skips.",
           tenantId,
-          discrepancyCount);
+          discrepancyCount,
+          measureSkipCount);
+    } else if (measureSkipCount > 0) {
+      log.info(
+          "Reconciliation completed for tenant {} with no discrepancies and {} measure skips.",
+          tenantId,
+          measureSkipCount);
     } else {
       log.debug("Reconciliation matched perfectly for tenant {}", tenantId);
+    }
+  }
+
+  private boolean isWeightBased(Batch batch) {
+    try {
+      PrimaryMeasure primaryMeasure = primaryMeasureService.primaryMeasure(batch.getProductType());
+      if (primaryMeasure == PrimaryMeasure.WEIGHT) {
+        return true;
+      }
+      log.info(
+          "Reconciliation skipped (dimension mismatch): batch={}, unit={} vs stock-unit weight KG",
+          batch.getBatchCode(),
+          batch.getUnit());
+      return false;
+    } catch (IllegalArgumentException exception) {
+      log.info(
+          "Reconciliation skipped (unsupported primary measure): batch={}, productType={}, reason={}",
+          batch.getBatchCode(),
+          batch.getProductType(),
+          exception.getMessage());
+      return false;
     }
   }
 }

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
@@ -1,12 +1,17 @@
 package com.fabricmanagement.production.execution.batch.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.exception.BatchDomainException;
 import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
 import com.fabricmanagement.production.execution.batch.dto.PartialAcceptanceSplitRequest;
@@ -14,6 +19,7 @@ import com.fabricmanagement.production.execution.batch.dto.SplitBatchRequest;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchOverrideLogRepository;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.lineage.app.BatchLineageService;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import java.math.BigDecimal;
 import java.util.Optional;
@@ -39,6 +45,7 @@ class BatchOperationsServiceTest {
   @Mock private BatchOverrideLogRepository overrideLogRepository;
   @Mock private BatchCodeGenerator batchCodeGenerator;
   @Mock private BatchLineageService batchLineageService;
+  @Mock private StockUnitRepository stockUnitRepository;
   @Mock private WarehouseLocationPort warehouseLocationPort;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
 
@@ -55,6 +62,7 @@ class BatchOperationsServiceTest {
             overrideLogRepository,
             batchCodeGenerator,
             batchLineageService,
+            stockUnitRepository,
             warehouseLocationPort,
             applicationEventPublisher);
   }
@@ -102,6 +110,70 @@ class BatchOperationsServiceTest {
             .build());
 
     assertThat(savedChild().getColorId()).isEqualTo(COLOR_ID);
+  }
+
+  @Test
+  void splitBatch_rejectsPieceBackedBatchWithoutMutatingSourceOrCreatingChild() {
+    Batch source = sourceBatch();
+    BigDecimal originalQuantity = source.getQuantity();
+    BatchStatus originalStatus = source.getStatus();
+    when(batchRepository.findByIdAndTenantId(SOURCE_ID, TENANT_ID)).thenReturn(Optional.of(source));
+    when(stockUnitRepository.existsByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, SOURCE_ID))
+        .thenReturn(true);
+
+    assertThatThrownBy(
+            () ->
+                service.splitBatch(
+                    SOURCE_ID,
+                    SplitBatchRequest.builder()
+                        .acceptedQuantity(new BigDecimal("4"))
+                        .reason("Accepted portion")
+                        .rejectedStatus(BatchStatus.RETURNED)
+                        .build()))
+        .isInstanceOfSatisfying(
+            BatchDomainException.class,
+            exception -> {
+              assertThat(exception.getErrorCode()).isEqualTo("BATCH_SPLIT_PIECE_BACKED");
+              assertThat(exception.getHttpStatus()).isEqualTo(422);
+            });
+
+    assertThat(source.getQuantity()).isEqualByComparingTo(originalQuantity);
+    assertThat(source.getStatus()).isEqualTo(originalStatus);
+    verify(batchRepository, never()).save(any(Batch.class));
+    verify(batchCodeGenerator, never()).generateSplitCode(any(UUID.class), any(String.class));
+    verifyNoInteractions(applicationEventPublisher);
+  }
+
+  @Test
+  void splitPartialAcceptance_rejectsPieceBackedBatchWithoutMutatingSourceOrCreatingChild() {
+    Batch source = sourceBatch();
+    BigDecimal originalQuantity = source.getQuantity();
+    BatchStatus originalStatus = source.getStatus();
+    when(batchRepository.findByIdAndTenantId(SOURCE_ID, TENANT_ID)).thenReturn(Optional.of(source));
+    when(stockUnitRepository.existsByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, SOURCE_ID))
+        .thenReturn(true);
+
+    assertThatThrownBy(
+            () ->
+                service.splitPartialAcceptance(
+                    SOURCE_ID,
+                    PartialAcceptanceSplitRequest.builder()
+                        .acceptedQuantity(new BigDecimal("4"))
+                        .reason("Accepted portion")
+                        .rejectedStatus(BatchStatus.QC_REJECTED)
+                        .build()))
+        .isInstanceOfSatisfying(
+            BatchDomainException.class,
+            exception -> {
+              assertThat(exception.getErrorCode()).isEqualTo("BATCH_SPLIT_PIECE_BACKED");
+              assertThat(exception.getHttpStatus()).isEqualTo(422);
+            });
+
+    assertThat(source.getQuantity()).isEqualByComparingTo(originalQuantity);
+    assertThat(source.getStatus()).isEqualTo(originalStatus);
+    verify(batchRepository, never()).save(any(Batch.class));
+    verify(batchCodeGenerator, never()).generateSplitCode(any(UUID.class), any(String.class));
+    verifyNoInteractions(applicationEventPublisher);
   }
 
   private Batch savedChild() {

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitReconciliationServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitReconciliationServiceTest.java
@@ -1,0 +1,142 @@
+package com.fabricmanagement.production.execution.stockunit.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort;
+import com.fabricmanagement.common.infrastructure.tenant.TenantReference;
+import com.fabricmanagement.production.execution.batch.app.BatchPrimaryMeasureService;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.PrimaryMeasure;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith({MockitoExtension.class, OutputCaptureExtension.class})
+class StockUnitReconciliationServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+
+  @Mock private TenantQueryPort tenantQueryPort;
+  @Mock private BatchRepository batchRepository;
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private BatchPrimaryMeasureService primaryMeasureService;
+
+  private StockUnitReconciliationService service;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new StockUnitReconciliationService(
+            tenantQueryPort, batchRepository, stockUnitRepository, primaryMeasureService);
+    when(tenantQueryPort.findAllActiveTenants())
+        .thenReturn(List.of(new TenantReference(TENANT_ID, "TEST", "Test Tenant", "TENANT")));
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void skipsNonWeightAndUnsupportedBatchesWithoutInterruptingWeightReconciliation(
+      CapturedOutput output) {
+    Batch fabric = batch("FABRIC-1", ProductType.FABRIC, "M", "10", "0");
+    Batch yarn = batch("YARN-1", ProductType.YARN, "KG", "8", "0");
+    Batch chemical = batch("CHEM-1", ProductType.CHEMICAL, "L", "4", "0");
+    Batch fiber = batch("FIBER-1", ProductType.FIBER, "KG", "6", "1");
+    Batch consumable = batch("CONS-1", ProductType.CONSUMABLE, "PCS", "3", "0");
+    when(batchRepository.findByTenantIdAndStatusIn(eq(TENANT_ID), anyCollection()))
+        .thenReturn(List.of(fabric, yarn, chemical, fiber, consumable));
+    when(primaryMeasureService.primaryMeasure(ProductType.FABRIC))
+        .thenReturn(PrimaryMeasure.LENGTH);
+    when(primaryMeasureService.primaryMeasure(ProductType.YARN)).thenReturn(PrimaryMeasure.WEIGHT);
+    when(primaryMeasureService.primaryMeasure(ProductType.CHEMICAL))
+        .thenThrow(new IllegalArgumentException("Unsupported product type: CHEMICAL"));
+    when(primaryMeasureService.primaryMeasure(ProductType.FIBER)).thenReturn(PrimaryMeasure.WEIGHT);
+    when(primaryMeasureService.primaryMeasure(ProductType.CONSUMABLE))
+        .thenThrow(new IllegalArgumentException("Unsupported product type: CONSUMABLE"));
+    when(stockUnitRepository.sumCurrentWeightByBatchId(
+            TENANT_ID, yarn.getId(), StockUnitStatus.DISPOSED))
+        .thenReturn(new BigDecimal("8"));
+    when(stockUnitRepository.sumCurrentWeightByBatchId(
+            TENANT_ID, fiber.getId(), StockUnitStatus.DISPOSED))
+        .thenReturn(new BigDecimal("5"));
+    ReflectionTestUtils.setField(service, "autoFix", true);
+
+    service.reconcileAllTenants();
+
+    verify(stockUnitRepository)
+        .sumCurrentWeightByBatchId(TENANT_ID, yarn.getId(), StockUnitStatus.DISPOSED);
+    verify(stockUnitRepository)
+        .sumCurrentWeightByBatchId(TENANT_ID, fiber.getId(), StockUnitStatus.DISPOSED);
+    verify(stockUnitRepository, never())
+        .sumCurrentWeightByBatchId(TENANT_ID, fabric.getId(), StockUnitStatus.DISPOSED);
+    verify(stockUnitRepository, never())
+        .sumCurrentWeightByBatchId(TENANT_ID, chemical.getId(), StockUnitStatus.DISPOSED);
+    verify(stockUnitRepository, never())
+        .sumCurrentWeightByBatchId(TENANT_ID, consumable.getId(), StockUnitStatus.DISPOSED);
+    verify(batchRepository, never()).save(any(Batch.class));
+    assertThat(output.getAll())
+        .contains("Reconciliation skipped (dimension mismatch): batch=FABRIC-1")
+        .contains("Reconciliation skipped (unsupported primary measure): batch=CHEM-1")
+        .contains("Reconciliation skipped (unsupported primary measure): batch=CONS-1")
+        .contains("no discrepancies and 3 measure skips");
+  }
+
+  @Test
+  void weightBatchStillReconcilesAndAutoFixes() {
+    Batch yarn = batch("YARN-2", ProductType.YARN, "KG", "10", "2");
+    when(batchRepository.findByTenantIdAndStatusIn(eq(TENANT_ID), anyCollection()))
+        .thenReturn(List.of(yarn));
+    when(primaryMeasureService.primaryMeasure(ProductType.YARN)).thenReturn(PrimaryMeasure.WEIGHT);
+    when(stockUnitRepository.sumCurrentWeightByBatchId(
+            TENANT_ID, yarn.getId(), StockUnitStatus.DISPOSED))
+        .thenReturn(new BigDecimal("7"));
+    ReflectionTestUtils.setField(service, "autoFix", true);
+
+    service.reconcileAllTenants();
+
+    assertThat(yarn.getConsumedQuantity()).isEqualByComparingTo("3");
+    verify(batchRepository).save(yarn);
+  }
+
+  private static Batch batch(
+      String code, ProductType productType, String unit, String quantity, String consumedQuantity) {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(productType)
+            .batchCode(code)
+            .quantity(new BigDecimal(quantity))
+            .reservedQuantity(BigDecimal.ZERO)
+            .consumedQuantity(new BigDecimal(consumedQuantity))
+            .wasteQuantity(BigDecimal.ZERO)
+            .unit(unit)
+            .status(BatchStatus.AVAILABLE)
+            .build();
+    batch.setId(UUID.randomUUID());
+    batch.setTenantId(TENANT_ID);
+    return batch;
+  }
+}


### PR DESCRIPTION
…hes + reconciliation dimension guard

Faz 0 safety patch for ADR-0011 (quality decision architecture). Closes two active risks ahead of the QualityDecision model work.

Split guard: splitBatch() and splitPartialAcceptance() now reject a batch that has active StockUnits with 422 BATCH_SPLIT_PIECE_BACKED, before any mutation. Previously a scalar split sent the source batch to RETURNED/DESTROYED/QC_REJECTED while its physical rolls stayed AVAILABLE and the child batch was born with zero units — rejected stock remained reservable. Piece-backed partial acceptance now requires selecting the physical units (SELECTED_UNITS decision arrives in QC-RELEASE-1).

Reconciliation dimension guard: StockUnitReconciliationService compares only WEIGHT-measure batches (via BatchPrimaryMeasureService); LENGTH (FABRIC) and unsupported (CHEMICAL/CONSUMABLE) product types are skipped and logged per batch, so FABRIC metres are never compared to — or auto-fixed against — stock-unit kilograms. The unsupported-type throw is caught per batch, so it can never interrupt reconciliation of the remaining weight batches. Skip count is surfaced in the summary log.

Tests: piece-backed rejection leaves source quantity/status untouched and creates no child batch or event; reconciliation skips FABRIC/CHEMICAL/ CONSUMABLE while interleaved YARN/FIBER still reconcile, plus a WEIGHT auto-fix regression guard.

Ref: docs/production/tickets/QC-SAFE-1.md, docs/architecture/ADR-0011.