### PR TITLE
feat(production): QC-RELEASE-1a — quality decision write model + rele…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -22472,6 +22472,12 @@ paths:
   /api/v1/iwm/locations:
     get:
       operationId: getAll_2
+      parameters:
+      - in: query
+        name: qualityArea
+        required: false
+        schema:
+          type: boolean
       responses:
         "200":
           content:
@@ -36162,6 +36168,85 @@ paths:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
       summary: Put StockUnit on hold
+      tags:
+      - StockUnit
+  /api/v1/production/stock-units/{id}/qc-relocate:
+    post:
+      description: Changes only the physical location. Operational status and quality
+        disposition remain unchanged.
+      operationId: relocateForQuality
+      parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StockUnitQcRelocateRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseStockUnitDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Relocate unreleased stock into an approved QC custody area
       tags:
       - StockUnit
   /api/v1/production/stock-units/{id}/quarantine:
@@ -53273,6 +53358,8 @@ components:
         parentId:
           type: string
           format: uuid
+        qualityArea:
+          type: boolean
         sortOrder:
           type: integer
           format: int32
@@ -60695,6 +60782,21 @@ components:
         updatedAt:
           type: string
           format: date-time
+    StockUnitQcRelocateRequest:
+      type: object
+      description: Privileged custody relocation of unreleased stock into a QC storage
+        area
+      properties:
+        reason:
+          type: string
+          maxLength: 500
+          minLength: 0
+        targetLocationId:
+          type: string
+          format: uuid
+      required:
+      - reason
+      - targetLocationId
     SubcontractOrderResponse:
       type: object
       properties:
@@ -62858,6 +62960,8 @@ components:
           type: string
           maxLength: 255
           minLength: 0
+        qualityArea:
+          type: boolean
         sortOrder:
           type: integer
           format: int32
@@ -63380,11 +63484,15 @@ components:
           type: number
         name:
           type: string
+        operational:
+          type: boolean
         parentId:
           type: string
           format: uuid
         path:
           type: string
+        qualityArea:
+          type: boolean
         sortOrder:
           type: integer
           format: int32
@@ -63404,6 +63512,8 @@ components:
           - HUMIDITY_CONTROLLED
           - HAZARDOUS
           - CLEAN_ROOM
+        storageLocation:
+          type: boolean
         type:
           type: string
           enum:
@@ -63465,11 +63575,15 @@ components:
           type: number
         name:
           type: string
+        operational:
+          type: boolean
         parentId:
           type: string
           format: uuid
         path:
           type: string
+        qualityArea:
+          type: boolean
         sortOrder:
           type: integer
           format: int32
@@ -63489,6 +63603,8 @@ components:
           - HUMIDITY_CONTROLLED
           - HAZARDOUS
           - CLEAN_ROOM
+        storageLocation:
+          type: boolean
         type:
           type: string
           enum:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -88,6 +88,8 @@ tags:
   name: WhatsApp Webhooks
 - description: User performance leaderboard
   name: FlowBoard — Performance
+- description: Immutable stock quality disposition decisions
+  name: Quality Decisions
 - description: Tenant go-real transition operations
   name: Tenant Go Real
 - description: Subcontract Order operations
@@ -28500,8 +28502,8 @@ paths:
       - Batch
   /api/v1/production/batches/{id}/override-status:
     patch:
-      description: "Overrides batch status (e.g., QC_REJECTED to AVAILABLE). Requires\
-        \ reason. Admin/Manager only."
+      description: Records a superseding RELEASED quality decision. Requires quality
+        approval permission and a reason.
       operationId: overrideStatus
       parameters:
       - in: path
@@ -34360,6 +34362,276 @@ paths:
       summary: Update a quality grade (code and productType are immutable)
       tags:
       - QualityGrade
+  /api/v1/production/quality/batches/{batchId}/decisions:
+    get:
+      operationId: listQualityDecisionHistory
+      parameters:
+      - in: path
+        name: batchId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 0
+          minimum: 0
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+      - description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        in: query
+        name: sort
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseQualityDecisionDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List batch decision history
+      tags:
+      - Quality Decisions
+    post:
+      operationId: recordQualityDecision
+      parameters:
+      - in: path
+        name: batchId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RecordQualityDecisionRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseQualityDecisionDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Record a quality decision
+      tags:
+      - Quality Decisions
+  /api/v1/production/quality/batches/{batchId}/units:
+    get:
+      operationId: listQualityDecisionUnits
+      parameters:
+      - in: path
+        name: batchId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 0
+          minimum: 0
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+      - description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        in: query
+        name: sort
+        required: false
+        schema:
+          type: array
+          default:
+          - "barcode,ASC"
+          items:
+            type: string
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseQualityDecisionUnitDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List batch units for QC
+      tags:
+      - Quality Decisions
   /api/v1/production/quality/fiber-tests:
     get:
       operationId: getAllTestResults
@@ -34851,6 +35123,96 @@ paths:
           description: Internal Server Error
       tags:
       - Fiber Test Result
+  /api/v1/production/quality/queue:
+    get:
+      operationId: listPendingQualityQueue
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 0
+          minimum: 0
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+      - description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        in: query
+        name: sort
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseQualityQueueItemDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List batches awaiting QC
+      tags:
+      - Quality Decisions
   /api/v1/production/recipes:
     post:
       operationId: createRecipe
@@ -47656,6 +48018,60 @@ components:
           type: array
           items:
             type: string
+    ApiResponsePagedResponseQualityDecisionDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseQualityDecisionDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponsePagedResponseQualityDecisionUnitDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseQualityDecisionUnitDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponsePagedResponseQualityQueueItemDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseQualityQueueItemDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponsePagedResponseQuoteResponse:
       type: object
       properties:
@@ -48201,6 +48617,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/PurchaseOrderResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseQualityDecisionDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/QualityDecisionDto"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -56040,6 +56474,75 @@ components:
         totalPages:
           type: integer
           format: int32
+    PagedResponseQualityDecisionDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityDecisionDto"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    PagedResponseQualityDecisionUnitDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityDecisionUnitDto"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    PagedResponseQualityQueueItemDto:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityQueueItemDto"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
     PagedResponseQuoteResponse:
       type: object
       properties:
@@ -57893,6 +58396,113 @@ components:
           type: string
       required:
       - specType
+    QualityDecisionDto:
+      type: object
+      properties:
+        actorId:
+          type: string
+          format: uuid
+        batchId:
+          type: string
+          format: uuid
+        decidedAt:
+          type: string
+          format: date-time
+        id:
+          type: string
+          format: uuid
+        origin:
+          type: string
+          enum:
+          - MANUAL
+          - SYSTEM_RELEASE
+          - SYSTEM_QC_EVENT
+          - MIGRATION_BACKFILL
+        outcome:
+          type: string
+          enum:
+          - RELEASED
+          - QUARANTINED
+          - NONCONFORMING
+        reasonCode:
+          type: string
+          enum:
+          - SUSPECTED_DAMAGE
+          - AWAITING_LAB
+          - SUPPLIER_DISPUTE
+          - SHADE_CHECK
+          - DAMAGE
+          - STAIN
+          - SHADE_VARIATION
+          - SHORT_LENGTH
+          - MEASURE_MISMATCH
+          - OTHER
+          - SYSTEM_QC_PASSED
+          - SYSTEM_QC_REJECTED
+          - MIGRATION_BASELINE
+        remarks:
+          type: string
+        scope:
+          type: string
+          enum:
+          - FULL_LOT
+          - SELECTED_UNITS
+        sequence:
+          type: integer
+          format: int64
+        sourceEventId:
+          type: string
+          format: uuid
+        supersedesDecisionId:
+          type: string
+          format: uuid
+    QualityDecisionUnitDto:
+      type: object
+      properties:
+        barcode:
+          type: string
+        currentWeight:
+          type: number
+        id:
+          type: string
+          format: uuid
+        length:
+          type: number
+        lengthUnit:
+          type: string
+        packageType:
+          type: string
+          enum:
+          - BALE
+          - ROLL
+          - BOBBIN
+          - SACK
+          - CARTON
+          - DRUM
+          - BAG
+          - PALLET
+          - CONE
+          - HANK
+        qualityDisposition:
+          type: string
+          enum:
+          - PENDING_INSPECTION
+          - RELEASED
+          - QUARANTINED
+          - NONCONFORMING
+        status:
+          type: string
+          enum:
+          - AVAILABLE
+          - PARTIAL
+          - RESERVED
+          - IN_TRANSIT
+          - ON_HOLD
+          - QUARANTINE
+          - DEPLETED
+          - DISPOSED
+        unit:
+          type: string
     QualityGradeDto:
       type: object
       properties:
@@ -57926,6 +58536,33 @@ components:
           type: boolean
         saleable:
           type: boolean
+    QualityQueueItemDto:
+      type: object
+      properties:
+        batchCode:
+          type: string
+        batchId:
+          type: string
+          format: uuid
+        pendingUnitCount:
+          type: integer
+          format: int64
+        productId:
+          type: string
+          format: uuid
+        productType:
+          type: string
+          enum:
+          - FIBER
+          - YARN
+          - FABRIC
+          - CHEMICAL
+          - CONSUMABLE
+        receivedAt:
+          type: string
+          format: date-time
+        supplierBatchCode:
+          type: string
     QuickCreateCustomerContactRequest:
       type: object
       properties:
@@ -58680,6 +59317,52 @@ components:
           format: uuid
       required:
       - stockUnitId
+    RecordQualityDecisionRequest:
+      type: object
+      properties:
+        outcome:
+          type: string
+          enum:
+          - RELEASED
+          - QUARANTINED
+          - NONCONFORMING
+        reasonCode:
+          type: string
+          enum:
+          - SUSPECTED_DAMAGE
+          - AWAITING_LAB
+          - SUPPLIER_DISPUTE
+          - SHADE_CHECK
+          - DAMAGE
+          - STAIN
+          - SHADE_VARIATION
+          - SHORT_LENGTH
+          - MEASURE_MISMATCH
+          - OTHER
+          - SYSTEM_QC_PASSED
+          - SYSTEM_QC_REJECTED
+          - MIGRATION_BASELINE
+        remarks:
+          type: string
+          maxLength: 2000
+          minLength: 0
+        scope:
+          type: string
+          enum:
+          - FULL_LOT
+          - SELECTED_UNITS
+        stockUnitIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          uniqueItems: true
+        supersedesDecisionId:
+          type: string
+          format: uuid
+      required:
+      - outcome
+      - scope
     RecordWasteRequest:
       type: object
       properties:
@@ -59971,6 +60654,13 @@ components:
           - FABRIC
           - CHEMICAL
           - CONSUMABLE
+        qualityDisposition:
+          type: string
+          enum:
+          - PENDING_INSPECTION
+          - RELEASED
+          - QUARANTINED
+          - NONCONFORMING
         qualityGradeId:
           type: string
           format: uuid

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeeder.java
@@ -157,7 +157,15 @@ public class PermissionTemplateSeeder {
             // even though PermissionEvaluator short-circuits ADMIN before consulting rows.
             new String[] {"ADMIN", "sales", "approve", "GLOBAL"},
             new String[] {"MANAGER", "sales", "approve", "ORGANIZATION"},
-            new String[] {"SUPERVISOR", "sales", "approve", "ORGANIZATION"}));
+            new String[] {"SUPERVISOR", "sales", "approve", "ORGANIZATION"},
+            new String[] {"ADMIN", "quality", "read", "GLOBAL"},
+            new String[] {"ADMIN", "quality", "write", "GLOBAL"},
+            new String[] {"ADMIN", "quality", "approve", "GLOBAL"},
+            new String[] {"ADMIN", "quality", "manage", "GLOBAL"},
+            new String[] {"PLATFORM_ADMIN", "quality", "read", "GLOBAL"},
+            new String[] {"PLATFORM_ADMIN", "quality", "write", "GLOBAL"},
+            new String[] {"PLATFORM_ADMIN", "quality", "approve", "GLOBAL"},
+            new String[] {"PLATFORM_ADMIN", "quality", "manage", "GLOBAL"}));
 
     // 2. SALES
     seedDepartment(
@@ -248,12 +256,21 @@ public class PermissionTemplateSeeder {
         List.of(
             new String[] {"WORKER", "fiber", "read", "OWN"},
             new String[] {"WORKER", "products", "read", "OWN"},
+            new String[] {"WORKER", "quality", "read", "ORGANIZATION"},
+            new String[] {"WORKER", "quality", "write", "ORGANIZATION"},
             new String[] {"SUPERVISOR", "fiber", "read", "DEPARTMENT"},
             new String[] {"SUPERVISOR", "products", "read", "DEPARTMENT"},
             new String[] {"SUPERVISOR", "products", "write", "DEPARTMENT"},
+            new String[] {"SUPERVISOR", "quality", "read", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "quality", "write", "ORGANIZATION"},
+            new String[] {"SUPERVISOR", "quality", "approve", "ORGANIZATION"},
             new String[] {"MANAGER", "fiber", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "products", "read", "ORGANIZATION"},
             new String[] {"MANAGER", "products", "write", "DEPARTMENT"},
+            new String[] {"MANAGER", "quality", "read", "ORGANIZATION"},
+            new String[] {"MANAGER", "quality", "write", "ORGANIZATION"},
+            new String[] {"MANAGER", "quality", "approve", "ORGANIZATION"},
+            new String[] {"MANAGER", "quality", "manage", "ORGANIZATION"},
             new String[] {"WORKER", "colors", "read", "ORGANIZATION"},
             new String[] {"SUPERVISOR", "colors", "read", "ORGANIZATION"},
             new String[] {"SUPERVISOR", "colors", "write", "ORGANIZATION"},

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
@@ -179,7 +179,7 @@ public class SalesQuoteDemoSeeder {
       // detail lives on the rolls (StockUnit.lengthUnit = "M"), which is also what the lot picker
       // surfaces for piece-backed length lots.
       BatchDto lot24011 =
-          saleableBatch(
+          pendingBatch(
               gabardine,
               "LOT-24011",
               "2000",
@@ -187,9 +187,10 @@ public class SalesQuoteDemoSeeder {
               navy.getId(),
               "Main Navy dye lot, spring run");
       addRolls(lot24011.getId(), "24011", 16, "125", "36.800", fabricGrades.first().getId());
+      releasePieceBackedBatch(lot24011.getId());
 
       BatchDto lot24012 =
-          saleableBatch(
+          pendingBatch(
               gabardine,
               "LOT-24012",
               "3000",
@@ -197,9 +198,10 @@ public class SalesQuoteDemoSeeder {
               navy.getId(),
               "Second Navy dye lot — shade may vary");
       addRolls(lot24012.getId(), "24012", 24, "125", "36.800", fabricGrades.first().getId());
+      releasePieceBackedBatch(lot24012.getId());
 
       BatchDto lot23087 =
-          saleableBatch(
+          pendingBatch(
               gabardine,
               "LOT-23087",
               "290",
@@ -209,18 +211,21 @@ public class SalesQuoteDemoSeeder {
       addRoll(lot23087.getId(), "23087", 1, "100", "29.500", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 2, "95", "28.000", fabricGrades.first().getId());
       addRoll(lot23087.getId(), "23087", 3, "95", "28.000", fabricGrades.first().getId());
+      releasePieceBackedBatch(lot23087.getId());
 
       BatchDto lot24020 =
-          saleableBatch(
+          pendingBatch(
               gabardine,
               "LOT-24020",
               "450",
               BATCH_UNIT_METRES,
               ecru.getId(),
-              "Second Quality Ecru — bulk, no pieces");
+              "Second Quality Ecru — piece-backed demo lot");
+      addRolls(lot24020.getId(), "24020", 18, "25", "25.000", fabricGrades.second().getId());
+      releasePieceBackedBatch(lot24020.getId());
 
       BatchDto lot24031 =
-          saleableBatch(
+          pendingBatch(
               combedYarn,
               "LOT-24031",
               "1200",
@@ -228,13 +233,14 @@ public class SalesQuoteDemoSeeder {
               pfd.getId(),
               "Combed yarn, prepared for dyeing");
       addCartons(lot24031.getId(), "24031", 48, "25.000", yarnGrades.first().getId());
+      releasePieceBackedBatch(lot24031.getId());
 
       // Raw cotton skips the colour axis entirely — fibre cascade has no Colour step.
-      saleableBatch(rawCotton, "LOT-24040", "5000", "KG", null, "Raw cotton, bulk store");
+      pendingBatch(rawCotton, "LOT-24040", "5000", "KG", null, "Raw cotton, bulk store");
 
       // Waste-grade stock exists but must stay invisible to the picker (negative test).
       BatchDto lot23050 =
-          saleableBatch(
+          pendingBatch(
               gabardine,
               "LOT-23050",
               "120",
@@ -243,6 +249,7 @@ public class SalesQuoteDemoSeeder {
               "Waste grade — not saleable");
       addRoll(lot23050.getId(), "23050", 1, "60", "17.700", fabricGrades.waste().getId());
       addRoll(lot23050.getId(), "23050", 2, "60", "17.700", fabricGrades.waste().getId());
+      releasePieceBackedBatch(lot23050.getId());
 
       // ── Actors ──
       TradingPartnerDto albion = createAlbionCustomer(tenantId);
@@ -391,7 +398,7 @@ public class SalesQuoteDemoSeeder {
 
   // ── Lot helpers ─────────────────────────────────────────────────────────────
 
-  private BatchDto saleableBatch(
+  private BatchDto pendingBatch(
       ProductDto product,
       String batchCode,
       String quantity,
@@ -410,9 +417,12 @@ public class SalesQuoteDemoSeeder {
                 .sourceType(BatchSourceType.INITIAL_STOCK)
                 .remarks(remarks)
                 .build());
-    // New batches start in PENDING_QC; the picker only lists AVAILABLE/RESERVED lots.
-    batchService.releaseFromQc(batch.getId());
     return batch;
+  }
+
+  private void releasePieceBackedBatch(UUID batchId) {
+    // Demo stock follows the same immutable QC release path as operational stock.
+    batchService.releaseFromQc(batchId);
   }
 
   private void addRolls(

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/WarehouseSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/WarehouseSeeder.java
@@ -26,7 +26,8 @@ public class WarehouseSeeder implements DataSeeder {
   private final TransactionTemplate transactionTemplate;
 
   /** All expected warehouse codes — used for granular isSeeded() verification. */
-  private static final List<String> EXPECTED_CODES = List.of("RAW_MAT", "SHOP_FL", "FIN_MAT");
+  private static final List<String> EXPECTED_CODES =
+      List.of("RAW_MAT", "SHOP_FL", "FIN_MAT", "QC_HOLD");
 
   @Override
   public boolean isSeeded() {
@@ -39,7 +40,7 @@ public class WarehouseSeeder implements DataSeeder {
         tenantOpt.get().getId(),
         () -> {
           UUID tenantId = tenantOpt.get().getId();
-          // Granular check: verify ALL 3 expected warehouse codes exist
+          // Granular check: verify all expected warehouse codes exist.
           return EXPECTED_CODES.stream()
               .allMatch(
                   code -> warehouseLocationRepository.existsByTenantIdAndCode(tenantId, code));
@@ -63,18 +64,27 @@ public class WarehouseSeeder implements DataSeeder {
                     "RAW_MAT",
                     "Ana Hammadde Deposu",
                     "Tüm hammaddeler buraya iner",
-                    tenant.getId());
+                    tenant.getId(),
+                    false);
                 seedWarehouse(
                     "SHOP_FL",
                     "Üretim Sahası",
                     "İş emirlerinin tüketim yaptığı alan",
-                    tenant.getId());
-                seedWarehouse("FIN_MAT", "Mamül Deposu", "Biten mallar", tenant.getId());
+                    tenant.getId(),
+                    false);
+                seedWarehouse("FIN_MAT", "Mamül Deposu", "Biten mallar", tenant.getId(), false);
+                seedWarehouse(
+                    "QC_HOLD",
+                    "Kalite Kontrol ve Karantina Alanı",
+                    "Muayene bekleyen veya karantinadaki fiziksel stok",
+                    tenant.getId(),
+                    true);
               });
         });
   }
 
-  private void seedWarehouse(String code, String name, String desc, UUID tenantId) {
+  private void seedWarehouse(
+      String code, String name, String desc, UUID tenantId, boolean qualityArea) {
     if (warehouseLocationRepository.existsByTenantIdAndCode(tenantId, code)) {
       log.debug("Warehouse already exists (code={}), skipping: {}", code, name);
       return;
@@ -86,6 +96,7 @@ public class WarehouseSeeder implements DataSeeder {
             .name(name)
             .description(desc)
             .type(WarehouseLocationType.WAREHOUSE)
+            .qualityArea(qualityArea)
             .build();
     warehouseLocationService.create(req);
     log.info("Created Warehouse: {}", name);

--- a/src/main/java/com/fabricmanagement/iwm/location/api/controller/WarehouseLocationController.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/api/controller/WarehouseLocationController.java
@@ -68,8 +68,9 @@ public class WarehouseLocationController {
 
   @GetMapping
   @PreAuthorize("@auth.can(authentication, 'products', 'read')")
-  public ResponseEntity<ApiResponse<List<WarehouseLocationDto>>> getAll() {
-    List<WarehouseLocationDto> locations = service.getAll();
+  public ResponseEntity<ApiResponse<List<WarehouseLocationDto>>> getAll(
+      @RequestParam(required = false) Boolean qualityArea) {
+    List<WarehouseLocationDto> locations = service.getAll(qualityArea);
     return ResponseEntity.ok(ApiResponse.success(locations));
   }
 

--- a/src/main/java/com/fabricmanagement/iwm/location/app/WarehouseLocationService.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/app/WarehouseLocationService.java
@@ -82,7 +82,8 @@ public class WarehouseLocationService {
             request.getMaxWeightKg(),
             request.getMaxVolumeM3(),
             request.getSortOrder(),
-            request.getLinkedMachineId());
+            request.getLinkedMachineId(),
+            request.isQualityArea());
     location.setTenantId(tenantId);
 
     String path = buildPath(parent, request.getCode());
@@ -122,7 +123,8 @@ public class WarehouseLocationService {
         request.getMaxWeightKg(),
         request.getMaxVolumeM3(),
         request.getSortOrder(),
-        request.getLinkedMachineId());
+        request.getLinkedMachineId(),
+        request.getQualityArea() != null ? request.getQualityArea() : location.isQualityArea());
 
     location = repository.save(location);
     log.info("Updated warehouse location: id={}, code={}", location.getId(), location.getCode());
@@ -192,6 +194,19 @@ public class WarehouseLocationService {
 
   @Transactional(readOnly = true)
   public List<WarehouseLocationDto> getAll() {
+    return getAll(null);
+  }
+
+  @Transactional(readOnly = true)
+  public List<WarehouseLocationDto> getAll(Boolean qualityArea) {
+    if (qualityArea != null) {
+      return repository
+          .findByQualityAreaAndIsActiveTrueOrderBySortOrderAscNameAsc(qualityArea)
+          .stream()
+          .filter(location -> !qualityArea || location.isOperational())
+          .map(WarehouseLocationDto::from)
+          .toList();
+    }
     return repository.findByIsActiveTrueOrderBySortOrderAscNameAsc().stream()
         .map(WarehouseLocationDto::from)
         .toList();

--- a/src/main/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapter.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapter.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.iwm.location.app.WarehouseLocationService;
 import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
 import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
 import com.fabricmanagement.production.execution.batch.domain.port.LocationValidationResult;
+import com.fabricmanagement.production.execution.batch.domain.port.QcLocationValidationResult;
 import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
@@ -32,5 +33,16 @@ public class ProductionLocationAdapter implements WarehouseLocationPort {
             || location.getType() == WarehouseLocationType.PRODUCTION_LINE;
 
     return new LocationValidationResult(locationId, location.getCode(), isProductionLocation);
+  }
+
+  @Override
+  public QcLocationValidationResult validateQcLocation(UUID locationId) {
+    WarehouseLocationDto location = warehouseLocationService.getById(locationId);
+    boolean validQcLocation =
+        location.isActive()
+            && location.isOperational()
+            && location.isStorageLocation()
+            && location.isQualityArea();
+    return new QcLocationValidationResult(locationId, location.getCode(), validQcLocation);
   }
 }

--- a/src/main/java/com/fabricmanagement/iwm/location/domain/WarehouseLocation.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/domain/WarehouseLocation.java
@@ -77,6 +77,10 @@ public class WarehouseLocation extends BaseEntity {
   @Column(name = "linked_machine_id")
   private UUID linkedMachineId;
 
+  /** Functional designation; independent from the location's physical hierarchy type. */
+  @Column(name = "is_quality_area", nullable = false)
+  private boolean qualityArea;
+
   public WarehouseLocation(
       UUID parentId,
       String code,
@@ -89,7 +93,8 @@ public class WarehouseLocation extends BaseEntity {
       BigDecimal maxWeightKg,
       BigDecimal maxVolumeM3,
       Integer sortOrder,
-      UUID linkedMachineId) {
+      UUID linkedMachineId,
+      boolean qualityArea) {
     this.parentId = parentId;
     this.code = code;
     this.name = name;
@@ -105,6 +110,7 @@ public class WarehouseLocation extends BaseEntity {
     this.currentVolumeM3 = BigDecimal.ZERO;
     this.sortOrder = sortOrder != null ? sortOrder : 0;
     this.linkedMachineId = linkedMachineId;
+    assignQualityArea(qualityArea);
     this.setIsActive(true);
   }
 
@@ -117,7 +123,8 @@ public class WarehouseLocation extends BaseEntity {
       BigDecimal maxWeightKg,
       BigDecimal maxVolumeM3,
       Integer sortOrder,
-      UUID linkedMachineId) {
+      UUID linkedMachineId,
+      boolean qualityArea) {
     this.name = name;
     this.description = description;
     this.storageCondition = storageCondition;
@@ -127,6 +134,7 @@ public class WarehouseLocation extends BaseEntity {
     this.maxVolumeM3 = maxVolumeM3;
     this.sortOrder = sortOrder;
     this.linkedMachineId = linkedMachineId;
+    assignQualityArea(qualityArea);
   }
 
   public void assignPath(String path, int level) {
@@ -258,6 +266,14 @@ public class WarehouseLocation extends BaseEntity {
     return this.getIsActive()
         && this.status != LocationStatus.BLOCKED
         && this.status != LocationStatus.MAINTENANCE;
+  }
+
+  private void assignQualityArea(boolean qualityArea) {
+    if (qualityArea && !isStorageLocation()) {
+      throw new IwmDomainException(
+          "Only storage-capable warehouse locations can be designated as QC areas");
+    }
+    this.qualityArea = qualityArea;
   }
 
   private void recalculateStatus() {

--- a/src/main/java/com/fabricmanagement/iwm/location/dto/CreateWarehouseLocationRequest.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/dto/CreateWarehouseLocationRequest.java
@@ -55,4 +55,7 @@ public class CreateWarehouseLocationRequest {
   private Integer sortOrder;
 
   private UUID linkedMachineId;
+
+  /** Marks this storage location as an approved QC/quarantine destination. */
+  private boolean qualityArea;
 }

--- a/src/main/java/com/fabricmanagement/iwm/location/dto/UpdateWarehouseLocationRequest.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/dto/UpdateWarehouseLocationRequest.java
@@ -44,4 +44,7 @@ public class UpdateWarehouseLocationRequest {
   private Integer sortOrder;
 
   private UUID linkedMachineId;
+
+  /** Nullable for backward-compatible updates; omitted values preserve the current designation. */
+  private Boolean qualityArea;
 }

--- a/src/main/java/com/fabricmanagement/iwm/location/dto/WarehouseLocationDto.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/dto/WarehouseLocationDto.java
@@ -38,6 +38,9 @@ public class WarehouseLocationDto {
   private BigDecimal currentVolumeM3;
   private double utilizationPercent;
   private UUID linkedMachineId;
+  private boolean qualityArea;
+  private boolean storageLocation;
+  private boolean operational;
   private boolean isActive;
   private Long version;
   private Instant createdAt;
@@ -65,6 +68,9 @@ public class WarehouseLocationDto {
         .currentVolumeM3(entity.getCurrentVolumeM3())
         .utilizationPercent(entity.getUtilizationPercent())
         .linkedMachineId(entity.getLinkedMachineId())
+        .qualityArea(entity.isQualityArea())
+        .storageLocation(entity.isStorageLocation())
+        .operational(entity.isOperational())
         .isActive(entity.getIsActive())
         .version(entity.getVersion())
         .createdAt(entity.getCreatedAt())

--- a/src/main/java/com/fabricmanagement/iwm/location/dto/WarehouseLocationTreeDto.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/dto/WarehouseLocationTreeDto.java
@@ -39,6 +39,9 @@ public class WarehouseLocationTreeDto {
   private BigDecimal currentVolumeM3;
   private double utilizationPercent;
   private UUID linkedMachineId;
+  private boolean qualityArea;
+  private boolean storageLocation;
+  private boolean operational;
   private boolean isActive;
   private Long version;
   private Instant createdAt;
@@ -68,6 +71,9 @@ public class WarehouseLocationTreeDto {
         .currentVolumeM3(entity.getCurrentVolumeM3())
         .utilizationPercent(entity.getUtilizationPercent())
         .linkedMachineId(entity.getLinkedMachineId())
+        .qualityArea(entity.isQualityArea())
+        .storageLocation(entity.isStorageLocation())
+        .operational(entity.isOperational())
         .isActive(entity.getIsActive())
         .version(entity.getVersion())
         .createdAt(entity.getCreatedAt())

--- a/src/main/java/com/fabricmanagement/iwm/location/infra/repository/WarehouseLocationRepository.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/infra/repository/WarehouseLocationRepository.java
@@ -24,6 +24,9 @@ public interface WarehouseLocationRepository extends JpaRepository<WarehouseLoca
 
   List<WarehouseLocation> findByIsActiveTrueOrderBySortOrderAscNameAsc();
 
+  List<WarehouseLocation> findByQualityAreaAndIsActiveTrueOrderBySortOrderAscNameAsc(
+      boolean qualityArea);
+
   List<WarehouseLocation> findByTypeAndIsActiveTrue(WarehouseLocationType type);
 
   List<WarehouseLocation> findByTypeInAndIsActiveTrue(List<WarehouseLocationType> types);

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -25,6 +25,7 @@ public class TenantTransactionalPurgeService {
 
   private static final String TENANT_DEMOMODE_CACHE = "tenant-demomode";
   private static final String TENANT_EMAIL_SANDBOX_CACHE = "tenant-emailsandbox";
+  private static final String QUALITY_DECISION_PURGE_SETTING = "app.quality_decision_purge_tenant";
 
   private static final List<String> TRANSACTIONAL_TABLES =
       List.of(
@@ -98,6 +99,8 @@ public class TenantTransactionalPurgeService {
           "production.production_output_record",
           "production.work_order_output",
           "production.work_order_consumption",
+          "production.quality_decision_unit",
+          "production.quality_decision",
           "production.stock_unit_audit_log",
           "production.stock_unit_soft_hold",
           "production.stock_unit",
@@ -238,10 +241,23 @@ public class TenantTransactionalPurgeService {
 
   private void deleteTransactionalRows(
       JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
+    authorizeQualityDecisionPurge(jdbc, tenantId);
     deleteChildRowsWithoutTenantId(jdbc, tenantId, rows);
     for (String table : TRANSACTIONAL_TABLES) {
       delete(jdbc, rows, table, "DELETE FROM " + table + " WHERE tenant_id = ?", tenantId);
     }
+  }
+
+  /**
+   * Opens the append-only ledger's narrowly scoped DELETE path for this system transaction only.
+   * The database trigger also verifies the executing role and matches every deleted row's tenant.
+   */
+  private void authorizeQualityDecisionPurge(JdbcTemplate jdbc, UUID tenantId) {
+    jdbc.queryForObject(
+        "SELECT set_config(?, ?, true)",
+        String.class,
+        QUALITY_DECISION_PURGE_SETTING,
+        tenantId.toString());
   }
 
   private void deleteChildRowsWithoutTenantId(

--- a/src/main/java/com/fabricmanagement/production/execution/batch/api/controller/BatchController.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/api/controller/BatchController.java
@@ -272,14 +272,14 @@ public class BatchController {
 
   /**
    * Override batch status (QC_REJECTED or QUARANTINE → AVAILABLE). Requires reason (min 10 chars).
-   * Logged to override_log for audit. Manager-only: SUPERVISOR/WORKER/VIEWER → 403.
+   * Records an immutable superseding quality decision and retains the legacy override audit row.
    */
   @PatchMapping("/{id}/override-status")
   @Operation(
       summary = "Override Batch Status",
       description =
-          "Overrides batch status (e.g., QC_REJECTED to AVAILABLE). Requires reason. Admin/Manager only.")
-  @PreAuthorize("@auth.can(authentication, 'products', 'manage')")
+          "Records a superseding RELEASED quality decision. Requires quality approval permission and a reason.")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'approve')")
   public ResponseEntity<ApiResponse<BatchDto>> overrideStatus(
       @PathVariable UUID id, @Valid @RequestBody OverrideStatusRequest request) {
     BatchDto batch = batchOperationsService.overrideStatus(id, request);

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsService.java
@@ -17,6 +17,7 @@ import com.fabricmanagement.production.execution.batch.infra.repository.BatchRep
 import com.fabricmanagement.production.execution.lineage.app.BatchLineageService;
 import com.fabricmanagement.production.execution.lineage.dto.CreateBatchLineageRequest;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -61,6 +62,7 @@ public class BatchOperationsService {
   private final StockUnitRepository stockUnitRepository;
   private final WarehouseLocationPort warehouseLocationPort;
   private final ApplicationEventPublisher applicationEventPublisher;
+  private final QualityDecisionService qualityDecisionService;
 
   // ── Blend ─────────────────────────────────────────────────────────────────
 
@@ -449,9 +451,7 @@ public class BatchOperationsService {
 
   // ── Override ───────────────────────────────────────────────────────────────
 
-  /**
-   * Override batch status (QC_REJECTED or QUARANTINE → AVAILABLE). Logs to override_log for audit.
-   */
+  /** Records a superseding RELEASED decision and retains the legacy override audit projection. */
   @Transactional
   public BatchDto overrideStatus(UUID batchId, OverrideStatusRequest request) {
     UUID tenantId = TenantContext.requireTenantId();
@@ -466,8 +466,7 @@ public class BatchOperationsService {
     }
 
     BatchStatus fromStatus = batch.getStatus();
-    batch.transitionStatus(BatchStatus.AVAILABLE, actorId);
-    batchRepository.save(batch);
+    qualityDecisionService.overrideToReleased(batchId, request.getReason());
 
     BatchOverrideLog logEntry =
         BatchOverrideLog.create(

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchQcEventListener.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchQcEventListener.java
@@ -1,47 +1,34 @@
 package com.fabricmanagement.production.execution.batch.app;
 
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.platform.communication.app.InAppNotificationService;
 import com.fabricmanagement.platform.communication.domain.NotificationDeliveryChannel;
 import com.fabricmanagement.platform.communication.domain.NotificationType;
-import com.fabricmanagement.production.execution.batch.domain.Batch;
-import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
-import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
-import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
-import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
-import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionCommand;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
+import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
 import com.fabricmanagement.production.quality.result.domain.TestApprovalStatus;
 import com.fabricmanagement.production.quality.result.domain.event.FiberTestResultApprovedEvent;
 import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.modulith.events.ApplicationModuleListener;
 import org.springframework.stereotype.Component;
 
-/**
- * Listens to {@link FiberTestResultApprovedEvent} and updates the associated batch status.
- *
- * <p>Mapping:
- *
- * <ul>
- *   <li>APPROVED → AVAILABLE (automatic release)
- *   <li>CONDITIONAL_ACCEPT → QUARANTINE (user decides next step)
- *   <li>REJECTED → QC_REJECTED (automatic block)
- *   <li>PENDING → no change
- * </ul>
- */
+/** Converts fiber-test approvals into immutable quality decisions. */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class BatchQcEventListener {
 
-  private static final Set<BatchStatus> QC_AWAITING_STATUSES =
-      Set.of(BatchStatus.PENDING_QC, BatchStatus.QUARANTINE);
-
-  private final BatchRepository batchRepository;
-  private final StockUnitRepository stockUnitRepository;
+  private final QualityDecisionService qualityDecisionService;
   private final InAppNotificationService notificationService;
-  private final com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler
-      idempotentHandler;
+  private final IdempotentEventHandler idempotentHandler;
 
   @ApplicationModuleListener
   public void onFiberTestResultApproved(FiberTestResultApprovedEvent event) {
@@ -49,118 +36,53 @@ public class BatchQcEventListener {
         event.getEventId(),
         this.getClass(),
         "onFiberTestResultApproved",
-        () -> {
-          if (event.getApprovalStatus() == TestApprovalStatus.PENDING) {
-            return;
-          }
-
-          if (event.getStockUnitId() != null) {
-            handleStockUnitQcResult(event);
-          } else {
-            handleBatchQcResult(event);
-          }
-        });
+        () ->
+            TenantContext.executeInTenantContext(
+                event.getTenantId(),
+                () -> {
+                  handleQcResult(event);
+                  return null;
+                }));
   }
 
-  private void handleStockUnitQcResult(FiberTestResultApprovedEvent event) {
-    StockUnit su =
-        stockUnitRepository
-            .findByIdAndTenantIdAndIsActiveTrue(event.getStockUnitId(), event.getTenantId())
-            .orElse(null);
-
-    if (su == null) {
-      log.warn(
-          "StockUnit not found for QC event: stockUnitId={}, tenantId={}",
-          event.getStockUnitId(),
-          event.getTenantId());
+  private void handleQcResult(FiberTestResultApprovedEvent event) {
+    if (event.getApprovalStatus() == TestApprovalStatus.PENDING) {
+      return;
+    }
+    if (event.getApprovalStatus() == TestApprovalStatus.CONDITIONAL_ACCEPT) {
+      notifyConcessionReview(event);
       return;
     }
 
-    switch (event.getApprovalStatus()) {
-      case APPROVED -> {
-        if (su.getStatus() == StockUnitStatus.QUARANTINE) {
-          su.releaseQuarantine();
-        } else if (su.getStatus() == StockUnitStatus.ON_HOLD) {
-          su.releaseHold();
-        }
-      }
-      case REJECTED -> {
-        if (su.getStatus().canTransitionTo(StockUnitStatus.QUARANTINE)) {
-          su.quarantine();
-        }
-      }
-      case CONDITIONAL_ACCEPT -> {
-        if (su.getStatus().canTransitionTo(StockUnitStatus.ON_HOLD)) {
-          su.hold();
-        }
-      }
-      case PENDING -> {}
-    }
+    boolean approved = event.getApprovalStatus() == TestApprovalStatus.APPROVED;
+    QualityDecisionScope scope =
+        event.getStockUnitId() == null
+            ? QualityDecisionScope.FULL_LOT
+            : QualityDecisionScope.SELECTED_UNITS;
+    Set<UUID> unitIds = event.getStockUnitId() == null ? Set.of() : Set.of(event.getStockUnitId());
 
-    stockUnitRepository.save(su);
-    log.info(
-        "StockUnit status updated by QC: stockUnitId={}, approval={}",
-        event.getStockUnitId(),
-        event.getApprovalStatus());
+    qualityDecisionService.recordDecision(
+        TrustedDecisionContext.qcEvent(event.getActorId(), event.getEventId()),
+        new QualityDecisionCommand(
+            event.getBatchId(),
+            scope,
+            approved ? QualityDecisionOutcome.RELEASED : QualityDecisionOutcome.NONCONFORMING,
+            approved ? QualityReasonCode.SYSTEM_QC_PASSED : QualityReasonCode.SYSTEM_QC_REJECTED,
+            null,
+            unitIds,
+            null));
   }
 
-  private void handleBatchQcResult(FiberTestResultApprovedEvent event) {
-    BatchStatus targetStatus = mapApprovalToBatchStatus(event.getApprovalStatus());
-    if (targetStatus == null) {
-      return;
-    }
-
-    Batch batch =
-        batchRepository.findByIdAndTenantId(event.getBatchId(), event.getTenantId()).orElse(null);
-
-    if (batch == null) {
-      log.warn(
-          "Batch not found for QC event: batchId={}, tenantId={}",
-          event.getBatchId(),
-          event.getTenantId());
-      return;
-    }
-
-    if (!QC_AWAITING_STATUSES.contains(batch.getStatus())) {
-      log.debug(
-          "Batch {} already in {} — skipping QC status update (approval={})",
-          batch.getBatchCode(),
-          batch.getStatus(),
-          event.getApprovalStatus());
-      return;
-    }
-
-    BatchStatus fromStatus = batch.getStatus();
-    batch.transitionStatus(targetStatus, event.getActorId());
-    batchRepository.save(batch);
-
-    log.info(
-        "Batch status updated by QC: batchId={}, {} → {} (approval={})",
+  private void notifyConcessionReview(FiberTestResultApprovedEvent event) {
+    notificationService.sendToTenantRoles(
+        event.getTenantId(),
+        InAppNotificationService.QUARANTINE_NOTIFY_ROLES,
+        NotificationType.BATCH_QUARANTINE,
+        "Concession review required",
+        "Conditional QC acceptance requires a scoped concession review",
         event.getBatchId(),
-        fromStatus,
-        targetStatus,
-        event.getApprovalStatus());
-
-    if (targetStatus == BatchStatus.QUARANTINE) {
-      notificationService.sendToTenantRoles(
-          event.getTenantId(),
-          InAppNotificationService.QUARANTINE_NOTIFY_ROLES,
-          NotificationType.BATCH_QUARANTINE,
-          "Batch Quarantined",
-          batch.getBatchCode() + " moved to quarantine — requires review",
-          event.getBatchId(),
-          "BATCH",
-          NotificationDeliveryChannel.IN_APP);
-      log.debug("BATCH_QUARANTINE notification sent: batchId={}", event.getBatchId());
-    }
-  }
-
-  private static BatchStatus mapApprovalToBatchStatus(TestApprovalStatus approval) {
-    return switch (approval) {
-      case APPROVED -> BatchStatus.AVAILABLE;
-      case CONDITIONAL_ACCEPT -> BatchStatus.QUARANTINE;
-      case REJECTED -> BatchStatus.QC_REJECTED;
-      case PENDING -> null;
-    };
+        "BATCH",
+        NotificationDeliveryChannel.IN_APP);
+    log.info("Conditional QC result left pending: batchId={}", event.getBatchId());
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/BatchService.java
@@ -22,6 +22,7 @@ import com.fabricmanagement.production.masterdata.fiber.domain.FiberQualityStand
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberQualityStandardRepository;
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -53,6 +54,7 @@ public class BatchService {
   private final ColorQueryService colorQueryService;
   private final ApplicationEventPublisher applicationEventPublisher;
   private final BatchPrimaryMeasureService primaryMeasureService;
+  private final QualityDecisionService qualityDecisionService;
 
   @Value("${batch.certification.enforce-on-reserve:true}")
   private boolean certEnforceOnReserve;
@@ -261,23 +263,17 @@ public class BatchService {
 
   // ── QC release ─────────────────────────────────────────────────────────────
 
-  /**
-   * Releases a batch from QC by applying the PENDING_QC → AVAILABLE transition.
-   *
-   * <p>Exists because there is no QC-approval service API yet: the only production path that
-   * releases a batch is the async {@link BatchQcEventListener} reacting to {@code
-   * FiberTestResultApproved}. This method mirrors that listener's APPROVED → AVAILABLE mapping so
-   * in-process callers (e.g. demo seeders) can make freshly created batches saleable without
-   * reaching into the batch infra layer.
-   */
+  /** Releases a piece-backed batch through the immutable quality-decision ledger. */
   @Transactional
   public BatchDto releaseFromQc(UUID batchId) {
     UUID tenantId = TenantContext.requireTenantId();
     log.debug("Releasing batch from QC: tenantId={}, batchId={}", tenantId, batchId);
 
-    Batch batch = loadBatchWithLock(batchId, tenantId);
-    batch.transitionStatus(BatchStatus.AVAILABLE, TenantContext.getCurrentUserId());
-    Batch saved = batchRepository.save(batch);
+    qualityDecisionService.releaseFromQc(batchId);
+    Batch saved =
+        batchRepository
+            .findByIdAndTenantId(batchId, tenantId)
+            .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
 
     log.info("Batch released from QC: id={}, batchCode={}", saved.getId(), saved.getBatchCode());
 

--- a/src/main/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryService.java
@@ -150,6 +150,8 @@ public class StockAvailabilityQueryService {
       return Map.of();
     }
     List<UUID> batchIds = batches.stream().map(Batch::getId).toList();
+    Set<UUID> pieceBackedBatchIds =
+        stockUnitRepository.findBatchIdsWithActiveStockUnits(tenantId, batchIds);
     Map<UUID, List<StockUnitRepository.AvailabilityVectorRow>> vectorRows =
         stockUnitRepository.findAvailabilityVectorRows(tenantId, batchIds).stream()
             .collect(Collectors.groupingBy(StockUnitRepository.AvailabilityVectorRow::getBatchId));
@@ -198,6 +200,7 @@ public class StockAvailabilityQueryService {
                     computeLot(
                         tenantId,
                         batch,
+                        pieceBackedBatchIds.contains(batch.getId()),
                         filter,
                         vectorRows.getOrDefault(batch.getId(), List.of()),
                         pieceRows.getOrDefault(batch.getId(), List.of()),
@@ -212,6 +215,7 @@ public class StockAvailabilityQueryService {
   private LotComputation computeLot(
       UUID tenantId,
       Batch batch,
+      boolean pieceBacked,
       Filter filter,
       List<StockUnitRepository.AvailabilityVectorRow> vectorRows,
       List<StockUnitRepository.AvailabilityPieceBreakdownRow> pieceRows,
@@ -220,7 +224,7 @@ public class StockAvailabilityQueryService {
       BatchCommitmentQuantityService.Summary commitments,
       StockAvailabilityDtos.Colour colour) {
     var resolution = primaryMeasureService.resolve(batch);
-    boolean hasPieces = !vectorRows.isEmpty();
+    boolean hasPieces = pieceBacked || !vectorRows.isEmpty();
     List<StockUnitRepository.AvailabilityVectorRow> selectableRows =
         vectorRows.stream()
             .filter(row -> SELECTABLE_PIECE_STATUSES.contains(row.getStatus()))

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.production.common.exception.InsufficientStockException;
 import com.fabricmanagement.production.common.exception.InvalidStatusTransitionException;
 import com.fabricmanagement.production.execution.batch.domain.exception.BatchDomainException;
+import com.fabricmanagement.production.execution.batch.domain.exception.BatchNotConsumableException;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -386,6 +387,37 @@ public class Batch extends BaseEntity {
     onUpdate();
   }
 
+  /**
+   * Updates lot counters for consumption of a specifically identified RELEASED StockUnit.
+   *
+   * <p>Unlike scalar batch consumption, QC compatibility projection statuses do not block this
+   * operation. The caller has already enforced the unit disposition invariant.
+   */
+  public void consumeReleasedUnitFromAvailable(BigDecimal qty) {
+    validateReleasedUnitConsumptionPreconditions(qty);
+    if (getAvailableQuantity().compareTo(qty) < 0) {
+      throw new InsufficientStockException(getId(), batchCode, qty, getAvailableQuantity(), unit);
+    }
+    this.consumedQuantity = this.consumedQuantity.add(qty);
+    transitionAfterConsumption();
+    onUpdate();
+  }
+
+  /** Updates lot counters for a specifically identified RELEASED reserved StockUnit. */
+  public void consumeReleasedUnitFromReservation(BigDecimal qty) {
+    validateReleasedUnitConsumptionPreconditions(qty);
+    if (this.reservedQuantity.compareTo(qty) < 0) {
+      throw new BatchDomainException(
+          String.format(
+              "Cannot consume %.3f %s from reservations of batch %s: only %.3f %s is reserved.",
+              qty, unit, batchCode, reservedQuantity, unit));
+    }
+    this.reservedQuantity = this.reservedQuantity.subtract(qty);
+    this.consumedQuantity = this.consumedQuantity.add(qty);
+    transitionAfterConsumption();
+    onUpdate();
+  }
+
   private void validateConsumptionPreconditions(BigDecimal qty) {
     if (qty.compareTo(BigDecimal.ZERO) <= 0) {
       throw new BatchDomainException("Consumption amount must be positive for batch " + batchCode);
@@ -395,6 +427,15 @@ public class Batch extends BaseEntity {
     }
     if (this.status == BatchStatus.DEPLETED) {
       throw new InvalidStatusTransitionException("Batch", "DEPLETED", "IN_PROGRESS");
+    }
+  }
+
+  private void validateReleasedUnitConsumptionPreconditions(BigDecimal qty) {
+    if (qty.compareTo(BigDecimal.ZERO) <= 0) {
+      throw new BatchDomainException("Consumption amount must be positive for batch " + batchCode);
+    }
+    if (BatchStatus.BLOCKED_FOR_RELEASED_UNIT_CONSUMPTION.contains(this.status)) {
+      throw new BatchNotConsumableException(batchCode, status);
     }
   }
 

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/Batch.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Set;
 import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -248,6 +249,39 @@ public class Batch extends BaseEntity {
     }
     if (!this.status.canTransitionTo(target)) {
       throw new InvalidStatusTransitionException("Batch", this.status.name(), target.name());
+    }
+    this.status = target;
+    onUpdate();
+  }
+
+  /**
+   * Applies the temporary QC compatibility projection derived from StockUnit dispositions.
+   *
+   * <p>This is deliberately separate from the business transition state machine. It may only run
+   * while the batch has no operational commitment and can never revive a terminal batch.
+   */
+  public void applyQualityProjection(BatchStatus target) {
+    if (!Set.of(
+            BatchStatus.AVAILABLE,
+            BatchStatus.PENDING_QC,
+            BatchStatus.QUARANTINE,
+            BatchStatus.QC_REJECTED)
+        .contains(target)) {
+      throw new BatchDomainException("Invalid quality projection target: " + target);
+    }
+    if (Set.of(
+            BatchStatus.RESERVED,
+            BatchStatus.IN_PROGRESS,
+            BatchStatus.ON_HOLD,
+            BatchStatus.DEPLETED,
+            BatchStatus.RETURNED,
+            BatchStatus.DESTROYED)
+        .contains(status)) {
+      throw new BatchDomainException("Quality projection cannot overwrite batch status " + status);
+    }
+    if (reservedQuantity.compareTo(BigDecimal.ZERO) > 0
+        || consumedQuantity.compareTo(BigDecimal.ZERO) > 0) {
+      throw new BatchDomainException("Quality projection cannot overwrite committed batch state");
     }
     this.status = target;
     onUpdate();

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/BatchStatus.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/BatchStatus.java
@@ -116,6 +116,13 @@ public enum BatchStatus {
       Set.of(PENDING_QC, QUARANTINE, ON_HOLD, QC_REJECTED, RETURNED, DESTROYED);
 
   /**
+   * True operational blockers for consumption of a specific RELEASED StockUnit. QC projection
+   * statuses are deliberately absent because unit disposition is authoritative on that path.
+   */
+  public static final Set<BatchStatus> BLOCKED_FOR_RELEASED_UNIT_CONSUMPTION =
+      Set.of(ON_HOLD, DEPLETED, RETURNED, DESTROYED);
+
+  /**
    * State machine transition rules for {@link
    * com.fabricmanagement.production.execution.batch.domain.Batch#transitionStatus}.
    *

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/exception/BatchNotConsumableException.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/exception/BatchNotConsumableException.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.production.execution.batch.domain.exception;
+
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+
+/** Raised when a real operational batch state blocks released-unit consumption. */
+public class BatchNotConsumableException extends BatchDomainException {
+
+  public BatchNotConsumableException(String batchCode, BatchStatus status) {
+    super(
+        "Batch " + batchCode + " is not consumable in operational status " + status,
+        "BATCH_NOT_CONSUMABLE",
+        422);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/QcLocationValidationResult.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/QcLocationValidationResult.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.production.execution.batch.domain.port;
+
+import java.util.UUID;
+
+/** Minimal production-owned view of an IWM location's QC custody eligibility. */
+public record QcLocationValidationResult(
+    UUID locationId, String locationCode, boolean validQcLocation) {}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationPort.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationPort.java
@@ -23,4 +23,13 @@ public interface WarehouseLocationPort {
    *     not found
    */
   LocationValidationResult validateProductionLocation(UUID locationId);
+
+  /**
+   * Validate that a location is an active, operational storage location designated for QC or
+   * quarantine custody.
+   *
+   * @param locationId the warehouse location ID
+   * @return minimal validation result translated from the IWM bounded context
+   */
+  QcLocationValidationResult validateQcLocation(UUID locationId);
 }

--- a/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/StockAvailabilityBatchRepositoryImpl.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/StockAvailabilityBatchRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.fabricmanagement.production.execution.batch.infra.repository;
 
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
@@ -106,7 +107,6 @@ public class StockAvailabilityBatchRepositoryImpl implements StockAvailabilityBa
     List<Predicate> predicates = new ArrayList<>();
     predicates.add(cb.equal(batch.get("tenantId"), tenantId));
     predicates.add(cb.isTrue(batch.get("isActive")));
-    predicates.add(batch.get("status").in(SALEABLE_BATCH_STATUSES));
     predicates.add(batch.get("productType").in(AVAILABILITY_PRODUCT_TYPES));
     if (filter.colorId() != null) {
       predicates.add(cb.equal(batch.get("colorId"), filter.colorId()));
@@ -122,23 +122,48 @@ public class StockAvailabilityBatchRepositoryImpl implements StockAvailabilityBa
     if (productIds != null) {
       predicates.add(batch.get("productId").in(productIds));
     }
-    if (filter.qualityGradeId() != null || filter.qualityUnassigned()) {
-      Subquery<Integer> pieceExists = query.subquery(Integer.class);
-      Root<StockUnit> piece = pieceExists.from(StockUnit.class);
-      List<Predicate> piecePredicates = new ArrayList<>();
-      piecePredicates.add(cb.equal(piece.get("tenantId"), tenantId));
-      piecePredicates.add(cb.equal(piece.get("batchId"), batch.get("id")));
-      piecePredicates.add(cb.isTrue(piece.get("isActive")));
-      piecePredicates.add(piece.get("status").in(SELECTABLE_PIECE_STATUSES));
-      if (filter.qualityGradeId() != null) {
-        piecePredicates.add(cb.equal(piece.get("qualityGradeId"), filter.qualityGradeId()));
-      } else {
-        piecePredicates.add(cb.isNull(piece.get("qualityGradeId")));
-      }
-      pieceExists.select(cb.literal(1)).where(piecePredicates.toArray(Predicate[]::new));
-      predicates.add(cb.exists(pieceExists));
-    }
+    predicates.add(availabilityPopulation(cb, query, batch, tenantId, filter));
     return predicates.toArray(Predicate[]::new);
+  }
+
+  private Predicate availabilityPopulation(
+      CriteriaBuilder cb, CriteriaQuery<?> query, Root<Batch> batch, UUID tenantId, Filter filter) {
+    Subquery<Integer> anyActivePiece = query.subquery(Integer.class);
+    Root<StockUnit> anyPiece = anyActivePiece.from(StockUnit.class);
+    anyActivePiece
+        .select(cb.literal(1))
+        .where(
+            cb.equal(anyPiece.get("tenantId"), tenantId),
+            cb.equal(anyPiece.get("batchId"), batch.get("id")),
+            cb.isTrue(anyPiece.get("isActive")));
+
+    Subquery<Integer> releasedSelectablePiece = query.subquery(Integer.class);
+    Root<StockUnit> releasedPiece = releasedSelectablePiece.from(StockUnit.class);
+    List<Predicate> releasedPredicates = new ArrayList<>();
+    releasedPredicates.add(cb.equal(releasedPiece.get("tenantId"), tenantId));
+    releasedPredicates.add(cb.equal(releasedPiece.get("batchId"), batch.get("id")));
+    releasedPredicates.add(cb.isTrue(releasedPiece.get("isActive")));
+    releasedPredicates.add(releasedPiece.get("status").in(SELECTABLE_PIECE_STATUSES));
+    releasedPredicates.add(
+        cb.equal(releasedPiece.get("qualityDisposition"), QualityDisposition.RELEASED));
+    if (filter.qualityGradeId() != null) {
+      releasedPredicates.add(
+          cb.equal(releasedPiece.get("qualityGradeId"), filter.qualityGradeId()));
+    } else if (filter.qualityUnassigned()) {
+      releasedPredicates.add(cb.isNull(releasedPiece.get("qualityGradeId")));
+    }
+    releasedSelectablePiece
+        .select(cb.literal(1))
+        .where(releasedPredicates.toArray(Predicate[]::new));
+
+    Predicate scalarLegacy =
+        cb.and(
+            cb.not(cb.exists(anyActivePiece)),
+            batch.get("status").in(SALEABLE_BATCH_STATUSES),
+            filter.qualityGradeId() == null && !filter.qualityUnassigned()
+                ? cb.conjunction()
+                : cb.disjunction());
+    return cb.or(cb.exists(releasedSelectablePiece), scalarLegacy);
   }
 
   private <T> TypedQuery<T> page(TypedQuery<T> query, Pageable pageable) {

--- a/src/main/java/com/fabricmanagement/production/execution/output/app/ProductionOutputService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/output/app/ProductionOutputService.java
@@ -3,6 +3,8 @@ package com.fabricmanagement.production.execution.output.app;
 import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.common.exception.ProductionDomainException;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.output.domain.ProductionOutputItem;
 import com.fabricmanagement.production.execution.output.domain.ProductionOutputRecord;
 import com.fabricmanagement.production.execution.output.domain.ProductionOutputStatus;
@@ -29,6 +31,7 @@ public class ProductionOutputService {
   private final ProductionOutputItemRepository itemRepo;
   private final DomainEventPublisher eventPublisher;
   private final ProductFacade productFacade;
+  private final BatchRepository batchRepository;
 
   @Transactional
   public ProductionOutputRecord create(CreateProductionOutputRequest request) {
@@ -125,6 +128,17 @@ public class ProductionOutputService {
 
       item.setBarcode(barcode);
       currentSeq++;
+    }
+
+    if (record.getBatchId() != null) {
+      var batch =
+          batchRepository
+              .findByIdAndTenantIdForUpdate(record.getBatchId(), tenantId)
+              .orElseThrow(() -> new ProductionDomainException("Output batch not found"));
+      // Confirmation fixes quantity/identity, not usability. Hide the lot synchronously; the
+      // listener then creates PENDING_INSPECTION units and derives the final fail-closed summary.
+      batch.applyQualityProjection(BatchStatus.PENDING_QC);
+      batchRepository.save(batch);
     }
 
     ProductionOutputConfirmedEvent event = record.confirm(userId);

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/api/StockUnitController.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/api/StockUnitController.java
@@ -129,6 +129,19 @@ public class StockUnitController {
     return ResponseEntity.ok(ApiResponse.success(StockUnitDto.from(unit)));
   }
 
+  @PostMapping("/{id}/qc-relocate")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'write')")
+  @Operation(
+      summary = "Relocate unreleased stock into an approved QC custody area",
+      description =
+          "Changes only the physical location. Operational status and quality disposition remain unchanged.")
+  public ResponseEntity<ApiResponse<StockUnitDto>> relocateForQuality(
+      @PathVariable UUID id, @Valid @RequestBody QcRelocateRequest request) {
+    var unit =
+        stockUnitService.relocateForQuality(id, request.targetLocationId(), request.reason());
+    return ResponseEntity.ok(ApiResponse.success(StockUnitDto.from(unit)));
+  }
+
   @PostMapping("/{id}/transfer/complete")
   @PreAuthorize("@auth.can(authentication, 'products', 'write')")
   @Operation(summary = "Complete a transfer — StockUnit arrives at destination")

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitService.java
@@ -8,6 +8,8 @@ import com.fabricmanagement.production.execution.batch.domain.WasteCategory;
 import com.fabricmanagement.production.execution.batch.domain.event.BatchAdjustedEvent;
 import com.fabricmanagement.production.execution.batch.domain.event.BatchConsumedEvent;
 import com.fabricmanagement.production.execution.batch.domain.event.BatchWasteRecordedEvent;
+import com.fabricmanagement.production.execution.batch.domain.port.QcLocationValidationResult;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
@@ -21,6 +23,7 @@ import com.fabricmanagement.production.execution.stockunit.domain.event.StockUni
 import com.fabricmanagement.production.execution.stockunit.domain.event.StockUnitDisposedEvent;
 import com.fabricmanagement.production.execution.stockunit.domain.event.StockUnitGradeChangedEvent;
 import com.fabricmanagement.production.execution.stockunit.domain.event.StockUnitTransferredEvent;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.QcRelocationException;
 import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitDomainException;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitAuditLogRepository;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
@@ -79,6 +82,7 @@ public class StockUnitService {
   private final QualityGradeService qualityGradeService;
   private final StockUnitAuditLogRepository auditLogRepository;
   private final ApplicationEventPublisher eventPublisher;
+  private final WarehouseLocationPort warehouseLocationPort;
 
   // ── Creation ─────────────────────────────────────────────────────────────
 
@@ -209,8 +213,8 @@ public class StockUnitService {
   /**
    * Consumes weight from an AVAILABLE or PARTIAL StockUnit.
    *
-   * <p>Checks the parent Batch status as a gate — consumption is blocked if the Batch is ON_HOLD,
-   * QUARANTINE, QC_REJECTED, RETURNED, or DESTROYED.
+   * <p>The unit must be quality-released. Parent batch QC projection statuses do not block this
+   * identified-unit path; true operational and terminal batch states still do.
    *
    * @param stockUnitId the unit to consume from
    * @param amount weight to consume (must be positive and ≤ currentWeight)
@@ -222,15 +226,13 @@ public class StockUnitService {
     StockUnit unit = loadUnit(stockUnitId, tenantId);
     Batch batch = loadBatchForUpdate(unit.getBatchId(), tenantId);
 
-    assertBatchAllowsConsumption(batch);
-
     BigDecimal prevWeight = unit.getCurrentWeight();
     StockUnitStatus prevStatus = unit.getStatus();
 
     unit.consume(amount);
     unit = stockUnitRepository.save(unit);
 
-    batch.consumeFromAvailable(amount);
+    batch.consumeReleasedUnitFromAvailable(amount);
     batchRepository.save(batch);
 
     writeAuditLog(
@@ -299,8 +301,7 @@ public class StockUnitService {
     StockUnit unit = loadUnit(stockUnitId, tenantId);
     Batch batch = loadBatchForUpdate(unit.getBatchId(), tenantId);
 
-    assertBatchAllowsConsumption(batch);
-
+    unit.assertQualityReleased();
     if (unit.getStatus() != StockUnitStatus.RESERVED) {
       throw new StockUnitDomainException(
           String.format(
@@ -315,7 +316,7 @@ public class StockUnitService {
     unit.consume(amount);
     unit = stockUnitRepository.save(unit);
 
-    batch.consumeFromReservation(amount);
+    batch.consumeReleasedUnitFromReservation(amount);
     batchRepository.save(batch);
 
     writeAuditLog(
@@ -447,6 +448,59 @@ public class StockUnitService {
         unit.getBarcode(),
         fromLocation,
         targetLocationId);
+    return unit;
+  }
+
+  /**
+   * Relocates unreleased stock into an approved QC custody area without changing operational status
+   * or quality disposition.
+   */
+  @Transactional
+  public StockUnit relocateForQuality(UUID stockUnitId, UUID targetLocationId, String reason) {
+    UUID tenantId = TenantContext.requireTenantId();
+    UUID actorId = TenantContext.getCurrentUserId();
+    StockUnit unit = loadUnit(stockUnitId, tenantId);
+
+    if (reason == null || reason.isBlank()) {
+      throw QcRelocationException.reasonRequired();
+    }
+    unit.assertAllowsQualityRelocation();
+    if (targetLocationId == null) {
+      throw QcRelocationException.targetInvalid(null);
+    }
+    if (targetLocationId.equals(unit.getLocationId())) {
+      throw QcRelocationException.sameLocation(targetLocationId);
+    }
+
+    QcLocationValidationResult target = warehouseLocationPort.validateQcLocation(targetLocationId);
+    if (!target.validQcLocation()) {
+      throw QcRelocationException.targetInvalid(targetLocationId);
+    }
+
+    UUID fromLocation = unit.getLocationId();
+    StockUnitStatus previousStatus = unit.getStatus();
+    QualityDisposition previousDisposition = unit.getQualityDisposition();
+    unit.relocateForQuality(targetLocationId);
+    unit = stockUnitRepository.save(unit);
+
+    writeAuditLog(
+        tenantId,
+        stockUnitId,
+        StockUnitAuditLog.OP_QC_RELOCATE,
+        "locationId",
+        fromLocation != null ? fromLocation.toString() : null,
+        targetLocationId.toString(),
+        actorId,
+        1,
+        reason.trim());
+
+    log.info(
+        "QC relocation completed: stockUnitId={}, from={}, to={}, status={}, disposition={}",
+        stockUnitId,
+        fromLocation,
+        targetLocationId,
+        previousStatus,
+        previousDisposition);
     return unit;
   }
 
@@ -854,19 +908,6 @@ public class StockUnitService {
     }
     batch.applyQualityProjection(target);
     batchRepository.save(batch);
-  }
-
-  /**
-   * Batch status gate — blocks consumption/transfer if the parent batch is in a non-operational
-   * state. StockUnit statuses are NOT cascaded; the batch acts as a gate only.
-   */
-  private void assertBatchAllowsConsumption(Batch batch) {
-    if (BatchStatus.BLOCKED_FOR_PRODUCTION.contains(batch.getStatus())) {
-      throw new StockUnitDomainException(
-          String.format(
-              "Batch %s is in status %s — consumption and transfer are blocked.",
-              batch.getBatchCode(), batch.getStatus()));
-    }
   }
 
   private void writeAuditLog(

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitService.java
@@ -10,6 +10,7 @@ import com.fabricmanagement.production.execution.batch.domain.event.BatchConsume
 import com.fabricmanagement.production.execution.batch.domain.event.BatchWasteRecordedEvent;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitAuditLog;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
@@ -105,26 +106,28 @@ public class StockUnitService {
 
     UUID tenantId = TenantContext.requireTenantId();
     UUID actorId = TenantContext.getCurrentUserId();
-    if (batchId != null) {
-      validateBatchExists(batchId, tenantId);
-    }
+    Batch batch = batchId == null ? null : loadBatch(batchId, tenantId);
 
-    return internalCreate(
-        tenantId,
-        batchId,
-        productType,
-        barcode,
-        serialNumber,
-        packageType,
-        initialWeight,
-        grossWeight,
-        unit,
-        length,
-        lengthUnit,
-        locationId,
-        sourceType,
-        sourceId,
-        actorId);
+    StockUnit created =
+        internalCreate(
+            tenantId,
+            batchId,
+            productType,
+            barcode,
+            serialNumber,
+            packageType,
+            initialWeight,
+            grossWeight,
+            unit,
+            length,
+            lengthUnit,
+            locationId,
+            sourceType,
+            sourceId,
+            QualityDisposition.PENDING_INSPECTION,
+            actorId);
+    projectQualityAfterBirth(batch, tenantId);
+    return created;
   }
 
   private StockUnit internalCreate(
@@ -142,6 +145,7 @@ public class StockUnitService {
       UUID locationId,
       StockUnitSourceType sourceType,
       UUID sourceId,
+      QualityDisposition initialQualityDisposition,
       UUID actorId) {
 
     StockUnit stockUnit =
@@ -157,7 +161,8 @@ public class StockUnitService {
             unit,
             locationId,
             sourceType,
-            sourceId);
+            sourceId,
+            initialQualityDisposition);
     if (length != null || lengthUnit != null) {
       stockUnit.recordLength(length, lengthUnit);
     }
@@ -768,30 +773,34 @@ public class StockUnitService {
   public List<StockUnit> createBulk(
       UUID batchId, List<CreateStockUnitRequest> requests, UUID actorId) {
     UUID tenantId = TenantContext.requireTenantId();
-    if (batchId != null) {
-      validateBatchExists(batchId, tenantId);
-    }
+    Batch batch = batchId == null ? null : loadBatch(batchId, tenantId);
 
-    return requests.stream()
-        .map(
-            r ->
-                internalCreate(
-                    tenantId,
-                    batchId,
-                    r.productType(),
-                    r.barcode(),
-                    r.serialNumber(),
-                    r.packageType(),
-                    r.initialWeight(),
-                    r.grossWeight(),
-                    r.unit(),
-                    r.length(),
-                    r.lengthUnit(),
-                    r.locationId(),
-                    r.sourceType(),
-                    r.sourceId(),
-                    actorId))
-        .toList();
+    List<StockUnit> created =
+        requests.stream()
+            .map(
+                r ->
+                    internalCreate(
+                        tenantId,
+                        batchId,
+                        r.productType(),
+                        r.barcode(),
+                        r.serialNumber(),
+                        r.packageType(),
+                        r.initialWeight(),
+                        r.grossWeight(),
+                        r.unit(),
+                        r.length(),
+                        r.lengthUnit(),
+                        r.locationId(),
+                        r.sourceType(),
+                        r.sourceId(),
+                        QualityDisposition.PENDING_INSPECTION,
+                        actorId))
+            .toList();
+    if (!created.isEmpty()) {
+      projectQualityAfterBirth(batch, tenantId);
+    }
+    return created;
   }
 
   /** Immutable command record for bulk creation — avoids long parameter lists. */
@@ -824,10 +833,27 @@ public class StockUnitService {
         .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
   }
 
-  private void validateBatchExists(UUID batchId, UUID tenantId) {
-    batchRepository
+  private Batch loadBatch(UUID batchId, UUID tenantId) {
+    return batchRepository
         .findByIdAndTenantId(batchId, tenantId)
         .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
+  }
+
+  private void projectQualityAfterBirth(Batch batch, UUID tenantId) {
+    if (batch == null) {
+      return;
+    }
+    var counts = stockUnitRepository.countQualityDispositions(tenantId, batch.getId());
+    long total =
+        counts.stream().mapToLong(StockUnitRepository.QualityDispositionCount::getUnitCount).sum();
+    BatchStatus target = BatchStatus.QUARANTINE;
+    if (counts.size() == 1
+        && total > 0
+        && counts.getFirst().getDisposition() == QualityDisposition.PENDING_INSPECTION) {
+      target = BatchStatus.PENDING_QC;
+    }
+    batch.applyQualityProjection(target);
+    batchRepository.save(batch);
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/app/listener/ProductionOutputConfirmedEventListener.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/app/listener/ProductionOutputConfirmedEventListener.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.production.execution.stockunit.app.listener;
 
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.execution.output.domain.event.ProductionOutputConfirmedEvent;
 import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
@@ -24,8 +25,7 @@ public class ProductionOutputConfirmedEventListener {
 
   private final StockUnitService stockUnitService;
   private final StockUnitRepository stockUnitRepository;
-  private final com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler
-      idempotentHandler;
+  private final IdempotentEventHandler idempotentHandler;
 
   @ApplicationModuleListener
   public void onProductionOutputConfirmed(ProductionOutputConfirmedEvent event) {
@@ -42,57 +42,49 @@ public class ProductionOutputConfirmedEventListener {
 
           UUID tenantId = event.getTenantId();
 
-          try {
-            TenantContext.executeInTenantContext(
-                tenantId,
-                () -> {
-                  ProductionOutputConfirmedEvent.OutputItemData firstItem = event.getItems().get(0);
-                  boolean alreadyProcessed =
-                      stockUnitRepository.existsByTenantIdAndSourceTypeAndSourceId(
-                          tenantId, StockUnitSourceType.PRODUCTION, firstItem.itemId());
+          TenantContext.executeInTenantContext(
+              tenantId,
+              () -> {
+                ProductionOutputConfirmedEvent.OutputItemData firstItem = event.getItems().get(0);
+                boolean alreadyProcessed =
+                    stockUnitRepository.existsByTenantIdAndSourceTypeAndSourceId(
+                        tenantId, StockUnitSourceType.PRODUCTION, firstItem.itemId());
 
-                  if (alreadyProcessed) {
-                    log.info(
-                        "ProductionOutputConfirmedEvent already processed. Skipping record: {}",
-                        event.getRecordId());
-                    return null;
-                  }
-
-                  List<StockUnitService.CreateStockUnitRequest> requests =
-                      event.getItems().stream()
-                          .map(
-                              item ->
-                                  new StockUnitService.CreateStockUnitRequest(
-                                      event.getOutputProductType(),
-                                      item.barcode(),
-                                      null, // serial number
-                                      item.packageType(),
-                                      item.netWeight(),
-                                      item.grossWeight(),
-                                      event.getUnit(),
-                                      null,
-                                      null,
-                                      item.locationId(),
-                                      StockUnitSourceType.PRODUCTION,
-                                      item.itemId()))
-                          .toList();
-
-                  stockUnitService.createBulk(
-                      event.getBatchId(), requests, TenantContext.SYSTEM_ACTOR_ID);
-
+                if (alreadyProcessed) {
                   log.info(
-                      "Auto-created {} StockUnits for Production Output {}",
-                      requests.size(),
+                      "ProductionOutputConfirmedEvent already processed. Skipping record: {}",
                       event.getRecordId());
                   return null;
-                });
-          } catch (Exception e) {
-            log.error(
-                "Failed to auto-create StockUnits for Production Output {}: {}",
-                event.getRecordId(),
-                e.getMessage(),
-                e);
-          }
+                }
+
+                List<StockUnitService.CreateStockUnitRequest> requests =
+                    event.getItems().stream()
+                        .map(
+                            item ->
+                                new StockUnitService.CreateStockUnitRequest(
+                                    event.getOutputProductType(),
+                                    item.barcode(),
+                                    null, // serial number
+                                    item.packageType(),
+                                    item.netWeight(),
+                                    item.grossWeight(),
+                                    event.getUnit(),
+                                    null,
+                                    null,
+                                    item.locationId(),
+                                    StockUnitSourceType.PRODUCTION,
+                                    item.itemId()))
+                        .toList();
+
+                stockUnitService.createBulk(
+                    event.getBatchId(), requests, TenantContext.SYSTEM_ACTOR_ID);
+
+                log.info(
+                    "Auto-created {} StockUnits for Production Output {}",
+                    requests.size(),
+                    event.getRecordId());
+                return null;
+              });
         });
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/QualityDisposition.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/QualityDisposition.java
@@ -1,0 +1,9 @@
+package com.fabricmanagement.production.execution.stockunit.domain;
+
+/** Independent quality disposition of a physical stock unit. */
+public enum QualityDisposition {
+  PENDING_INSPECTION,
+  RELEASED,
+  QUARANTINED,
+  NONCONFORMING
+}

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
@@ -170,6 +170,11 @@ public class StockUnit extends BaseEntity {
   @Column(name = "quality_grade_id")
   private UUID qualityGradeId;
 
+  /** Quality acceptance axis; independent from operational status and commercial grade. */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "quality_disposition", nullable = false, length = 30)
+  private QualityDisposition qualityDisposition;
+
   /** Previous grade ID — populated on grade change for audit trail. */
   @Column(name = "previous_grade_id")
   private UUID previousGradeId;
@@ -240,7 +245,8 @@ public class StockUnit extends BaseEntity {
    * @param locationId initial warehouse location
    * @param sourceType origin type
    * @param sourceId origin record ID
-   * @return new StockUnit in AVAILABLE status
+   * @param initialQualityDisposition trusted server-owned quality disposition at birth
+   * @return new StockUnit in operational AVAILABLE status with the supplied quality disposition
    */
   public static StockUnit create(
       UUID tenantId,
@@ -254,7 +260,8 @@ public class StockUnit extends BaseEntity {
       String unit,
       UUID locationId,
       StockUnitSourceType sourceType,
-      UUID sourceId) {
+      UUID sourceId,
+      QualityDisposition initialQualityDisposition) {
 
     if (productType == null) {
       throw new StockUnitDomainException("productType must not be null");
@@ -271,6 +278,9 @@ public class StockUnit extends BaseEntity {
     if (!packageType.isCompatibleWith(productType)) {
       throw new InvalidPackageTypeException(packageType, productType);
     }
+    if (initialQualityDisposition == null) {
+      throw new StockUnitDomainException("initialQualityDisposition must not be null");
+    }
 
     StockUnit stockUnit =
         StockUnit.builder()
@@ -285,6 +295,7 @@ public class StockUnit extends BaseEntity {
             .unit(unit)
             .locationId(locationId)
             .qualityGradeId(null)
+            .qualityDisposition(initialQualityDisposition)
             .previousGradeId(null)
             .previousLocationId(null)
             .status(StockUnitStatus.AVAILABLE)

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
@@ -3,7 +3,9 @@ package com.fabricmanagement.production.execution.stockunit.domain;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.production.execution.stockunit.domain.exception.InsufficientWeightException;
 import com.fabricmanagement.production.execution.stockunit.domain.exception.InvalidPackageTypeException;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.QcRelocationException;
 import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitDomainException;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitNotReleasedException;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +15,8 @@ import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -75,6 +79,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class StockUnit extends BaseEntity {
+
+  private static final Set<StockUnitStatus> QC_RELOCATION_STATUSES =
+      Set.of(
+          StockUnitStatus.AVAILABLE,
+          StockUnitStatus.PARTIAL,
+          StockUnitStatus.ON_HOLD,
+          StockUnitStatus.QUARANTINE);
 
   // ── Identity ──────────────────────────────────────────────────────────────
 
@@ -334,6 +345,7 @@ public class StockUnit extends BaseEntity {
    * @throws InsufficientWeightException if amount exceeds currentWeight
    */
   public void consume(BigDecimal amount) {
+    assertQualityReleased();
     validatePositive(amount, "Consumption amount");
     if (!status.isConsumable()) {
       throw new StockUnitDomainException(
@@ -401,6 +413,7 @@ public class StockUnit extends BaseEntity {
    * @throws StockUnitDomainException if unit is in a status that blocks transfers
    */
   public void startTransfer(UUID targetLocationId) {
+    assertQualityReleased();
     if (!status.canTransitionTo(StockUnitStatus.IN_TRANSIT)) {
       throw new StockUnitDomainException(
           String.format("StockUnit %s cannot transition to IN_TRANSIT from %s.", barcode, status));
@@ -409,6 +422,33 @@ public class StockUnit extends BaseEntity {
     this.locationId = targetLocationId;
     this.status = StockUnitStatus.IN_TRANSIT;
     onUpdate();
+  }
+
+  /**
+   * Atomically moves unreleased stock into an approved QC custody location without changing either
+   * operational status or quality disposition.
+   */
+  public void relocateForQuality(UUID targetLocationId) {
+    assertAllowsQualityRelocation();
+    if (targetLocationId == null) {
+      throw QcRelocationException.targetInvalid(null);
+    }
+    if (Objects.equals(locationId, targetLocationId)) {
+      throw QcRelocationException.sameLocation(targetLocationId);
+    }
+    this.previousLocationId = this.locationId;
+    this.locationId = targetLocationId;
+    onUpdate();
+  }
+
+  /** Validates the source side before resolving an external IWM target. */
+  public void assertAllowsQualityRelocation() {
+    if (qualityDisposition == QualityDisposition.RELEASED) {
+      throw QcRelocationException.releasedUnit(barcode);
+    }
+    if (!QC_RELOCATION_STATUSES.contains(status)) {
+      throw QcRelocationException.sourceInvalid(barcode, status, qualityDisposition);
+    }
   }
 
   /**
@@ -513,7 +553,15 @@ public class StockUnit extends BaseEntity {
    * @throws StockUnitDomainException if current status does not allow reservation
    */
   public void reserve() {
+    assertQualityReleased();
     transitionStatus(StockUnitStatus.RESERVED);
+  }
+
+  /** Enforces the quality acceptance invariant independently from operational status. */
+  public void assertQualityReleased() {
+    if (qualityDisposition != QualityDisposition.RELEASED) {
+      throw new StockUnitNotReleasedException(barcode, qualityDisposition);
+    }
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitAuditLog.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitAuditLog.java
@@ -27,6 +27,7 @@ import lombok.NoArgsConstructor;
  *   <li>REVERSAL — mandatory explanation for undoing a consumption
  *   <li>DISPOSAL — admin must document why the unit is destroyed
  *   <li>QUARANTINE_RELEASE — QC manager must confirm clearance
+ *   <li>QC_RELOCATE — custodian must document the physical move
  * </ul>
  *
  * <p>For other operations (CONSUME, TRANSFER, RESERVE) {@code reason} is optional.
@@ -84,6 +85,7 @@ public class StockUnitAuditLog extends BaseEntity {
   public static final String OP_CONSUME = "CONSUME";
   public static final String OP_REVERSAL = "REVERSAL";
   public static final String OP_TRANSFER = "TRANSFER";
+  public static final String OP_QC_RELOCATE = "QC_RELOCATE";
   public static final String OP_GRADE_CHANGE = "GRADE_CHANGE";
   public static final String OP_HOLD = "HOLD";
   public static final String OP_HOLD_RELEASE = "HOLD_RELEASE";

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitStatus.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitStatus.java
@@ -43,12 +43,12 @@ import java.util.Set;
  *   <li>DISPOSED → (terminal — no transitions)
  * </ul>
  *
- * <h2>Batch Status as Gate</h2>
+ * <h2>Batch and quality gates</h2>
  *
- * <p>StockUnit statuses are independent of the parent Batch status. The Batch status acts as a
- * <b>gate</b> at the service layer — when a Batch is ON_HOLD, new consumption is blocked, but
- * individual StockUnit statuses are NOT cascaded. This avoids the operational nightmare of updating
- * hundreds of StockUnit statuses and then reverting them.
+ * <p>StockUnit statuses are independent of the parent Batch status and quality disposition.
+ * Identified-unit operations enforce quality through {@link QualityDisposition}; true operational
+ * batch states such as ON_HOLD remain service-layer gates. Statuses are not cascaded across all
+ * units.
  *
  * @see StockUnit
  */

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/exception/QcRelocationException.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/exception/QcRelocationException.java
@@ -1,0 +1,49 @@
+package com.fabricmanagement.production.execution.stockunit.domain.exception;
+
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import java.util.UUID;
+
+/** Coded validation errors for the privileged QC custody relocation path. */
+public class QcRelocationException extends StockUnitDomainException {
+
+  private QcRelocationException(String message, String errorCode) {
+    super(message, errorCode, 422);
+  }
+
+  public static QcRelocationException releasedUnit(String barcode) {
+    return new QcRelocationException(
+        "Released StockUnit " + barcode + " must use the standard transfer path",
+        "QC_RELOCATE_RELEASED_UNIT");
+  }
+
+  public static QcRelocationException sourceInvalid(
+      String barcode, StockUnitStatus status, QualityDisposition disposition) {
+    return new QcRelocationException(
+        "StockUnit "
+            + barcode
+            + " cannot be relocated for QC in status "
+            + status
+            + " (disposition="
+            + disposition
+            + ")",
+        "QC_RELOCATE_STATUS_INVALID");
+  }
+
+  public static QcRelocationException targetInvalid(UUID targetLocationId) {
+    return new QcRelocationException(
+        "Location " + targetLocationId + " is not an approved operational QC storage area",
+        "QC_RELOCATE_TARGET_INVALID");
+  }
+
+  public static QcRelocationException sameLocation(UUID targetLocationId) {
+    return new QcRelocationException(
+        "StockUnit is already located at QC location " + targetLocationId,
+        "QC_RELOCATE_SAME_LOCATION");
+  }
+
+  public static QcRelocationException reasonRequired() {
+    return new QcRelocationException(
+        "QC relocation reason must not be blank", "QC_RELOCATE_REASON_REQUIRED");
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/exception/StockUnitNotReleasedException.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/exception/StockUnitNotReleasedException.java
@@ -1,0 +1,18 @@
+package com.fabricmanagement.production.execution.stockunit.domain.exception;
+
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+
+/** Raised when an operation requiring accepted stock targets an unreleased physical unit. */
+public class StockUnitNotReleasedException extends StockUnitDomainException {
+
+  public StockUnitNotReleasedException(String barcode, QualityDisposition disposition) {
+    super(
+        "StockUnit "
+            + barcode
+            + " is not released for operational use (disposition="
+            + disposition
+            + ")",
+        "STOCK_UNIT_NOT_RELEASED",
+        422);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/dto/QcRelocateRequest.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/dto/QcRelocateRequest.java
@@ -1,0 +1,15 @@
+package com.fabricmanagement.production.execution.stockunit.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+@Schema(
+    name = "StockUnitQcRelocateRequest",
+    description = "Privileged custody relocation of unreleased stock into a QC storage area")
+public record QcRelocateRequest(
+    @NotNull @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID targetLocationId,
+    @NotBlank @Size(max = 500) @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        String reason) {}

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/dto/StockUnitDto.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/dto/StockUnitDto.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.production.execution.stockunit.dto;
 
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
@@ -30,6 +31,7 @@ public record StockUnitDto(
     UUID locationId,
     UUID previousLocationId,
     UUID qualityGradeId,
+    QualityDisposition qualityDisposition,
     UUID previousGradeId,
     StockUnitStatus status,
     StockUnitSourceType sourceType,
@@ -63,6 +65,7 @@ public record StockUnitDto(
         entity.getLocationId(),
         entity.getPreviousLocationId(),
         entity.getQualityGradeId(),
+        entity.getQualityDisposition(),
         entity.getPreviousGradeId(),
         entity.getStatus(),
         entity.getSourceType(),

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -44,6 +45,17 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
   boolean existsByTenantIdAndBatchIdInAndIsActiveTrue(UUID tenantId, List<UUID> batchIds);
 
   List<StockUnit> findByTenantIdAndBatchIdInAndIsActiveTrue(UUID tenantId, List<UUID> batchIds);
+
+  @Query(
+      """
+      SELECT DISTINCT s.batchId
+      FROM StockUnit s
+      WHERE s.tenantId = :tenantId
+        AND s.batchId IN :batchIds
+        AND s.isActive = true
+      """)
+  Set<UUID> findBatchIdsWithActiveStockUnits(
+      @Param("tenantId") UUID tenantId, @Param("batchIds") Collection<UUID> batchIds);
 
   Page<StockUnit> findByTenantIdAndBatchIdAndIsActiveTrue(
       UUID tenantId, UUID batchId, Pageable pageable);
@@ -167,6 +179,7 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
       WHERE s.tenantId = :tenantId
         AND s.batchId IN :batchIds
         AND s.isActive = true
+        AND s.qualityDisposition = com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition.RELEASED
       GROUP BY s.batchId, s.status, s.qualityGradeId,
                UPPER(TRIM(s.unit)), UPPER(TRIM(s.lengthUnit))
       """)
@@ -187,6 +200,7 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
         AND s.batchId IN :batchIds
         AND s.isActive = true
         AND s.status IN :statuses
+        AND s.qualityDisposition = com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition.RELEASED
         AND (:qualityGradeId IS NULL OR s.qualityGradeId = :qualityGradeId)
         AND (:qualityUnassigned = false OR s.qualityGradeId IS NULL)
       GROUP BY s.batchId, s.packageType,
@@ -213,6 +227,7 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
         AND s.batchId IN :batchIds
         AND s.isActive = true
         AND s.status IN :statuses
+        AND s.qualityDisposition = com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition.RELEASED
         AND (:qualityGradeId IS NULL OR s.qualityGradeId = :qualityGradeId)
         AND (:qualityUnassigned = false OR s.qualityGradeId IS NULL)
       GROUP BY s.batchId, s.qualityGradeId,

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.production.execution.stockunit.infra.repository;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import jakarta.persistence.LockModeType;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
@@ -11,6 +12,8 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -41,6 +44,114 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
   boolean existsByTenantIdAndBatchIdInAndIsActiveTrue(UUID tenantId, List<UUID> batchIds);
 
   List<StockUnit> findByTenantIdAndBatchIdInAndIsActiveTrue(UUID tenantId, List<UUID> batchIds);
+
+  Page<StockUnit> findByTenantIdAndBatchIdAndIsActiveTrue(
+      UUID tenantId, UUID batchId, Pageable pageable);
+
+  Page<StockUnit> findByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+      UUID tenantId, UUID batchId, Collection<StockUnitStatus> statuses, Pageable pageable);
+
+  @Query(
+      value =
+          """
+          SELECT b.id AS batchId,
+                 b.batch_code AS batchCode,
+                 b.product_id AS productId,
+                 b.product_type AS productType,
+                 b.supplier_batch_code AS supplierBatchCode,
+                 COUNT(s.id) AS pendingUnitCount,
+                 b.created_at AS createdAt
+          FROM production.stock_unit s
+          JOIN production.production_execution_batch b
+            ON b.id = s.batch_id AND b.tenant_id = s.tenant_id
+          WHERE s.tenant_id = :tenantId
+            AND s.is_active = TRUE
+            AND b.is_active = TRUE
+            AND s.quality_disposition = 'PENDING_INSPECTION'
+          GROUP BY b.id, b.batch_code, b.product_id, b.product_type,
+                   b.supplier_batch_code, b.created_at
+          ORDER BY b.created_at ASC, b.id ASC
+          """,
+      countQuery =
+          """
+          SELECT COUNT(DISTINCT s.batch_id)
+          FROM production.stock_unit s
+          JOIN production.production_execution_batch b
+            ON b.id = s.batch_id AND b.tenant_id = s.tenant_id
+          WHERE s.tenant_id = :tenantId
+            AND s.is_active = TRUE
+            AND b.is_active = TRUE
+            AND s.quality_disposition = 'PENDING_INSPECTION'
+          """,
+      nativeQuery = true)
+  Page<QualityQueueRow> findQualityQueue(@Param("tenantId") UUID tenantId, Pageable pageable);
+
+  long countByTenantIdAndBatchIdAndIsActiveTrue(UUID tenantId, UUID batchId);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      """
+      SELECT s FROM StockUnit s
+      WHERE s.tenantId = :tenantId
+        AND s.batchId = :batchId
+        AND s.isActive = true
+        AND s.status IN :statuses
+      ORDER BY s.id
+      """)
+  List<StockUnit> lockDecisionPopulation(
+      @Param("tenantId") UUID tenantId,
+      @Param("batchId") UUID batchId,
+      @Param("statuses") Collection<StockUnitStatus> statuses);
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query(
+      """
+      SELECT s FROM StockUnit s
+      WHERE s.tenantId = :tenantId
+        AND s.batchId = :batchId
+        AND s.id IN :ids
+        AND s.isActive = true
+        AND s.status IN :statuses
+      ORDER BY s.id
+      """)
+  List<StockUnit> lockSelectedDecisionPopulation(
+      @Param("tenantId") UUID tenantId,
+      @Param("batchId") UUID batchId,
+      @Param("ids") Collection<UUID> ids,
+      @Param("statuses") Collection<StockUnitStatus> statuses);
+
+  @Modifying(flushAutomatically = true)
+  @Query(
+      """
+      UPDATE StockUnit s
+      SET s.qualityDisposition = :disposition,
+          s.version = s.version + 1
+      WHERE s.tenantId = :tenantId
+        AND s.batchId = :batchId
+        AND s.id IN :ids
+        AND s.isActive = true
+        AND s.status IN :statuses
+      """)
+  int applyQualityDisposition(
+      @Param("tenantId") UUID tenantId,
+      @Param("batchId") UUID batchId,
+      @Param("ids") Collection<UUID> ids,
+      @Param("statuses") Collection<StockUnitStatus> statuses,
+      @Param("disposition")
+          com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition
+              disposition);
+
+  @Query(
+      """
+      SELECT s.qualityDisposition AS disposition, COUNT(s.id) AS unitCount
+      FROM StockUnit s
+      WHERE s.tenantId = :tenantId
+        AND s.batchId = :batchId
+        AND s.isActive = true
+      GROUP BY s.qualityDisposition
+      """)
+  List<QualityDispositionCount> countQualityDispositions(
+      @Param("tenantId") UUID tenantId, @Param("batchId") UUID batchId);
 
   @Query(
       """
@@ -185,5 +296,27 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
     BigDecimal getLengthQuantity();
 
     long getPieceCount();
+  }
+
+  interface QualityDispositionCount {
+    com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition getDisposition();
+
+    long getUnitCount();
+  }
+
+  interface QualityQueueRow {
+    UUID getBatchId();
+
+    String getBatchCode();
+
+    UUID getProductId();
+
+    String getProductType();
+
+    String getSupplierBatchCode();
+
+    long getPendingUnitCount();
+
+    java.time.Instant getCreatedAt();
   }
 }

--- a/src/main/java/com/fabricmanagement/production/masterdata/qualitygrade/api/QualityGradeController.java
+++ b/src/main/java/com/fabricmanagement/production/masterdata/qualitygrade/api/QualityGradeController.java
@@ -51,7 +51,7 @@ public class QualityGradeController {
   }
 
   @PostMapping
-  @PreAuthorize("@auth.can(authentication, 'quality', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'manage')")
   @Operation(summary = "Create a new quality grade")
   public ResponseEntity<ApiResponse<QualityGradeDto>> create(
       @Valid @RequestBody CreateQualityGradeRequest request) {
@@ -71,7 +71,7 @@ public class QualityGradeController {
   }
 
   @PutMapping("/{id}")
-  @PreAuthorize("@auth.can(authentication, 'quality', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'manage')")
   @Operation(summary = "Update a quality grade (code and productType are immutable)")
   public ResponseEntity<ApiResponse<QualityGradeDto>> update(
       @PathVariable UUID id, @Valid @RequestBody UpdateQualityGradeRequest request) {
@@ -89,7 +89,7 @@ public class QualityGradeController {
   }
 
   @DeleteMapping("/{id}")
-  @PreAuthorize("@auth.can(authentication, 'quality', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'manage')")
   @Operation(summary = "Deactivate (soft-delete) a quality grade")
   public ResponseEntity<Void> deactivate(@PathVariable UUID id) {
     qualityGradeService.deactivate(id);

--- a/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
@@ -1,0 +1,84 @@
+package com.fabricmanagement.production.quality.decision.api.controller;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionQueryService;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
+import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
+import com.fabricmanagement.production.quality.decision.dto.RecordQualityDecisionRequest;
+import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/production/quality")
+@RequiredArgsConstructor
+@Tag(name = "Quality Decisions", description = "Immutable stock quality disposition decisions")
+public class QualityDecisionController {
+
+  private final QualityDecisionService decisionService;
+  private final QualityDecisionQueryService queryService;
+  private final QualityDecisionMapper mapper;
+
+  @PostMapping("/batches/{batchId}/decisions")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'approve')")
+  @Operation(operationId = "recordQualityDecision", summary = "Record a quality decision")
+  public ResponseEntity<ApiResponse<QualityDecisionDto>> record(
+      @PathVariable UUID batchId, @Valid @RequestBody RecordQualityDecisionRequest request) {
+    var decision =
+        decisionService.recordDecision(
+            TrustedDecisionContext.manual(TenantContext.getCurrentUserId()),
+            request.toCommand(batchId));
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResponse.success(mapper.toDto(decision)));
+  }
+
+  @GetMapping("/queue")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(operationId = "listPendingQualityQueue", summary = "List batches awaiting QC")
+  public ResponseEntity<ApiResponse<PagedResponse<QualityQueueItemDto>>> queue(
+      @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(PagedResponse.from(queryService.getQueue(pageable))));
+  }
+
+  @GetMapping("/batches/{batchId}/decisions")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(operationId = "listQualityDecisionHistory", summary = "List batch decision history")
+  public ResponseEntity<ApiResponse<PagedResponse<QualityDecisionDto>>> history(
+      @PathVariable UUID batchId, @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            PagedResponse.from(queryService.getHistory(batchId, pageable), mapper::toDto)));
+  }
+
+  @GetMapping("/batches/{batchId}/units")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(operationId = "listQualityDecisionUnits", summary = "List batch units for QC")
+  public ResponseEntity<ApiResponse<PagedResponse<QualityDecisionUnitDto>>> units(
+      @PathVariable UUID batchId,
+      @ParameterObject @PageableDefault(size = 20, sort = "barcode") Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            PagedResponse.from(queryService.getUnits(batchId, pageable), mapper::toUnitDto)));
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionCommand.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionCommand.java
@@ -1,0 +1,16 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
+import java.util.Set;
+import java.util.UUID;
+
+public record QualityDecisionCommand(
+    UUID batchId,
+    QualityDecisionScope scope,
+    QualityDecisionOutcome outcome,
+    QualityReasonCode reasonCode,
+    String remarks,
+    Set<UUID> stockUnitIds,
+    UUID supersedesDecisionId) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
@@ -1,0 +1,64 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class QualityDecisionQueryService {
+
+  private static final Set<StockUnitStatus> DECISION_ELIGIBLE_STATUSES =
+      EnumSet.of(
+          StockUnitStatus.AVAILABLE,
+          StockUnitStatus.PARTIAL,
+          StockUnitStatus.QUARANTINE,
+          StockUnitStatus.ON_HOLD);
+
+  private final QualityDecisionRepository decisionRepository;
+  private final StockUnitRepository stockUnitRepository;
+
+  public QualityDecisionQueryService(
+      QualityDecisionRepository decisionRepository, StockUnitRepository stockUnitRepository) {
+    this.decisionRepository = decisionRepository;
+    this.stockUnitRepository = stockUnitRepository;
+  }
+
+  public Page<QualityQueueItemDto> getQueue(Pageable pageable) {
+    UUID tenantId = TenantContext.requireTenantId();
+    return stockUnitRepository
+        .findQualityQueue(tenantId, pageable)
+        .map(
+            row ->
+                new QualityQueueItemDto(
+                    row.getBatchId(),
+                    row.getBatchCode(),
+                    row.getProductId(),
+                    ProductType.valueOf(row.getProductType()),
+                    row.getSupplierBatchCode(),
+                    row.getPendingUnitCount(),
+                    row.getCreatedAt()));
+  }
+
+  public Page<QualityDecision> getHistory(UUID batchId, Pageable pageable) {
+    return decisionRepository.findByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(
+        TenantContext.requireTenantId(), batchId, pageable);
+  }
+
+  public Page<StockUnit> getUnits(UUID batchId, Pageable pageable) {
+    return stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+        TenantContext.requireTenantId(), batchId, DECISION_ELIGIBLE_STATUSES, pageable);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
@@ -41,7 +41,20 @@ public class QualityDecisionService {
           StockUnitStatus.QUARANTINE,
           StockUnitStatus.ON_HOLD);
 
-  private static final Set<BatchStatus> ACTIVE_OR_TERMINAL_BATCH_STATUSES =
+  private static final Set<BatchStatus> FULL_LOT_BLOCKED_BATCH_STATUSES =
+      EnumSet.of(
+          BatchStatus.RESERVED,
+          BatchStatus.IN_PROGRESS,
+          BatchStatus.ON_HOLD,
+          BatchStatus.DEPLETED,
+          BatchStatus.RETURNED,
+          BatchStatus.DESTROYED);
+
+  private static final Set<BatchStatus> SELECTED_UNITS_BLOCKED_BATCH_STATUSES =
+      EnumSet.of(
+          BatchStatus.RESERVED, BatchStatus.DEPLETED, BatchStatus.RETURNED, BatchStatus.DESTROYED);
+
+  private static final Set<BatchStatus> PROJECTION_BLOCKED_BATCH_STATUSES =
       EnumSet.of(
           BatchStatus.RESERVED,
           BatchStatus.IN_PROGRESS,
@@ -81,7 +94,7 @@ public class QualityDecisionService {
         return assertIdempotentEventMatchesCommand(concurrentWinner.get(), command);
       }
     }
-    assertBatchAllowsDecision(batch);
+    assertBatchAllowsDecision(batch, command.scope());
 
     List<StockUnit> population = lockPopulation(tenantId, command, batch);
     validateSupersedes(tenantId, command, batch);
@@ -120,8 +133,10 @@ public class QualityDecisionService {
       throw QualityDecisionException.populationDrift();
     }
 
-    applyBatchProjection(tenantId, batch);
-    batchRepository.save(batch);
+    if (allowsQualityProjection(batch)) {
+      applyBatchProjection(tenantId, batch);
+      batchRepository.save(batch);
+    }
     log.info(
         "Recorded quality decision: tenantId={}, batchId={}, decisionId={}, outcome={}, units={}",
         tenantId,
@@ -221,12 +236,23 @@ public class QualityDecisionService {
     return existing;
   }
 
-  private void assertBatchAllowsDecision(Batch batch) {
-    if (ACTIVE_OR_TERMINAL_BATCH_STATUSES.contains(batch.getStatus())
-        || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0
-        || batch.getConsumedQuantity().compareTo(BigDecimal.ZERO) > 0) {
+  private void assertBatchAllowsDecision(Batch batch, QualityDecisionScope scope) {
+    boolean blocked =
+        scope == QualityDecisionScope.FULL_LOT
+            ? FULL_LOT_BLOCKED_BATCH_STATUSES.contains(batch.getStatus())
+                || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0
+                || batch.getConsumedQuantity().compareTo(BigDecimal.ZERO) > 0
+            : SELECTED_UNITS_BLOCKED_BATCH_STATUSES.contains(batch.getStatus())
+                || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0;
+    if (blocked) {
       throw QualityDecisionException.batchActive(batch.getStatus().name());
     }
+  }
+
+  private boolean allowsQualityProjection(Batch batch) {
+    return !PROJECTION_BLOCKED_BATCH_STATUSES.contains(batch.getStatus())
+        && batch.getReservedQuantity().compareTo(BigDecimal.ZERO) == 0
+        && batch.getConsumedQuantity().compareTo(BigDecimal.ZERO) == 0;
   }
 
   private void applyBatchProjection(UUID tenantId, Batch batch) {

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
@@ -1,0 +1,332 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionUnit;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
+import com.fabricmanagement.production.quality.decision.domain.exception.QualityDecisionException;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionUnitRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QualityDecisionService {
+
+  private static final Set<StockUnitStatus> DECISION_ELIGIBLE_STATUSES =
+      EnumSet.of(
+          StockUnitStatus.AVAILABLE,
+          StockUnitStatus.PARTIAL,
+          StockUnitStatus.QUARANTINE,
+          StockUnitStatus.ON_HOLD);
+
+  private static final Set<BatchStatus> ACTIVE_OR_TERMINAL_BATCH_STATUSES =
+      EnumSet.of(
+          BatchStatus.RESERVED,
+          BatchStatus.IN_PROGRESS,
+          BatchStatus.ON_HOLD,
+          BatchStatus.DEPLETED,
+          BatchStatus.RETURNED,
+          BatchStatus.DESTROYED);
+
+  private final BatchRepository batchRepository;
+  private final StockUnitRepository stockUnitRepository;
+  private final QualityDecisionRepository decisionRepository;
+  private final QualityDecisionUnitRepository decisionUnitRepository;
+
+  @Transactional
+  public QualityDecision recordDecision(
+      TrustedDecisionContext context, QualityDecisionCommand command) {
+    UUID tenantId = TenantContext.requireTenantId();
+    validateContext(context);
+    validateCommand(context, command);
+
+    if (context.sourceEventId() != null) {
+      var existing =
+          decisionRepository.findByTenantIdAndSourceEventId(tenantId, context.sourceEventId());
+      if (existing.isPresent()) {
+        return assertIdempotentEventMatchesCommand(existing.get(), command);
+      }
+    }
+
+    Batch batch =
+        batchRepository
+            .findByIdAndTenantIdForUpdate(command.batchId(), tenantId)
+            .orElseThrow(() -> new NotFoundException("Batch not found: " + command.batchId()));
+    if (context.sourceEventId() != null) {
+      var concurrentWinner =
+          decisionRepository.findByTenantIdAndSourceEventId(tenantId, context.sourceEventId());
+      if (concurrentWinner.isPresent()) {
+        return assertIdempotentEventMatchesCommand(concurrentWinner.get(), command);
+      }
+    }
+    assertBatchAllowsDecision(batch);
+
+    List<StockUnit> population = lockPopulation(tenantId, command, batch);
+    validateSupersedes(tenantId, command, batch);
+
+    long seq = decisionRepository.findMaxSeq(tenantId, batch.getId()) + 1;
+    Instant now = Instant.now();
+    QualityDecision decision =
+        QualityDecision.create(
+            tenantId,
+            batch.getId(),
+            command.scope(),
+            command.outcome(),
+            command.reasonCode(),
+            normalizedRemarks(command.remarks()),
+            context.actorId(),
+            context.origin(),
+            context.sourceEventId(),
+            command.supersedesDecisionId(),
+            seq,
+            now);
+    decisionRepository.save(decision);
+    decisionUnitRepository.saveAll(
+        population.stream()
+            .map(unit -> QualityDecisionUnit.of(tenantId, decision.getId(), unit.getId()))
+            .toList());
+
+    List<UUID> populationIds = population.stream().map(StockUnit::getId).toList();
+    int affected =
+        stockUnitRepository.applyQualityDisposition(
+            tenantId,
+            batch.getId(),
+            populationIds,
+            DECISION_ELIGIBLE_STATUSES,
+            command.outcome().toDisposition());
+    if (affected != populationIds.size()) {
+      throw QualityDecisionException.populationDrift();
+    }
+
+    applyBatchProjection(tenantId, batch);
+    batchRepository.save(batch);
+    log.info(
+        "Recorded quality decision: tenantId={}, batchId={}, decisionId={}, outcome={}, units={}",
+        tenantId,
+        batch.getId(),
+        decision.getId(),
+        decision.getOutcome(),
+        population.size());
+    return decision;
+  }
+
+  @Transactional
+  public QualityDecision releaseFromQc(UUID batchId) {
+    return recordDecision(
+        TrustedDecisionContext.systemRelease(TenantContext.SYSTEM_ACTOR_ID),
+        new QualityDecisionCommand(
+            batchId,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.RELEASED,
+            QualityReasonCode.SYSTEM_QC_PASSED,
+            null,
+            Set.of(),
+            null));
+  }
+
+  /** Compatibility path for the legacy batch override action; the ledger remains authoritative. */
+  @Transactional
+  public QualityDecision overrideToReleased(UUID batchId, String reason) {
+    UUID tenantId = TenantContext.requireTenantId();
+    batchRepository
+        .findByIdAndTenantIdForUpdate(batchId, tenantId)
+        .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
+    UUID supersedesDecisionId =
+        decisionRepository
+            .findFirstByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(tenantId, batchId)
+            .map(QualityDecision::getId)
+            .orElse(null);
+    return recordDecision(
+        TrustedDecisionContext.manual(TenantContext.getCurrentUserId()),
+        new QualityDecisionCommand(
+            batchId,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            reason,
+            Set.of(),
+            supersedesDecisionId));
+  }
+
+  private List<StockUnit> lockPopulation(
+      UUID tenantId, QualityDecisionCommand command, Batch batch) {
+    if (command.scope() == QualityDecisionScope.FULL_LOT) {
+      long activeCount =
+          stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(tenantId, batch.getId());
+      List<StockUnit> population =
+          stockUnitRepository.lockDecisionPopulation(
+              tenantId, batch.getId(), DECISION_ELIGIBLE_STATUSES);
+      if (population.isEmpty()) {
+        throw QualityDecisionException.noUnits();
+      }
+      if (population.size() != activeCount) {
+        throw QualityDecisionException.populationDrift();
+      }
+      return population;
+    }
+
+    Set<UUID> requestedIds = command.stockUnitIds();
+    List<StockUnit> population =
+        stockUnitRepository.lockSelectedDecisionPopulation(
+            tenantId, batch.getId(), requestedIds, DECISION_ELIGIBLE_STATUSES);
+    if (population.size() != requestedIds.size()) {
+      throw QualityDecisionException.unitMismatch();
+    }
+    return population;
+  }
+
+  private void validateSupersedes(UUID tenantId, QualityDecisionCommand command, Batch batch) {
+    if (command.supersedesDecisionId() == null) {
+      return;
+    }
+    QualityDecision superseded =
+        decisionRepository
+            .findByIdAndTenantId(command.supersedesDecisionId(), tenantId)
+            .orElseThrow(QualityDecisionException::supersedesInvalid);
+    if (!superseded.getBatchId().equals(batch.getId())) {
+      throw QualityDecisionException.supersedesInvalid();
+    }
+  }
+
+  private QualityDecision assertIdempotentEventMatchesCommand(
+      QualityDecision existing, QualityDecisionCommand command) {
+    if (!existing.getBatchId().equals(command.batchId())
+        || existing.getDecisionScope() != command.scope()
+        || existing.getOutcome() != command.outcome()
+        || existing.getReasonCode() != command.reasonCode()) {
+      throw QualityDecisionException.sourceEventConflict();
+    }
+    return existing;
+  }
+
+  private void assertBatchAllowsDecision(Batch batch) {
+    if (ACTIVE_OR_TERMINAL_BATCH_STATUSES.contains(batch.getStatus())
+        || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0
+        || batch.getConsumedQuantity().compareTo(BigDecimal.ZERO) > 0) {
+      throw QualityDecisionException.batchActive(batch.getStatus().name());
+    }
+  }
+
+  private void applyBatchProjection(UUID tenantId, Batch batch) {
+    var counts = stockUnitRepository.countQualityDispositions(tenantId, batch.getId());
+    long total =
+        counts.stream().mapToLong(StockUnitRepository.QualityDispositionCount::getUnitCount).sum();
+    BatchStatus target = BatchStatus.QUARANTINE;
+    if (counts.size() == 1 && total > 0) {
+      QualityDisposition disposition = counts.get(0).getDisposition();
+      target =
+          switch (disposition) {
+            case RELEASED -> BatchStatus.AVAILABLE;
+            case PENDING_INSPECTION -> BatchStatus.PENDING_QC;
+            case NONCONFORMING -> BatchStatus.QC_REJECTED;
+            case QUARANTINED -> BatchStatus.QUARANTINE;
+          };
+    }
+    batch.applyQualityProjection(target);
+  }
+
+  private void validateContext(TrustedDecisionContext context) {
+    if (context == null || context.actorId() == null || context.origin() == null) {
+      throw QualityDecisionException.actorMissing();
+    }
+    if (context.origin() == QualityDecisionOrigin.SYSTEM_QC_EVENT
+        && context.sourceEventId() == null) {
+      throw QualityDecisionException.commandInvalid("SYSTEM_QC_EVENT requires sourceEventId");
+    }
+    if (context.origin() != QualityDecisionOrigin.SYSTEM_QC_EVENT
+        && context.sourceEventId() != null) {
+      throw QualityDecisionException.commandInvalid("sourceEventId is reserved for QC events");
+    }
+    if (context.origin() == QualityDecisionOrigin.MIGRATION_BACKFILL) {
+      throw QualityDecisionException.commandInvalid("MIGRATION_BACKFILL is migration-only");
+    }
+  }
+
+  private void validateCommand(TrustedDecisionContext context, QualityDecisionCommand command) {
+    if (command == null
+        || command.batchId() == null
+        || command.scope() == null
+        || command.outcome() == null) {
+      throw QualityDecisionException.commandInvalid("batchId, scope and outcome are required");
+    }
+    Set<UUID> ids = command.stockUnitIds() == null ? Set.of() : command.stockUnitIds();
+    if (command.scope() == QualityDecisionScope.FULL_LOT && !ids.isEmpty()) {
+      throw QualityDecisionException.commandInvalid("FULL_LOT must not include stockUnitIds");
+    }
+    if (command.scope() == QualityDecisionScope.SELECTED_UNITS && ids.isEmpty()) {
+      throw QualityDecisionException.commandInvalid("SELECTED_UNITS requires stockUnitIds");
+    }
+    if (command.reasonCode() == QualityReasonCode.OTHER
+        && normalizedRemarks(command.remarks()) == null) {
+      throw QualityDecisionException.remarksRequired();
+    }
+    if (!reasonAllowed(context.origin(), command.outcome(), command.reasonCode())) {
+      throw QualityDecisionException.reasonInvalid();
+    }
+  }
+
+  private boolean reasonAllowed(
+      QualityDecisionOrigin origin, QualityDecisionOutcome outcome, QualityReasonCode reasonCode) {
+    if (origin == QualityDecisionOrigin.SYSTEM_RELEASE) {
+      return outcome == QualityDecisionOutcome.RELEASED
+          && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED;
+    }
+    if (origin == QualityDecisionOrigin.SYSTEM_QC_EVENT) {
+      return (outcome == QualityDecisionOutcome.RELEASED
+              && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED)
+          || (outcome == QualityDecisionOutcome.NONCONFORMING
+              && reasonCode == QualityReasonCode.SYSTEM_QC_REJECTED);
+    }
+    if (origin != QualityDecisionOrigin.MANUAL) {
+      return false;
+    }
+    return switch (outcome) {
+      case RELEASED -> reasonCode == null;
+      case QUARANTINED ->
+          reasonCode != null
+              && Set.of(
+                      QualityReasonCode.SUSPECTED_DAMAGE,
+                      QualityReasonCode.AWAITING_LAB,
+                      QualityReasonCode.SUPPLIER_DISPUTE,
+                      QualityReasonCode.SHADE_CHECK,
+                      QualityReasonCode.OTHER)
+                  .contains(reasonCode);
+      case NONCONFORMING ->
+          reasonCode != null
+              && Set.of(
+                      QualityReasonCode.DAMAGE,
+                      QualityReasonCode.STAIN,
+                      QualityReasonCode.SHADE_VARIATION,
+                      QualityReasonCode.SHORT_LENGTH,
+                      QualityReasonCode.MEASURE_MISMATCH,
+                      QualityReasonCode.OTHER)
+                  .contains(reasonCode);
+    };
+  }
+
+  private String normalizedRemarks(String remarks) {
+    return remarks == null || remarks.isBlank() ? null : remarks.trim();
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/TrustedDecisionContext.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/TrustedDecisionContext.java
@@ -1,0 +1,21 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
+import java.util.UUID;
+
+/** Server-owned decision provenance. This type is never deserialized from HTTP. */
+public record TrustedDecisionContext(
+    UUID actorId, QualityDecisionOrigin origin, UUID sourceEventId) {
+
+  public static TrustedDecisionContext manual(UUID actorId) {
+    return new TrustedDecisionContext(actorId, QualityDecisionOrigin.MANUAL, null);
+  }
+
+  public static TrustedDecisionContext systemRelease(UUID systemActorId) {
+    return new TrustedDecisionContext(systemActorId, QualityDecisionOrigin.SYSTEM_RELEASE, null);
+  }
+
+  public static TrustedDecisionContext qcEvent(UUID actorId, UUID eventId) {
+    return new TrustedDecisionContext(actorId, QualityDecisionOrigin.SYSTEM_QC_EVENT, eventId);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecision.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecision.java
@@ -1,0 +1,113 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
+
+/** Append-only quality decision ledger entry. Corrections are represented by new decisions. */
+@Entity
+@Table(name = "quality_decision", schema = "production")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QualityDecision implements Persistable<UUID> {
+
+  @Id
+  @Column(name = "id", nullable = false, updatable = false)
+  private UUID id;
+
+  @Column(name = "tenant_id", nullable = false, updatable = false)
+  private UUID tenantId;
+
+  @Column(name = "batch_id", nullable = false, updatable = false)
+  private UUID batchId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "decision_scope", nullable = false, updatable = false, length = 30)
+  private QualityDecisionScope decisionScope;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "outcome", nullable = false, updatable = false, length = 30)
+  private QualityDecisionOutcome outcome;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "reason_code", updatable = false, length = 50)
+  private QualityReasonCode reasonCode;
+
+  @Column(name = "remarks", updatable = false, columnDefinition = "TEXT")
+  private String remarks;
+
+  @Column(name = "actor_id", nullable = false, updatable = false)
+  private UUID actorId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "origin", nullable = false, updatable = false, length = 40)
+  private QualityDecisionOrigin origin;
+
+  @Column(name = "source_event_id", updatable = false)
+  private UUID sourceEventId;
+
+  @Column(name = "supersedes_decision_id", updatable = false)
+  private UUID supersedesDecisionId;
+
+  @Column(name = "decided_at", nullable = false, updatable = false)
+  private Instant decidedAt;
+
+  @Column(name = "seq", nullable = false, updatable = false)
+  private long seq;
+
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private Instant createdAt;
+
+  @Override
+  public UUID getId() {
+    return id;
+  }
+
+  /** Ledger entries are insert-only; Spring Data must never select/merge by the assigned UUID. */
+  @Override
+  @Transient
+  public boolean isNew() {
+    return true;
+  }
+
+  public static QualityDecision create(
+      UUID tenantId,
+      UUID batchId,
+      QualityDecisionScope decisionScope,
+      QualityDecisionOutcome outcome,
+      QualityReasonCode reasonCode,
+      String remarks,
+      UUID actorId,
+      QualityDecisionOrigin origin,
+      UUID sourceEventId,
+      UUID supersedesDecisionId,
+      long seq,
+      Instant decidedAt) {
+    QualityDecision decision = new QualityDecision();
+    decision.id = UUID.randomUUID();
+    decision.tenantId = tenantId;
+    decision.batchId = batchId;
+    decision.decisionScope = decisionScope;
+    decision.outcome = outcome;
+    decision.reasonCode = reasonCode;
+    decision.remarks = remarks;
+    decision.actorId = actorId;
+    decision.origin = origin;
+    decision.sourceEventId = sourceEventId;
+    decision.supersedesDecisionId = supersedesDecisionId;
+    decision.seq = seq;
+    decision.decidedAt = decidedAt;
+    decision.createdAt = decidedAt;
+    return decision;
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionOrigin.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionOrigin.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+public enum QualityDecisionOrigin {
+  MANUAL,
+  SYSTEM_RELEASE,
+  SYSTEM_QC_EVENT,
+  MIGRATION_BACKFILL
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionOutcome.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionOutcome.java
@@ -1,0 +1,13 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+
+public enum QualityDecisionOutcome {
+  RELEASED,
+  QUARANTINED,
+  NONCONFORMING;
+
+  public QualityDisposition toDisposition() {
+    return QualityDisposition.valueOf(name());
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionScope.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionScope.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+public enum QualityDecisionScope {
+  FULL_LOT,
+  SELECTED_UNITS
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionUnit.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionUnit.java
@@ -1,0 +1,55 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Persistable;
+
+/** Append-only population snapshot row for a quality decision. */
+@Entity
+@Table(name = "quality_decision_unit", schema = "production")
+@IdClass(QualityDecisionUnitId.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QualityDecisionUnit implements Persistable<QualityDecisionUnitId> {
+
+  @Id
+  @Column(name = "tenant_id", nullable = false, updatable = false)
+  private UUID tenantId;
+
+  @Id
+  @Column(name = "decision_id", nullable = false, updatable = false)
+  private UUID decisionId;
+
+  @Id
+  @Column(name = "stock_unit_id", nullable = false, updatable = false)
+  private UUID stockUnitId;
+
+  @Override
+  @Transient
+  public QualityDecisionUnitId getId() {
+    return new QualityDecisionUnitId(tenantId, decisionId, stockUnitId);
+  }
+
+  /** Population snapshots are insert-only and use assigned composite keys. */
+  @Override
+  @Transient
+  public boolean isNew() {
+    return true;
+  }
+
+  public static QualityDecisionUnit of(UUID tenantId, UUID decisionId, UUID stockUnitId) {
+    QualityDecisionUnit unit = new QualityDecisionUnit();
+    unit.tenantId = tenantId;
+    unit.decisionId = decisionId;
+    unit.stockUnitId = stockUnitId;
+    return unit;
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionUnitId.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionUnitId.java
@@ -1,0 +1,37 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class QualityDecisionUnitId implements Serializable {
+  @Serial private static final long serialVersionUID = 1L;
+
+  private UUID tenantId;
+  private UUID decisionId;
+  private UUID stockUnitId;
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof QualityDecisionUnitId that)) {
+      return false;
+    }
+    return Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(decisionId, that.decisionId)
+        && Objects.equals(stockUnitId, that.stockUnitId);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tenantId, decisionId, stockUnitId);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityReasonCode.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityReasonCode.java
@@ -1,0 +1,17 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+public enum QualityReasonCode {
+  SUSPECTED_DAMAGE,
+  AWAITING_LAB,
+  SUPPLIER_DISPUTE,
+  SHADE_CHECK,
+  DAMAGE,
+  STAIN,
+  SHADE_VARIATION,
+  SHORT_LENGTH,
+  MEASURE_MISMATCH,
+  OTHER,
+  SYSTEM_QC_PASSED,
+  SYSTEM_QC_REJECTED,
+  MIGRATION_BASELINE
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/exception/QualityDecisionException.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/exception/QualityDecisionException.java
@@ -1,0 +1,71 @@
+package com.fabricmanagement.production.quality.decision.domain.exception;
+
+import com.fabricmanagement.production.common.exception.ProductionDomainException;
+
+public class QualityDecisionException extends ProductionDomainException {
+
+  private QualityDecisionException(String message, String code, int status) {
+    super(message, code, status);
+  }
+
+  public static QualityDecisionException noUnits() {
+    return new QualityDecisionException(
+        "Batch has no eligible StockUnits for a quality decision", "QC_DECISION_NO_UNITS", 422);
+  }
+
+  public static QualityDecisionException unitMismatch() {
+    return new QualityDecisionException(
+        "Selected StockUnits must be active, eligible, tenant-owned, and belong to the batch",
+        "QC_DECISION_UNIT_MISMATCH",
+        422);
+  }
+
+  public static QualityDecisionException populationDrift() {
+    return new QualityDecisionException(
+        "Quality decision population changed while the decision was being applied",
+        "QC_DECISION_POPULATION_DRIFT",
+        409);
+  }
+
+  public static QualityDecisionException batchActive(String status) {
+    return new QualityDecisionException(
+        "Quality decision is not allowed for active or terminal batch status " + status,
+        "QC_DECISION_BATCH_ACTIVE",
+        409);
+  }
+
+  public static QualityDecisionException reasonInvalid() {
+    return new QualityDecisionException(
+        "Reason code is not valid for the requested outcome and origin",
+        "QC_DECISION_REASON_INVALID",
+        422);
+  }
+
+  public static QualityDecisionException remarksRequired() {
+    return new QualityDecisionException(
+        "Remarks are required when reasonCode is OTHER", "QC_DECISION_REMARKS_REQUIRED", 422);
+  }
+
+  public static QualityDecisionException commandInvalid(String message) {
+    return new QualityDecisionException(message, "QC_DECISION_COMMAND_INVALID", 422);
+  }
+
+  public static QualityDecisionException supersedesInvalid() {
+    return new QualityDecisionException(
+        "supersedesDecisionId must identify an earlier decision for the same batch",
+        "QC_DECISION_SUPERSEDES_INVALID",
+        422);
+  }
+
+  public static QualityDecisionException actorMissing() {
+    return new QualityDecisionException(
+        "A trusted decision actor is required", "QC_DECISION_ACTOR_REQUIRED", 500);
+  }
+
+  public static QualityDecisionException sourceEventConflict() {
+    return new QualityDecisionException(
+        "sourceEventId is already bound to a different quality decision",
+        "QC_DECISION_SOURCE_EVENT_CONFLICT",
+        409);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionDto.java
@@ -1,0 +1,22 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
+import java.time.Instant;
+import java.util.UUID;
+
+public record QualityDecisionDto(
+    UUID id,
+    UUID batchId,
+    QualityDecisionScope scope,
+    QualityDecisionOutcome outcome,
+    QualityReasonCode reasonCode,
+    String remarks,
+    UUID actorId,
+    QualityDecisionOrigin origin,
+    UUID sourceEventId,
+    UUID supersedesDecisionId,
+    Instant decidedAt,
+    long sequence) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
@@ -1,0 +1,18 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record QualityDecisionUnitDto(
+    UUID id,
+    String barcode,
+    PackageType packageType,
+    BigDecimal currentWeight,
+    String unit,
+    BigDecimal length,
+    String lengthUnit,
+    StockUnitStatus status,
+    QualityDisposition qualityDisposition) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityQueueItemDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityQueueItemDto.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.time.Instant;
+import java.util.UUID;
+
+public record QualityQueueItemDto(
+    UUID batchId,
+    String batchCode,
+    UUID productId,
+    ProductType productType,
+    String supplierBatchCode,
+    long pendingUnitCount,
+    Instant receivedAt) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/RecordQualityDecisionRequest.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/RecordQualityDecisionRequest.java
@@ -1,0 +1,31 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionCommand;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.Set;
+import java.util.UUID;
+
+public record RecordQualityDecisionRequest(
+    @NotNull @Schema(requiredMode = Schema.RequiredMode.REQUIRED) QualityDecisionScope scope,
+    @NotNull @Schema(requiredMode = Schema.RequiredMode.REQUIRED) QualityDecisionOutcome outcome,
+    QualityReasonCode reasonCode,
+    @Size(max = 2000) String remarks,
+    Set<@NotNull UUID> stockUnitIds,
+    UUID supersedesDecisionId) {
+
+  public QualityDecisionCommand toCommand(UUID batchId) {
+    return new QualityDecisionCommand(
+        batchId,
+        scope,
+        outcome,
+        reasonCode,
+        remarks,
+        stockUnitIds == null ? Set.of() : Set.copyOf(stockUnitIds),
+        supersedesDecisionId);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/infra/repository/QualityDecisionRepository.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/infra/repository/QualityDecisionRepository.java
@@ -1,0 +1,33 @@
+package com.fabricmanagement.production.quality.decision.infra.repository;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QualityDecisionRepository extends JpaRepository<QualityDecision, UUID> {
+
+  @Query(
+      """
+      SELECT COALESCE(MAX(d.seq), 0)
+      FROM QualityDecision d
+      WHERE d.tenantId = :tenantId AND d.batchId = :batchId
+      """)
+  long findMaxSeq(@Param("tenantId") UUID tenantId, @Param("batchId") UUID batchId);
+
+  Optional<QualityDecision> findByIdAndTenantId(UUID id, UUID tenantId);
+
+  Optional<QualityDecision> findByTenantIdAndSourceEventId(UUID tenantId, UUID sourceEventId);
+
+  Optional<QualityDecision> findFirstByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(
+      UUID tenantId, UUID batchId);
+
+  Page<QualityDecision> findByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(
+      UUID tenantId, UUID batchId, Pageable pageable);
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/infra/repository/QualityDecisionUnitRepository.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/infra/repository/QualityDecisionUnitRepository.java
@@ -1,0 +1,14 @@
+package com.fabricmanagement.production.quality.decision.infra.repository;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionUnit;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionUnitId;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QualityDecisionUnitRepository
+    extends JpaRepository<QualityDecisionUnit, QualityDecisionUnitId> {
+
+  long countByTenantIdAndDecisionId(UUID tenantId, UUID decisionId);
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
@@ -1,0 +1,19 @@
+package com.fabricmanagement.production.quality.decision.mapper;
+
+import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(config = MapStructConfig.class)
+public interface QualityDecisionMapper {
+
+  @Mapping(target = "scope", source = "decisionScope")
+  @Mapping(target = "sequence", source = "seq")
+  QualityDecisionDto toDto(QualityDecision decision);
+
+  QualityDecisionUnitDto toUnitDto(StockUnit stockUnit);
+}

--- a/src/main/java/com/fabricmanagement/production/quality/result/api/controller/FiberTestResultController.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/api/controller/FiberTestResultController.java
@@ -82,7 +82,7 @@ public class FiberTestResultController {
   }
 
   @PatchMapping("/{id}/approval")
-  @PreAuthorize("@auth.can(authentication, 'quality', 'write')")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'approve')")
   public ResponseEntity<ApiResponse<FiberTestResultDto>> updateApproval(
       @PathVariable UUID id, @Valid @RequestBody UpdateApprovalRequest request) {
     log.info("Updating test approval: id={}, status={}", id, request.getApprovalStatus());

--- a/src/main/java/com/fabricmanagement/production/quality/result/app/FiberQcAutoEvaluator.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/app/FiberQcAutoEvaluator.java
@@ -26,7 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
  *   <li>If standard exists: compares all values to min/target/max:
  *       <ul>
  *         <li>All within min-max, all at target → APPROVED → AVAILABLE
- *         <li>All within min-max, one+ outside target → CONDITIONAL_ACCEPT → QUARANTINE
+ *         <li>All within min-max, one+ outside target → CONDITIONAL_ACCEPT → concession review
  *         <li>One+ outside min or max → REJECTED → QC_REJECTED
  *       </ul>
  * </ul>

--- a/src/main/java/com/fabricmanagement/production/quality/result/domain/event/FiberTestResultApprovedEvent.java
+++ b/src/main/java/com/fabricmanagement/production/quality/result/domain/event/FiberTestResultApprovedEvent.java
@@ -12,8 +12,8 @@ import lombok.Getter;
  * Published when a fiber test result receives an approval decision (APPROVED, REJECTED,
  * CONDITIONAL_ACCEPT).
  *
- * <p>Listeners (e.g. BatchStatusUpdateListener) use this to transition the associated batch from
- * PENDING_QC to AVAILABLE (on APPROVED/CONDITIONAL_ACCEPT) or QC_REJECTED (on REJECTED).
+ * <p>The QC decision listener records APPROVED/REJECTED as immutable quality decisions.
+ * CONDITIONAL_ACCEPT remains pending and requests a separate concession review.
  */
 @Getter
 public class FiberTestResultApprovedEvent extends DomainEvent {

--- a/src/main/resources/db/migration/V20260721120000__quality_decision_release_model.sql
+++ b/src/main/resources/db/migration/V20260721120000__quality_decision_release_model.sql
@@ -1,0 +1,274 @@
+ALTER TABLE production.production_execution_batch
+    ADD CONSTRAINT uq_batch_id_tenant UNIQUE (id, tenant_id);
+
+ALTER TABLE production.stock_unit
+    ADD CONSTRAINT uq_stock_unit_id_tenant UNIQUE (id, tenant_id);
+
+-- The decision service locks the batch before freezing its StockUnit population. This tenant-safe
+-- FK makes concurrent StockUnit inserts take a key-share lock on that same batch row, so they
+-- cannot slip in between the population snapshot and the compatibility projection.
+ALTER TABLE production.stock_unit
+    ADD CONSTRAINT fk_stock_unit_batch_tenant
+        FOREIGN KEY (batch_id, tenant_id)
+        REFERENCES production.production_execution_batch (id, tenant_id)
+        ON DELETE RESTRICT;
+
+ALTER TABLE production.stock_unit
+    ADD COLUMN quality_disposition VARCHAR(30);
+
+UPDATE production.stock_unit su
+SET quality_disposition = CASE
+    WHEN su.status = 'QUARANTINE' THEN 'QUARANTINED'
+    WHEN batch.status = 'PENDING_QC' THEN 'PENDING_INSPECTION'
+    WHEN batch.status = 'QUARANTINE' THEN 'QUARANTINED'
+    WHEN batch.status = 'QC_REJECTED' THEN 'NONCONFORMING'
+    WHEN batch.status IN ('AVAILABLE', 'RESERVED', 'IN_PROGRESS', 'ON_HOLD', 'DEPLETED')
+        THEN 'RELEASED'
+    WHEN batch.status IN ('RETURNED', 'DESTROYED') THEN 'NONCONFORMING'
+END
+FROM production.production_execution_batch batch
+WHERE batch.id = su.batch_id
+  AND batch.tenant_id = su.tenant_id;
+
+DO $$
+DECLARE
+    legacy_quarantine_count BIGINT;
+    legacy_quarantine_ids UUID[];
+BEGIN
+    SELECT count(*)
+    INTO legacy_quarantine_count
+    FROM production.stock_unit
+    WHERE status = 'QUARANTINE';
+
+    SELECT array_agg(id ORDER BY id)
+    INTO legacy_quarantine_ids
+    FROM (
+        SELECT id
+        FROM production.stock_unit
+        WHERE status = 'QUARANTINE'
+        ORDER BY id
+        LIMIT 100
+    ) legacy;
+
+    IF legacy_quarantine_count > 0 THEN
+        RAISE NOTICE
+            'QC-RELEASE-1a retained % legacy QUARANTINE StockUnits for manual operational-status review; first ids: %',
+            legacy_quarantine_count,
+            legacy_quarantine_ids;
+    END IF;
+END $$;
+
+DO $$
+DECLARE
+    unmapped_count BIGINT;
+BEGIN
+    SELECT COUNT(*)
+    INTO unmapped_count
+    FROM production.stock_unit
+    WHERE quality_disposition IS NULL;
+
+    IF unmapped_count > 0 THEN
+        RAISE EXCEPTION
+            'QC-RELEASE-1a cannot map % stock_unit rows to quality_disposition; manual review required',
+            unmapped_count;
+    END IF;
+END $$;
+
+ALTER TABLE production.stock_unit
+    ALTER COLUMN quality_disposition SET NOT NULL,
+    ADD CONSTRAINT chk_stock_unit_quality_disposition
+        CHECK (quality_disposition IN (
+            'PENDING_INSPECTION', 'RELEASED', 'QUARANTINED', 'NONCONFORMING'
+        ));
+
+CREATE TABLE IF NOT EXISTS production.quality_decision (
+    id                       UUID PRIMARY KEY,
+    tenant_id                UUID NOT NULL,
+    batch_id                 UUID NOT NULL,
+    decision_scope           VARCHAR(30) NOT NULL,
+    outcome                  VARCHAR(30) NOT NULL,
+    reason_code              VARCHAR(50),
+    remarks                  TEXT,
+    actor_id                 UUID NOT NULL,
+    origin                   VARCHAR(40) NOT NULL,
+    source_event_id          UUID,
+    supersedes_decision_id   UUID,
+    decided_at               TIMESTAMPTZ NOT NULL,
+    seq                      BIGINT NOT NULL,
+    created_at               TIMESTAMPTZ NOT NULL,
+
+    CONSTRAINT uq_quality_decision_id_tenant UNIQUE (id, tenant_id),
+    CONSTRAINT uq_quality_decision_batch_seq UNIQUE (tenant_id, batch_id, seq),
+    CONSTRAINT uq_quality_decision_source_event UNIQUE (tenant_id, source_event_id),
+    CONSTRAINT fk_quality_decision_batch
+        FOREIGN KEY (batch_id, tenant_id)
+        REFERENCES production.production_execution_batch (id, tenant_id),
+    CONSTRAINT fk_quality_decision_supersedes
+        FOREIGN KEY (supersedes_decision_id, tenant_id)
+        REFERENCES production.quality_decision (id, tenant_id),
+    CONSTRAINT chk_quality_decision_scope
+        CHECK (decision_scope IN ('FULL_LOT', 'SELECTED_UNITS')),
+    CONSTRAINT chk_quality_decision_outcome
+        CHECK (outcome IN ('RELEASED', 'QUARANTINED', 'NONCONFORMING')),
+    CONSTRAINT chk_quality_decision_origin
+        CHECK (origin IN (
+            'MANUAL', 'SYSTEM_RELEASE', 'SYSTEM_QC_EVENT', 'MIGRATION_BACKFILL'
+        )),
+    CONSTRAINT chk_quality_decision_source_event
+        CHECK (
+            (origin = 'SYSTEM_QC_EVENT' AND source_event_id IS NOT NULL)
+            OR (origin <> 'SYSTEM_QC_EVENT' AND source_event_id IS NULL)
+        ),
+    CONSTRAINT chk_quality_decision_reason_matrix
+        CHECK (
+            (origin = 'MANUAL' AND outcome = 'RELEASED' AND reason_code IS NULL)
+            OR (origin = 'MANUAL' AND outcome = 'QUARANTINED'
+                AND reason_code IN (
+                    'SUSPECTED_DAMAGE', 'AWAITING_LAB', 'SUPPLIER_DISPUTE',
+                    'SHADE_CHECK', 'OTHER'
+                ))
+            OR (origin = 'MANUAL' AND outcome = 'NONCONFORMING'
+                AND reason_code IN (
+                    'DAMAGE', 'STAIN', 'SHADE_VARIATION', 'SHORT_LENGTH',
+                    'MEASURE_MISMATCH', 'OTHER'
+                ))
+            OR (origin = 'SYSTEM_RELEASE' AND outcome = 'RELEASED'
+                AND reason_code = 'SYSTEM_QC_PASSED')
+            OR (origin = 'SYSTEM_QC_EVENT' AND outcome = 'RELEASED'
+                AND reason_code = 'SYSTEM_QC_PASSED')
+            OR (origin = 'SYSTEM_QC_EVENT' AND outcome = 'NONCONFORMING'
+                AND reason_code = 'SYSTEM_QC_REJECTED')
+            OR (origin = 'MIGRATION_BACKFILL' AND reason_code = 'MIGRATION_BASELINE')
+        ),
+    CONSTRAINT chk_quality_decision_other_remarks
+        CHECK (reason_code <> 'OTHER' OR NULLIF(BTRIM(remarks), '') IS NOT NULL)
+);
+
+CREATE TABLE IF NOT EXISTS production.quality_decision_unit (
+    tenant_id       UUID NOT NULL,
+    decision_id     UUID NOT NULL,
+    stock_unit_id   UUID NOT NULL,
+
+    CONSTRAINT pk_quality_decision_unit
+        PRIMARY KEY (tenant_id, decision_id, stock_unit_id),
+    CONSTRAINT fk_quality_decision_unit_decision
+        FOREIGN KEY (decision_id, tenant_id)
+        REFERENCES production.quality_decision (id, tenant_id),
+    CONSTRAINT fk_quality_decision_unit_stock_unit
+        FOREIGN KEY (stock_unit_id, tenant_id)
+        REFERENCES production.stock_unit (id, tenant_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_quality_decision_history
+    ON production.quality_decision (tenant_id, batch_id, decided_at DESC, seq DESC);
+
+CREATE INDEX IF NOT EXISTS idx_quality_decision_unit_stock
+    ON production.quality_decision_unit (tenant_id, stock_unit_id);
+
+CREATE INDEX IF NOT EXISTS idx_stock_unit_pending_quality
+    ON production.stock_unit (tenant_id, quality_disposition, batch_id)
+    WHERE is_active = TRUE;
+
+CREATE TEMP TABLE IF NOT EXISTS qc_release_baseline ON COMMIT DROP AS
+SELECT
+    gen_random_uuid() AS decision_id,
+    su.tenant_id,
+    su.batch_id,
+    su.quality_disposition AS outcome,
+    CASE
+        WHEN COUNT(*) = (
+            SELECT COUNT(*)
+            FROM production.stock_unit population
+            WHERE population.tenant_id = su.tenant_id
+              AND population.batch_id = su.batch_id
+        ) THEN 'FULL_LOT'
+        ELSE 'SELECTED_UNITS'
+    END AS decision_scope,
+    ROW_NUMBER() OVER (
+        PARTITION BY su.tenant_id, su.batch_id
+        ORDER BY su.quality_disposition
+    ) AS seq
+FROM production.stock_unit su
+WHERE su.quality_disposition <> 'PENDING_INSPECTION'
+GROUP BY su.tenant_id, su.batch_id, su.quality_disposition;
+
+INSERT INTO production.quality_decision (
+    id, tenant_id, batch_id, decision_scope, outcome, reason_code, remarks,
+    actor_id, origin, source_event_id, supersedes_decision_id, decided_at, seq, created_at
+)
+SELECT
+    decision_id,
+    tenant_id,
+    batch_id,
+    decision_scope,
+    outcome,
+    'MIGRATION_BASELINE',
+    'QC-RELEASE-1a baseline generated from the pre-cutover batch/unit state',
+    '00000000-0000-0000-0000-000000000001'::UUID,
+    'MIGRATION_BACKFILL',
+    NULL,
+    NULL,
+    clock_timestamp(),
+    seq,
+    clock_timestamp()
+FROM qc_release_baseline;
+
+INSERT INTO production.quality_decision_unit (tenant_id, decision_id, stock_unit_id)
+SELECT baseline.tenant_id, baseline.decision_id, unit.id
+FROM qc_release_baseline baseline
+JOIN production.stock_unit unit
+ ON unit.tenant_id = baseline.tenant_id
+ AND unit.batch_id = baseline.batch_id
+ AND unit.quality_disposition = baseline.outcome;
+
+CREATE OR REPLACE FUNCTION production.reject_quality_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION '% is append-only; % is forbidden', TG_TABLE_NAME, TG_OP
+        USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE TRIGGER trg_quality_decision_append_only
+    BEFORE UPDATE OR DELETE ON production.quality_decision
+    FOR EACH ROW EXECUTE FUNCTION production.reject_quality_decision_mutation();
+
+CREATE TRIGGER trg_quality_decision_unit_append_only
+    BEFORE UPDATE OR DELETE ON production.quality_decision_unit
+    FOR EACH ROW EXECUTE FUNCTION production.reject_quality_decision_mutation();
+
+ALTER TABLE production.quality_decision ENABLE ROW LEVEL SECURITY;
+ALTER TABLE production.quality_decision FORCE ROW LEVEL SECURITY;
+CREATE POLICY rls_tenant_isolation ON production.quality_decision
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::UUID);
+
+ALTER TABLE production.quality_decision_unit ENABLE ROW LEVEL SECURITY;
+ALTER TABLE production.quality_decision_unit FORCE ROW LEVEL SECURITY;
+CREATE POLICY rls_tenant_isolation ON production.quality_decision_unit
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::UUID);
+
+DO $$
+BEGIN
+    GRANT SELECT, INSERT ON TABLE
+        production.quality_decision,
+        production.quality_decision_unit
+    TO fabric_app;
+EXCEPTION WHEN undefined_object THEN
+    NULL;
+END $$;
+
+DO $$
+BEGIN
+    GRANT SELECT, INSERT ON TABLE
+        production.quality_decision,
+        production.quality_decision_unit
+    TO fabric_system;
+EXCEPTION WHEN undefined_object THEN
+    NULL;
+END $$;

--- a/src/main/resources/db/migration/V20260721125000__quality_decision_tenant_purge.sql
+++ b/src/main/resources/db/migration/V20260721125000__quality_decision_tenant_purge.sql
@@ -1,0 +1,58 @@
+-- QC-RELEASE-1a follow-up: allow the system tenant-reset transaction to remove ledger rows
+-- without weakening append-only behavior for normal application traffic.
+
+CREATE OR REPLACE FUNCTION production.reject_quality_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    purge_tenant TEXT := current_setting('app.quality_decision_purge_tenant', true);
+    trusted_purge_role BOOLEAN;
+BEGIN
+    SELECT
+        EXISTS (
+            SELECT 1
+            FROM pg_roles active_role
+            WHERE active_role.rolname = current_user
+              AND active_role.rolsuper
+        )
+        OR current_user = 'fabric_system'
+        OR EXISTS (
+            SELECT 1
+            FROM pg_roles system_role
+            WHERE system_role.rolname = 'fabric_system'
+              AND pg_has_role(current_user, system_role.oid, 'MEMBER')
+        )
+    INTO trusted_purge_role;
+
+    IF TG_OP = 'DELETE'
+       AND trusted_purge_role
+       AND purge_tenant = OLD.tenant_id::TEXT THEN
+        RETURN OLD;
+    END IF;
+
+    RAISE EXCEPTION '% is append-only; % is forbidden', TG_TABLE_NAME, TG_OP
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_app') THEN
+        REVOKE UPDATE, DELETE ON TABLE
+            production.quality_decision,
+            production.quality_decision_unit
+        FROM fabric_app;
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_system') THEN
+        REVOKE UPDATE ON TABLE
+            production.quality_decision,
+            production.quality_decision_unit
+        FROM fabric_system;
+        GRANT DELETE ON TABLE
+            production.quality_decision,
+            production.quality_decision_unit
+        TO fabric_system;
+    END IF;
+END $$;

--- a/src/main/resources/db/migration/V20260721130000__warehouse_location_quality_area.sql
+++ b/src/main/resources/db/migration/V20260721130000__warehouse_location_quality_area.sql
@@ -1,0 +1,6 @@
+ALTER TABLE iwm.warehouse_location
+    ADD COLUMN is_quality_area BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_warehouse_location_tenant_quality_area
+    ON iwm.warehouse_location (tenant_id, is_active)
+    WHERE is_quality_area = TRUE;

--- a/src/main/resources/db/rollback/V20260721125000_ROLLBACK__quality_decision_tenant_purge.sql
+++ b/src/main/resources/db/rollback/V20260721125000_ROLLBACK__quality_decision_tenant_purge.sql
@@ -1,0 +1,19 @@
+CREATE OR REPLACE FUNCTION production.reject_quality_decision_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    RAISE EXCEPTION '% is append-only; % is forbidden', TG_TABLE_NAME, TG_OP
+        USING ERRCODE = '55000';
+END;
+$$;
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'fabric_system') THEN
+        REVOKE UPDATE, DELETE ON TABLE
+            production.quality_decision,
+            production.quality_decision_unit
+        FROM fabric_system;
+    END IF;
+END $$;

--- a/src/main/resources/db/rollback/V20260721130000_ROLLBACK__warehouse_location_quality_area.sql
+++ b/src/main/resources/db/rollback/V20260721130000_ROLLBACK__warehouse_location_quality_area.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS iwm.idx_warehouse_location_tenant_quality_area;
+
+ALTER TABLE iwm.warehouse_location
+    DROP COLUMN IF EXISTS is_quality_area;

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -205,6 +205,8 @@ class ConstitutionArchTest {
       //   - TradingPartnerRegistry  : Platform-wide registry; no tenant scope by design
       //   - EmployeeNumberSequence  : tenantId IS the @Id (per-tenant singleton counter)
       //   - BatchOverrideLog        : Append-only audit log; soft-delete/version semantics N/A
+      //   - QualityDecision         : Append-only QC ledger; mutation/version semantics forbidden
+      //   - QualityDecisionUnit     : Append-only population snapshot with a composite primary key
       //   - Lead                    : Tenant-independent marketing record; linked via nullable
       //                               trialTenantId and must survive tenant lifecycle events
       //   - UserDepartment          : Junction table with composite @IdClass key; incompatible with
@@ -235,6 +237,10 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("EmployeeNumberSequence")
               .and()
               .doNotHaveSimpleName("BatchOverrideLog")
+              .and()
+              .doNotHaveSimpleName("QualityDecision")
+              .and()
+              .doNotHaveSimpleName("QualityDecisionUnit")
               .and()
               .doNotHaveSimpleName("Lead")
               .and()

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/PermissionTemplateSeederTest.java
@@ -123,6 +123,37 @@ class PermissionTemplateSeederTest {
   }
 
   @Test
+  @DisplayName("seeds least-privilege quality permissions for the QUALITY department")
+  void seedsQualityPermissionMatrix() {
+    List<PermissionTemplate> saved = new ArrayList<>();
+    seeder(List.of(), saved).seed();
+
+    List<Tuple> grants =
+        saved.stream()
+            .filter(t -> "quality".equals(t.getResource()))
+            .map(
+                t ->
+                    Tuple.tuple(
+                        t.getRoleCode(), t.getDepartmentCode(), t.getAction(), t.getDataScope()))
+            .toList();
+
+    assertThat(grants)
+        .contains(
+            Tuple.tuple("WORKER", "QUALITY", "read", DataScope.ORGANIZATION),
+            Tuple.tuple("WORKER", "QUALITY", "write", DataScope.ORGANIZATION),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "read", DataScope.ORGANIZATION),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "write", DataScope.ORGANIZATION),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "approve", DataScope.ORGANIZATION),
+            Tuple.tuple("MANAGER", "QUALITY", "manage", DataScope.ORGANIZATION),
+            Tuple.tuple("ADMIN", null, "approve", DataScope.GLOBAL),
+            Tuple.tuple("PLATFORM_ADMIN", null, "manage", DataScope.GLOBAL))
+        .doesNotContain(
+            Tuple.tuple("WORKER", "QUALITY", "approve", DataScope.ORGANIZATION),
+            Tuple.tuple("SUPERVISOR", "QUALITY", "manage", DataScope.ORGANIZATION),
+            Tuple.tuple("MANAGER", "PROCUREMENT", "approve", DataScope.ORGANIZATION));
+  }
+
+  @Test
   @DisplayName("owns the sales:approve rows that migration V20260706120000 used to write")
   void catalogueOwnsWildcardSalesApprove() {
     List<PermissionTemplate> saved = new ArrayList<>();

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
@@ -169,11 +169,12 @@ class SalesQuoteDemoSeederTest {
     verify(productFacade, times(3)).createProduct(any(CreateProductRequest.class));
     verify(salesProductService, times(3)).createEntry(any());
 
-    // 6 scenario lots + 1 waste-grade negative-test lot; all released from QC via the service.
+    // Six piece-backed lots are released through an explicit immutable QC decision. The raw-cotton
+    // scalar lot has no physical units and remains pending.
     ArgumentCaptor<CreateBatchRequest> batchCaptor =
         ArgumentCaptor.forClass(CreateBatchRequest.class);
     verify(batchService, times(7)).create(batchCaptor.capture());
-    verify(batchService, times(7)).releaseFromQc(any(UUID.class));
+    verify(batchService, times(6)).releaseFromQc(any(UUID.class));
     // Regression guard: production_execution_batch.chk_batch_unit admits canonical batch units;
     // demo lots currently remain weight-based, while FABRIC purchase lots may use M.
     assertThat(batchCaptor.getAllValues())
@@ -190,12 +191,12 @@ class SalesQuoteDemoSeederTest {
         .extracting(CreateBatchRequest::getColorId)
         .isNull();
 
-    // 16 + 24 + 3 rolls, 48 yarn cartons, 2 waste rolls — each graded through the service.
-    verify(stockUnitService, times(93))
+    // 16 + 24 + 3 + 18 rolls, 48 yarn cartons, 2 waste rolls — all born pending, then graded.
+    verify(stockUnitService, times(111))
         .create(
             any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(), any(),
             any());
-    verify(stockUnitService, times(93)).changeGrade(any(), any(), any(), any());
+    verify(stockUnitService, times(111)).changeGrade(any(), any(), any(), any());
 
     // Emma's open quote + the demo user's draft quote.
     ArgumentCaptor<QuoteCreateRequest> quoteCaptor =

--- a/src/test/java/com/fabricmanagement/common/infrastructure/persistence/PermissionTemplateBackfillIT.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/persistence/PermissionTemplateBackfillIT.java
@@ -100,6 +100,12 @@ class PermissionTemplateBackfillIT {
     assertThat(countOf(crippled, "colors", "approve")).isGreaterThan(0);
     assertThat(countOf(crippled, "colors", "manage")).isGreaterThan(0);
 
+    // QC-RELEASE-1a: the canonical template/backfill path carries the complete quality matrix.
+    assertThat(countOf(crippled, "quality", "read")).isGreaterThan(0);
+    assertThat(countOf(crippled, "quality", "write")).isGreaterThan(0);
+    assertThat(countOf(crippled, "quality", "approve")).isGreaterThan(0);
+    assertThat(countOf(crippled, "quality", "manage")).isGreaterThan(0);
+
     // A tenant that never existed before the fix still gets the full set.
     assertThat(countOf(healthy, "sales", "read")).isGreaterThan(0);
 

--- a/src/test/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapterTest.java
@@ -1,0 +1,78 @@
+package com.fabricmanagement.iwm.location.app.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.iwm.location.app.WarehouseLocationService;
+import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
+import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionLocationAdapterTest {
+
+  @Mock private WarehouseLocationService warehouseLocationService;
+  @InjectMocks private ProductionLocationAdapter adapter;
+
+  @Test
+  void validatesActiveOperationalStorageQualityAreaAsQcTarget() {
+    UUID locationId = UUID.randomUUID();
+    when(warehouseLocationService.getById(locationId))
+        .thenReturn(location(locationId, true, true, true, true));
+
+    var result = adapter.validateQcLocation(locationId);
+
+    assertThat(result.locationId()).isEqualTo(locationId);
+    assertThat(result.locationCode()).isEqualTo("QC-HOLD");
+    assertThat(result.validQcLocation()).isTrue();
+  }
+
+  @Test
+  void rejectsQualityAreaThatIsNotStorageCapable() {
+    UUID locationId = UUID.randomUUID();
+    when(warehouseLocationService.getById(locationId))
+        .thenReturn(location(locationId, true, true, false, true));
+
+    assertThat(adapter.validateQcLocation(locationId).validQcLocation()).isFalse();
+  }
+
+  @Test
+  void rejectsStorageLocationWithoutQualityDesignation() {
+    UUID locationId = UUID.randomUUID();
+    when(warehouseLocationService.getById(locationId))
+        .thenReturn(location(locationId, true, true, true, false));
+
+    assertThat(adapter.validateQcLocation(locationId).validQcLocation()).isFalse();
+  }
+
+  @Test
+  void rejectsInactiveOrNonOperationalQualityAreas() {
+    UUID inactiveId = UUID.randomUUID();
+    UUID blockedId = UUID.randomUUID();
+    when(warehouseLocationService.getById(inactiveId))
+        .thenReturn(location(inactiveId, false, false, true, true));
+    when(warehouseLocationService.getById(blockedId))
+        .thenReturn(location(blockedId, true, false, true, true));
+
+    assertThat(adapter.validateQcLocation(inactiveId).validQcLocation()).isFalse();
+    assertThat(adapter.validateQcLocation(blockedId).validQcLocation()).isFalse();
+  }
+
+  private WarehouseLocationDto location(
+      UUID id, boolean active, boolean operational, boolean storage, boolean qualityArea) {
+    return WarehouseLocationDto.builder()
+        .id(id)
+        .code("QC-HOLD")
+        .type(WarehouseLocationType.WAREHOUSE)
+        .isActive(active)
+        .operational(operational)
+        .storageLocation(storage)
+        .qualityArea(qualityArea)
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/iwm/location/domain/WarehouseLocationTest.java
+++ b/src/test/java/com/fabricmanagement/iwm/location/domain/WarehouseLocationTest.java
@@ -1,0 +1,42 @@
+package com.fabricmanagement.iwm.location.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fabricmanagement.iwm.common.exception.IwmDomainException;
+import org.junit.jupiter.api.Test;
+
+class WarehouseLocationTest {
+
+  @Test
+  void storageLocationCanBeDesignatedAsQualityArea() {
+    WarehouseLocation location = location(WarehouseLocationType.WAREHOUSE, true);
+
+    assertThat(location.isQualityArea()).isTrue();
+    assertThat(location.isStorageLocation()).isTrue();
+  }
+
+  @Test
+  void nonStorageLocationCannotBeDesignatedAsQualityArea() {
+    assertThatThrownBy(() -> location(WarehouseLocationType.MACHINE, true))
+        .isInstanceOf(IwmDomainException.class)
+        .hasMessageContaining("storage-capable");
+  }
+
+  private WarehouseLocation location(WarehouseLocationType type, boolean qualityArea) {
+    return new WarehouseLocation(
+        null,
+        "QC-AREA",
+        "QC Area",
+        null,
+        type,
+        StorageCondition.STANDARD,
+        null,
+        null,
+        null,
+        null,
+        0,
+        null,
+        qualityArea);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -84,6 +84,8 @@ class TenantTransactionalPurgeServiceTest {
             "production.prod_product",
             "production.production_execution_batch_color_archive",
             "production.stock_unit_soft_hold",
+            "production.quality_decision_unit",
+            "production.quality_decision",
             "iwm.warehouse_location",
             "finance.finance_invoice",
             "flowboard.task",
@@ -108,6 +110,13 @@ class TenantTransactionalPurgeServiceTest {
         .update(
             contains("DELETE FROM production.stock_unit_soft_hold WHERE tenant_id = ?"),
             eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM production.quality_decision_unit WHERE tenant_id = ?"),
+            eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM production.quality_decision WHERE tenant_id = ?"), eq(TENANT_ID));
     verify(jdbc)
         .update(
             contains(
@@ -293,6 +302,18 @@ class TenantTransactionalPurgeServiceTest {
 
     assertThat(tables.indexOf("production.production_execution_batch_color_archive"))
         .isLessThan(tables.indexOf("production.production_execution_batch_attribute"));
+  }
+
+  @Test
+  void shouldDeleteQualityDecisionLedgerInFkSafeOrder() {
+    List<String> tables = TenantTransactionalPurgeService.tenantScopedDeleteTables();
+
+    assertThat(tables.indexOf("production.quality_decision_unit"))
+        .isLessThan(tables.indexOf("production.quality_decision"));
+    assertThat(tables.indexOf("production.quality_decision"))
+        .isLessThan(tables.indexOf("production.stock_unit"));
+    assertThat(tables.indexOf("production.quality_decision"))
+        .isLessThan(tables.indexOf("production.production_execution_batch"));
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/WalkingSkeletonIT.java
+++ b/src/test/java/com/fabricmanagement/production/WalkingSkeletonIT.java
@@ -334,7 +334,8 @@ class WalkingSkeletonIT {
             "KG",
             null,
             StockUnitSourceType.GOODS_RECEIPT,
-            rawBatch1.getId());
+            rawBatch1.getId(),
+            com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition.RELEASED);
     su1 = stockUnitRepository.save(su1);
 
     Batch rawBatch2 =
@@ -372,7 +373,8 @@ class WalkingSkeletonIT {
             "KG",
             null,
             StockUnitSourceType.GOODS_RECEIPT,
-            rawBatch2.getId());
+            rawBatch2.getId(),
+            com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition.RELEASED);
     su2 = stockUnitRepository.save(su2);
 
     // ----------------------------------------------------------------------------------
@@ -415,7 +417,9 @@ class WalkingSkeletonIT {
             "KG",
             null,
             StockUnitSourceType.PRODUCTION,
-            lotResponse.id());
+            lotResponse.id(),
+            com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition
+                .PENDING_INSPECTION);
     outputSu = stockUnitRepository.save(outputSu);
 
     productionRecordService.recordProduction(

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchOperationsServiceTest.java
@@ -14,6 +14,7 @@ import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.domain.exception.BatchDomainException;
 import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
 import com.fabricmanagement.production.execution.batch.dto.BatchDto;
+import com.fabricmanagement.production.execution.batch.dto.OverrideStatusRequest;
 import com.fabricmanagement.production.execution.batch.dto.PartialAcceptanceSplitRequest;
 import com.fabricmanagement.production.execution.batch.dto.SplitBatchRequest;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchOverrideLogRepository;
@@ -21,6 +22,7 @@ import com.fabricmanagement.production.execution.batch.infra.repository.BatchRep
 import com.fabricmanagement.production.execution.lineage.app.BatchLineageService;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
@@ -48,6 +50,7 @@ class BatchOperationsServiceTest {
   @Mock private StockUnitRepository stockUnitRepository;
   @Mock private WarehouseLocationPort warehouseLocationPort;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
+  @Mock private QualityDecisionService qualityDecisionService;
 
   private BatchOperationsService service;
 
@@ -64,7 +67,8 @@ class BatchOperationsServiceTest {
             batchLineageService,
             stockUnitRepository,
             warehouseLocationPort,
-            applicationEventPublisher);
+            applicationEventPublisher,
+            qualityDecisionService);
   }
 
   @AfterEach
@@ -110,6 +114,34 @@ class BatchOperationsServiceTest {
             .build());
 
     assertThat(savedChild().getColorId()).isEqualTo(COLOR_ID);
+  }
+
+  @Test
+  void overrideStatusDelegatesReleaseToImmutableQualityDecisionPath() {
+    Batch source = sourceBatch();
+    source.setStatus(BatchStatus.QC_REJECTED);
+    when(batchRepository.findByIdAndTenantId(SOURCE_ID, TENANT_ID)).thenReturn(Optional.of(source));
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              source.applyQualityProjection(BatchStatus.AVAILABLE);
+              return null;
+            })
+        .when(qualityDecisionService)
+        .overrideToReleased(SOURCE_ID, "Quality manager accepted after review");
+    when(batchService.toBatchDto(source))
+        .thenReturn(BatchDto.builder().status(BatchStatus.AVAILABLE).build());
+
+    BatchDto result =
+        service.overrideStatus(
+            SOURCE_ID,
+            OverrideStatusRequest.builder()
+                .reason("Quality manager accepted after review")
+                .build());
+
+    verify(qualityDecisionService)
+        .overrideToReleased(SOURCE_ID, "Quality manager accepted after review");
+    verify(overrideLogRepository).save(any());
+    assertThat(result.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchQcEventListenerTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchQcEventListenerTest.java
@@ -1,0 +1,115 @@
+package com.fabricmanagement.production.execution.batch.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.platform.communication.app.InAppNotificationService;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionCommand;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
+import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.result.domain.TestApprovalStatus;
+import com.fabricmanagement.production.quality.result.domain.event.FiberTestResultApprovedEvent;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BatchQcEventListenerTest {
+
+  @Mock private QualityDecisionService decisionService;
+  @Mock private InAppNotificationService notificationService;
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+  @InjectMocks private BatchQcEventListener listener;
+
+  @Test
+  void approvedUnitEventCreatesSelectedReleasedDecisionWithEventProvenance() {
+    executeHandlerBody();
+    UUID tenantId = UUID.randomUUID();
+    UUID batchId = UUID.randomUUID();
+    UUID unitId = UUID.randomUUID();
+    UUID actorId = UUID.randomUUID();
+    FiberTestResultApprovedEvent event =
+        new FiberTestResultApprovedEvent(
+            tenantId, batchId, unitId, TestApprovalStatus.APPROVED, actorId);
+
+    listener.onFiberTestResultApproved(event);
+
+    ArgumentCaptor<TrustedDecisionContext> contextCaptor =
+        ArgumentCaptor.forClass(TrustedDecisionContext.class);
+    ArgumentCaptor<QualityDecisionCommand> commandCaptor =
+        ArgumentCaptor.forClass(QualityDecisionCommand.class);
+    verify(decisionService).recordDecision(contextCaptor.capture(), commandCaptor.capture());
+    assertThat(contextCaptor.getValue().actorId()).isEqualTo(actorId);
+    assertThat(contextCaptor.getValue().sourceEventId()).isEqualTo(event.getEventId());
+    assertThat(commandCaptor.getValue().scope()).isEqualTo(QualityDecisionScope.SELECTED_UNITS);
+    assertThat(commandCaptor.getValue().outcome()).isEqualTo(QualityDecisionOutcome.RELEASED);
+    assertThat(commandCaptor.getValue().stockUnitIds()).containsExactly(unitId);
+  }
+
+  @Test
+  void conditionalAcceptLeavesDispositionPendingAndNotifiesForConcessionReview() {
+    executeHandlerBody();
+    FiberTestResultApprovedEvent event =
+        new FiberTestResultApprovedEvent(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            TestApprovalStatus.CONDITIONAL_ACCEPT,
+            UUID.randomUUID());
+
+    listener.onFiberTestResultApproved(event);
+
+    verify(decisionService, never()).recordDecision(any(), any());
+    verify(notificationService)
+        .sendToTenantRoles(
+            eq(event.getTenantId()),
+            eq(InAppNotificationService.QUARANTINE_NOTIFY_ROLES),
+            any(),
+            eq("Concession review required"),
+            any(),
+            eq(event.getBatchId()),
+            eq("BATCH"),
+            any());
+  }
+
+  @Test
+  void rejectedBatchEventCreatesFullLotNonconformingDecision() {
+    executeHandlerBody();
+    FiberTestResultApprovedEvent event =
+        new FiberTestResultApprovedEvent(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            null,
+            TestApprovalStatus.REJECTED,
+            UUID.randomUUID());
+
+    listener.onFiberTestResultApproved(event);
+
+    ArgumentCaptor<QualityDecisionCommand> commandCaptor =
+        ArgumentCaptor.forClass(QualityDecisionCommand.class);
+    verify(decisionService).recordDecision(any(), commandCaptor.capture());
+    assertThat(commandCaptor.getValue().scope()).isEqualTo(QualityDecisionScope.FULL_LOT);
+    assertThat(commandCaptor.getValue().outcome()).isEqualTo(QualityDecisionOutcome.NONCONFORMING);
+  }
+
+  private void executeHandlerBody() {
+    doAnswer(
+            invocation -> {
+              invocation.<Runnable>getArgument(3).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(), any(), any(), any());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/BatchServiceTest.java
@@ -24,6 +24,7 @@ import com.fabricmanagement.production.masterdata.color.api.query.ColorQueryServ
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberQualityStandardRepository;
 import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
@@ -51,6 +52,7 @@ class BatchServiceTest {
   @Mock private ColorQueryService colorQueryService;
   @Mock private ApplicationEventPublisher applicationEventPublisher;
   @Spy private BatchPrimaryMeasureService primaryMeasureService = new BatchPrimaryMeasureService();
+  @Mock private QualityDecisionService qualityDecisionService;
 
   @InjectMocks private BatchService batchService;
 
@@ -67,14 +69,20 @@ class BatchServiceTest {
   @Test
   void releaseFromQc_transitionsPendingQcBatchToAvailable() {
     Batch batch = pendingQcBatch();
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              batch.applyQualityProjection(BatchStatus.AVAILABLE);
+              return null;
+            })
+        .when(qualityDecisionService)
+        .releaseFromQc(BATCH_ID);
     when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
-    when(batchRepository.save(any(Batch.class))).thenAnswer(inv -> inv.getArgument(0));
 
     BatchDto result = batchService.releaseFromQc(BATCH_ID);
 
     assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
     assertThat(result.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
-    verify(batchRepository).save(batch);
+    verify(qualityDecisionService).releaseFromQc(BATCH_ID);
   }
 
   @Test
@@ -84,7 +92,7 @@ class BatchServiceTest {
     assertThatThrownBy(() -> batchService.releaseFromQc(BATCH_ID))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining(BATCH_ID.toString());
-    verify(batchRepository, never()).save(any());
+    verify(qualityDecisionService).releaseFromQc(BATCH_ID);
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryIT.java
@@ -3,16 +3,22 @@ package com.fabricmanagement.production.execution.batch.app;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.iwm.location.app.WarehouseLocationService;
+import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
+import com.fabricmanagement.iwm.location.dto.CreateWarehouseLocationRequest;
 import com.fabricmanagement.platform.tenant.domain.Tenant;
 import com.fabricmanagement.platform.tenant.infra.repository.TenantRepository;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitAuditLogRepository;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
@@ -47,6 +53,9 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
   @Autowired private TenantRepository tenantRepository;
   @Autowired private QualityDecisionService qualityDecisionService;
   @Autowired private QualityDecisionUnitRepository decisionUnitRepository;
+  @Autowired private StockUnitService stockUnitService;
+  @Autowired private StockUnitAuditLogRepository stockUnitAuditLogRepository;
+  @Autowired private WarehouseLocationService warehouseLocationService;
   @Autowired private EntityManager entityManager;
 
   private UUID tenantId;
@@ -55,6 +64,7 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
   void setUpTenant() {
     tenantId = tenant("primary");
     TenantContext.setCurrentTenantId(tenantId);
+    TenantContext.setCurrentUserId(UUID.randomUUID());
   }
 
   @AfterEach
@@ -168,10 +178,165 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
     assertThat(decisionUnitRepository.countByTenantIdAndDecisionId(tenantId, decision.getId()))
         .isEqualTo(1);
 
+    assertThat(stockUnitService.reserve(received.getId()).getStatus())
+        .isEqualTo(StockUnitStatus.RESERVED);
+    stockUnitService.releaseReservation(received.getId());
+    stockUnitService.consume(received.getId(), BigDecimal.ONE);
+    entityManager.flush();
+    entityManager.clear();
+
     var visible =
         service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20));
     assertThat(visible).hasSize(1);
     assertThat(visible.getContent().getFirst().lotNo()).isEqualTo("LOT-RECEIPT-QC");
+  }
+
+  @Test
+  void stockUnitLessLegacyBatchRetainsScalarAvailabilityFallback() {
+    Product product = product(ProductType.FABRIC, "M", tenantId);
+    batch(product, "LOT-LEGACY-SCALAR", BatchStatus.AVAILABLE, tenantId);
+
+    var visible =
+        service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20));
+
+    assertThat(visible).hasSize(1);
+    assertThat(visible.getContent().getFirst().lotNo()).isEqualTo("LOT-LEGACY-SCALAR");
+    assertThat(visible.getContent().getFirst().physical().pieceCount()).isZero();
+  }
+
+  @Test
+  void quarantinedUnitRelocatesToPersistedQualityAreaWithoutChangingItsGates() {
+    Product product = product(ProductType.FABRIC, "M", tenantId);
+    Batch batch = batch(product, "LOT-QC-RELOCATE", BatchStatus.QUARANTINE, tenantId);
+    UUID sourceLocationId = UUID.randomUUID();
+    StockUnit quarantined =
+        StockUnit.create(
+            tenantId,
+            batch.getId(),
+            ProductType.FABRIC,
+            "ROLL-QC-RELOCATE-" + UUID.randomUUID().toString().substring(0, 8),
+            null,
+            PackageType.ROLL,
+            BigDecimal.TEN,
+            null,
+            "KG",
+            sourceLocationId,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.QUARANTINED);
+    quarantined.quarantine();
+    stockUnitRepository.saveAndFlush(quarantined);
+    var qualityArea =
+        warehouseLocationService.create(
+            CreateWarehouseLocationRequest.builder()
+                .code("QC-" + UUID.randomUUID().toString().substring(0, 8))
+                .name("QC Hold")
+                .type(WarehouseLocationType.WAREHOUSE)
+                .qualityArea(true)
+                .build());
+
+    stockUnitService.relocateForQuality(
+        quarantined.getId(), qualityArea.getId(), "Awaiting laboratory review");
+    entityManager.flush();
+    entityManager.clear();
+
+    StockUnit relocated = stockUnitRepository.findById(quarantined.getId()).orElseThrow();
+    assertThat(relocated.getPreviousLocationId()).isEqualTo(sourceLocationId);
+    assertThat(relocated.getLocationId()).isEqualTo(qualityArea.getId());
+    assertThat(relocated.getStatus()).isEqualTo(StockUnitStatus.QUARANTINE);
+    assertThat(relocated.getQualityDisposition()).isEqualTo(QualityDisposition.QUARANTINED);
+    assertThat(
+            stockUnitAuditLogRepository.findByTenantIdAndStockUnitIdOrderByCreatedAtAsc(
+                tenantId, quarantined.getId()))
+        .singleElement()
+        .satisfies(
+            audit -> {
+              assertThat(audit.getOperationType()).isEqualTo("QC_RELOCATE");
+              assertThat(audit.getReason()).isEqualTo("Awaiting laboratory review");
+            });
+  }
+
+  @Test
+  void mixedBatchExposesAndConsumesReleasedUnitsAndCanInspectRemainingUnitsLater() {
+    Product product = product(ProductType.FABRIC, "M", tenantId);
+    Batch pending = batch(product, "LOT-MIXED-QC", BatchStatus.PENDING_QC, tenantId);
+    StockUnit first =
+        StockUnit.create(
+            tenantId,
+            pending.getId(),
+            ProductType.FABRIC,
+            "ROLL-MIXED-1-" + UUID.randomUUID().toString().substring(0, 8),
+            null,
+            PackageType.ROLL,
+            new BigDecimal("10"),
+            null,
+            "KG",
+            null,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.PENDING_INSPECTION);
+    first.recordLength(new BigDecimal("100"), "M");
+    StockUnit second =
+        StockUnit.create(
+            tenantId,
+            pending.getId(),
+            ProductType.FABRIC,
+            "ROLL-MIXED-2-" + UUID.randomUUID().toString().substring(0, 8),
+            null,
+            PackageType.ROLL,
+            new BigDecimal("10"),
+            null,
+            "KG",
+            null,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.PENDING_INSPECTION);
+    second.recordLength(new BigDecimal("100"), "M");
+    stockUnitRepository.saveAllAndFlush(java.util.List.of(first, second));
+
+    qualityDecisionService.recordDecision(
+        TrustedDecisionContext.manual(UUID.randomUUID()),
+        new QualityDecisionCommand(
+            pending.getId(),
+            QualityDecisionScope.SELECTED_UNITS,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            "First roll passed",
+            java.util.Set.of(first.getId()),
+            null));
+    entityManager.flush();
+    entityManager.clear();
+
+    Batch mixed = batchRepository.findById(pending.getId()).orElseThrow();
+    assertThat(mixed.getStatus()).isEqualTo(BatchStatus.QUARANTINE);
+    var firstAvailability =
+        service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20));
+    assertThat(firstAvailability).hasSize(1);
+    assertThat(firstAvailability.getContent().getFirst().physical().pieceCount()).isEqualTo(1);
+
+    stockUnitService.consume(first.getId(), BigDecimal.ONE);
+    entityManager.flush();
+    entityManager.clear();
+
+    qualityDecisionService.recordDecision(
+        TrustedDecisionContext.manual(UUID.randomUUID()),
+        new QualityDecisionCommand(
+            pending.getId(),
+            QualityDecisionScope.SELECTED_UNITS,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            "Remaining roll passed after production started",
+            java.util.Set.of(second.getId()),
+            null));
+    entityManager.flush();
+    entityManager.clear();
+
+    Batch operational = batchRepository.findById(pending.getId()).orElseThrow();
+    assertThat(operational.getConsumedQuantity()).isEqualByComparingTo("1");
+    assertThat(operational.getStatus()).isEqualTo(BatchStatus.QUARANTINE);
+    var allReleased =
+        service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20));
+    assertThat(allReleased.getContent().getFirst().physical().pieceCount()).isEqualTo(2);
   }
 
   private Product product(ProductType type, String unit, UUID ownerTenantId) {

--- a/src/test/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/app/StockAvailabilityQueryIT.java
@@ -10,6 +10,7 @@ import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
@@ -18,7 +19,14 @@ import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
 import com.fabricmanagement.production.masterdata.qualitygrade.infra.repository.QualityGradeRepository;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionCommand;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
+import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionUnitRepository;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -37,6 +45,9 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
   @Autowired private StockUnitRepository stockUnitRepository;
   @Autowired private QualityGradeRepository qualityGradeRepository;
   @Autowired private TenantRepository tenantRepository;
+  @Autowired private QualityDecisionService qualityDecisionService;
+  @Autowired private QualityDecisionUnitRepository decisionUnitRepository;
+  @Autowired private EntityManager entityManager;
 
   private UUID tenantId;
 
@@ -109,6 +120,60 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
         .isEmpty();
   }
 
+  @Test
+  void pendingReceiptStockBecomesVisibleOnlyAfterImmutableFullLotRelease() {
+    Product product = product(ProductType.FABRIC, "M", tenantId);
+    Batch pending = batch(product, "LOT-RECEIPT-QC", BatchStatus.PENDING_QC, tenantId);
+    UUID actorId = UUID.randomUUID();
+    StockUnit received =
+        StockUnit.create(
+            tenantId,
+            pending.getId(),
+            ProductType.FABRIC,
+            "GR-ROLL-" + UUID.randomUUID().toString().substring(0, 8),
+            null,
+            PackageType.ROLL,
+            new BigDecimal("10"),
+            null,
+            "KG",
+            null,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.PENDING_INSPECTION);
+    received.recordLength(new BigDecimal("100"), "M");
+    stockUnitRepository.saveAndFlush(received);
+
+    assertThat(service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20)))
+        .isEmpty();
+
+    var decision =
+        qualityDecisionService.recordDecision(
+            TrustedDecisionContext.manual(actorId),
+            new QualityDecisionCommand(
+                pending.getId(),
+                QualityDecisionScope.FULL_LOT,
+                QualityDecisionOutcome.RELEASED,
+                null,
+                "Goods receipt inspection passed",
+                java.util.Set.of(),
+                null));
+    entityManager.flush();
+    entityManager.clear();
+
+    StockUnit released = stockUnitRepository.findById(received.getId()).orElseThrow();
+    Batch projected = batchRepository.findById(pending.getId()).orElseThrow();
+    assertThat(released.getQualityDisposition()).isEqualTo(QualityDisposition.RELEASED);
+    assertThat(projected.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+    assertThat(decision.getActorId()).isEqualTo(actorId);
+    assertThat(decisionUnitRepository.countByTenantIdAndDecisionId(tenantId, decision.getId()))
+        .isEqualTo(1);
+
+    var visible =
+        service.lots(null, null, product.getId(), null, null, null, PageRequest.of(0, 20));
+    assertThat(visible).hasSize(1);
+    assertThat(visible.getContent().getFirst().lotNo()).isEqualTo("LOT-RECEIPT-QC");
+  }
+
   private Product product(ProductType type, String unit, UUID ownerTenantId) {
     Product product = Product.create(type, unit);
     product.setTenantId(ownerTenantId);
@@ -171,7 +236,8 @@ class StockAvailabilityQueryIT extends AbstractIntegrationTest {
             "KG",
             null,
             StockUnitSourceType.PRODUCTION,
-            UUID.randomUUID());
+            UUID.randomUUID(),
+            QualityDisposition.RELEASED);
     piece.recordLength(new BigDecimal(metres), "M");
     return piece;
   }

--- a/src/test/java/com/fabricmanagement/production/execution/batch/domain/BatchReleasedUnitConsumptionTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/batch/domain/BatchReleasedUnitConsumptionTest.java
@@ -1,0 +1,50 @@
+package com.fabricmanagement.production.execution.batch.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fabricmanagement.production.execution.batch.domain.exception.BatchNotConsumableException;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class BatchReleasedUnitConsumptionTest {
+
+  @Test
+  void mixedQualityProjectionDoesNotBlockReleasedUnitConsumption() {
+    Batch batch = batch(BatchStatus.QUARANTINE);
+
+    batch.consumeReleasedUnitFromAvailable(new BigDecimal("5.000"));
+
+    assertThat(batch.getConsumedQuantity()).isEqualByComparingTo("5.000");
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.QUARANTINE);
+  }
+
+  @Test
+  void operationalHoldStillBlocksReleasedUnitConsumption() {
+    Batch batch = batch(BatchStatus.ON_HOLD);
+
+    assertThatThrownBy(() -> batch.consumeReleasedUnitFromAvailable(BigDecimal.ONE))
+        .isInstanceOf(BatchNotConsumableException.class)
+        .extracting(error -> ((BatchNotConsumableException) error).getErrorCode())
+        .isEqualTo("BATCH_NOT_CONSUMABLE");
+  }
+
+  private Batch batch(BatchStatus status) {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(ProductType.FABRIC)
+            .batchCode("LOT-MIXED-QC")
+            .quantity(new BigDecimal("20.000"))
+            .reservedQuantity(BigDecimal.ZERO)
+            .consumedQuantity(BigDecimal.ZERO)
+            .wasteQuantity(BigDecimal.ZERO)
+            .unit("KG")
+            .status(status)
+            .build();
+    batch.setId(UUID.randomUUID());
+    return batch;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/output/app/ProductionOutputServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/output/app/ProductionOutputServiceTest.java
@@ -1,0 +1,90 @@
+package com.fabricmanagement.production.execution.output.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEventPublisher;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.output.domain.ProductionOutputItem;
+import com.fabricmanagement.production.execution.output.domain.ProductionOutputRecord;
+import com.fabricmanagement.production.execution.output.infra.repository.ProductionOutputItemRepository;
+import com.fabricmanagement.production.execution.output.infra.repository.ProductionOutputRecordRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.masterdata.product.api.facade.ProductFacade;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionOutputServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID RECORD_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Mock private ProductionOutputRecordRepository recordRepository;
+  @Mock private ProductionOutputItemRepository itemRepository;
+  @Mock private DomainEventPublisher eventPublisher;
+  @Mock private ProductFacade productFacade;
+  @Mock private BatchRepository batchRepository;
+  @InjectMocks private ProductionOutputService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(UUID.randomUUID());
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void confirmSynchronouslyClosesAvailabilityGateBeforePublishingOutputEvent() {
+    ProductionOutputRecord record =
+        ProductionOutputRecord.create(
+            TENANT_ID,
+            UUID.randomUUID(),
+            "WO-100",
+            BATCH_ID,
+            UUID.randomUUID(),
+            ProductType.FABRIC,
+            "M",
+            null);
+    record.setId(RECORD_ID);
+    record.addItem(
+        ProductionOutputItem.create(
+            PackageType.ROLL, new BigDecimal("25"), null, UUID.randomUUID(), 0, null));
+    Batch batch = new Batch();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    batch.setStatus(BatchStatus.AVAILABLE);
+    batch.setReservedQuantity(BigDecimal.ZERO);
+    batch.setConsumedQuantity(BigDecimal.ZERO);
+    when(recordRepository.findByIdAndTenantIdAndIsActiveTrue(RECORD_ID, TENANT_ID))
+        .thenReturn(Optional.of(record));
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(recordRepository.save(record)).thenReturn(record);
+
+    service.confirm(RECORD_ID);
+
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.PENDING_QC);
+    verify(batchRepository).save(batch);
+    verify(eventPublisher).publish(any());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/api/StockUnitControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/api/StockUnitControllerSecurityTest.java
@@ -1,0 +1,111 @@
+package com.fabricmanagement.production.execution.stockunit.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitQueryService;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StockUnitController.class)
+@EnableMethodSecurity
+class StockUnitControllerSecurityTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private StockUnitService stockUnitService;
+  @MockBean private StockUnitQueryService stockUnitQueryService;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  @Test
+  @WithMockUser
+  void qcRelocationRequiresQualityWrite() throws Exception {
+    UUID stockUnitId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("write")))
+        .thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/stock-units/{id}/qc-relocate", stockUnitId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"targetLocationId":"%s","reason":"Move to inspection"}
+                    """
+                        .formatted(UUID.randomUUID())))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void qualityWriterCanRelocatePendingUnit() throws Exception {
+    UUID stockUnitId = UUID.randomUUID();
+    UUID targetLocationId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("write"))).thenReturn(true);
+    StockUnit unit = pendingUnit(stockUnitId, targetLocationId);
+    when(stockUnitService.relocateForQuality(stockUnitId, targetLocationId, "Move to inspection"))
+        .thenReturn(unit);
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/stock-units/{id}/qc-relocate", stockUnitId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"targetLocationId":"%s","reason":"Move to inspection"}
+                    """
+                        .formatted(targetLocationId)))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.id").value(stockUnitId.toString()))
+        .andExpect(jsonPath("$.data.qualityDisposition").value("PENDING_INSPECTION"));
+  }
+
+  private StockUnit pendingUnit(UUID id, UUID locationId) {
+    StockUnit unit =
+        StockUnit.create(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            ProductType.FABRIC,
+            "ROLL-QC-SECURITY",
+            null,
+            PackageType.ROLL,
+            BigDecimal.TEN,
+            null,
+            "KG",
+            locationId,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.PENDING_INSPECTION);
+    unit.setId(id);
+    return unit;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceCreationTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceCreationTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
@@ -42,6 +43,7 @@ class StockUnitServiceCreationTest {
   @Mock private QualityGradeService qualityGradeService;
   @Mock private StockUnitAuditLogRepository auditLogRepository;
   @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private WarehouseLocationPort warehouseLocationPort;
   @InjectMocks private StockUnitService service;
 
   @BeforeEach

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceCreationTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceCreationTest.java
@@ -1,0 +1,163 @@
+package com.fabricmanagement.production.execution.stockunit.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitAuditLogRepository;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class StockUnitServiceCreationTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private BatchRepository batchRepository;
+  @Mock private QualityGradeService qualityGradeService;
+  @Mock private StockUnitAuditLogRepository auditLogRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
+  @InjectMocks private StockUnitService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(UUID.randomUUID());
+    Batch batch = new Batch();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    batch.setStatus(BatchStatus.AVAILABLE);
+    batch.setReservedQuantity(BigDecimal.ZERO);
+    batch.setConsumedQuantity(BigDecimal.ZERO);
+    when(batchRepository.findByIdAndTenantId(BATCH_ID, TENANT_ID)).thenReturn(Optional.of(batch));
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, BATCH_ID))
+        .thenReturn(List.of(pendingCount(1)));
+    when(stockUnitRepository.save(any(StockUnit.class)))
+        .thenAnswer(
+            invocation -> {
+              StockUnit unit = invocation.getArgument(0);
+              if (unit.getId() == null) {
+                unit.setId(UUID.randomUUID());
+              }
+              return unit;
+            });
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void manualCreateCannotUseProductionSourceToBypassInspection() {
+    StockUnit result =
+        service.create(
+            BATCH_ID,
+            ProductType.FABRIC,
+            "ROLL-MANUAL-1",
+            null,
+            PackageType.ROLL,
+            new BigDecimal("30.000"),
+            null,
+            "KG",
+            new BigDecimal("100.000"),
+            "M",
+            UUID.randomUUID(),
+            StockUnitSourceType.PRODUCTION,
+            UUID.randomUUID());
+
+    assertThat(result.getQualityDisposition()).isEqualTo(QualityDisposition.PENDING_INSPECTION);
+  }
+
+  @Test
+  void productionOutputBulkCreationStartsPendingInspection() {
+    List<StockUnit> result =
+        service.createBulk(
+            BATCH_ID,
+            List.of(
+                new StockUnitService.CreateStockUnitRequest(
+                    ProductType.FABRIC,
+                    "ROLL-OUTPUT-1",
+                    null,
+                    PackageType.ROLL,
+                    new BigDecimal("30.000"),
+                    null,
+                    "KG",
+                    new BigDecimal("100.000"),
+                    "M",
+                    UUID.randomUUID(),
+                    StockUnitSourceType.PRODUCTION,
+                    UUID.randomUUID())),
+            TenantContext.SYSTEM_ACTOR_ID);
+
+    assertThat(result)
+        .extracting(StockUnit::getQualityDisposition)
+        .containsExactly(QualityDisposition.PENDING_INSPECTION);
+    verify(batchRepository).save(argThat(batch -> batch.getStatus() == BatchStatus.PENDING_QC));
+  }
+
+  @Test
+  void goodsReceiptBulkCreationStartsPendingInspection() {
+    List<StockUnit> result =
+        service.createBulk(
+            BATCH_ID,
+            List.of(
+                new StockUnitService.CreateStockUnitRequest(
+                    ProductType.FABRIC,
+                    "ROLL-RECEIPT-1",
+                    null,
+                    PackageType.ROLL,
+                    new BigDecimal("30.000"),
+                    null,
+                    "KG",
+                    new BigDecimal("100.000"),
+                    "M",
+                    UUID.randomUUID(),
+                    StockUnitSourceType.GOODS_RECEIPT,
+                    UUID.randomUUID())),
+            TenantContext.SYSTEM_ACTOR_ID);
+
+    assertThat(result)
+        .extracting(StockUnit::getQualityDisposition)
+        .containsExactly(QualityDisposition.PENDING_INSPECTION);
+  }
+
+  private StockUnitRepository.QualityDispositionCount pendingCount(long count) {
+    return new StockUnitRepository.QualityDispositionCount() {
+      @Override
+      public QualityDisposition getDisposition() {
+        return QualityDisposition.PENDING_INSPECTION;
+      }
+
+      @Override
+      public long getUnitCount() {
+        return count;
+      }
+    };
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceQualityGateTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/StockUnitServiceQualityGateTest.java
@@ -1,0 +1,230 @@
+package com.fabricmanagement.production.execution.stockunit.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.port.QcLocationValidationResult;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitAuditLog;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.QcRelocationException;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitNotReleasedException;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitAuditLogRepository;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class StockUnitServiceQualityGateTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private BatchRepository batchRepository;
+  @Mock private QualityGradeService qualityGradeService;
+  @Mock private StockUnitAuditLogRepository auditLogRepository;
+  @Mock private ApplicationEventPublisher eventPublisher;
+  @Mock private WarehouseLocationPort warehouseLocationPort;
+  @InjectMocks private StockUnitService service;
+
+  @BeforeEach
+  void setUpContext() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(ACTOR_ID);
+    lenient()
+        .when(stockUnitRepository.save(any(StockUnit.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+  }
+
+  @AfterEach
+  void clearContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void pendingUnitCannotBeConsumed() {
+    StockUnit pending = unit(QualityDisposition.PENDING_INSPECTION, UUID.randomUUID());
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    givenUnitAndBatch(pending, batch);
+
+    assertThatThrownBy(() -> service.consume(pending.getId(), BigDecimal.ONE))
+        .isInstanceOf(StockUnitNotReleasedException.class)
+        .extracting(error -> ((StockUnitNotReleasedException) error).getErrorCode())
+        .isEqualTo("STOCK_UNIT_NOT_RELEASED");
+
+    verify(stockUnitRepository, never()).save(any());
+    assertThat(batch.getConsumedQuantity()).isZero();
+  }
+
+  @Test
+  void releasedUnitInMixedBatchCanBeConsumedWithoutOverwritingProjection() {
+    StockUnit released = unit(QualityDisposition.RELEASED, UUID.randomUUID());
+    Batch mixed = batch(BatchStatus.QUARANTINE);
+    givenUnitAndBatch(released, mixed);
+
+    StockUnit result = service.consume(released.getId(), new BigDecimal("2.000"));
+
+    assertThat(result.getCurrentWeight()).isEqualByComparingTo("8.000");
+    assertThat(result.getStatus()).isEqualTo(StockUnitStatus.PARTIAL);
+    assertThat(mixed.getConsumedQuantity()).isEqualByComparingTo("2.000");
+    assertThat(mixed.getStatus()).isEqualTo(BatchStatus.QUARANTINE);
+  }
+
+  @Test
+  void qcRelocationPreservesStatusAndDispositionAndWritesReasonedAudit() {
+    UUID source = UUID.randomUUID();
+    UUID target = UUID.randomUUID();
+    StockUnit quarantined = unit(QualityDisposition.QUARANTINED, source);
+    quarantined.quarantine();
+    when(stockUnitRepository.findById(quarantined.getId())).thenReturn(Optional.of(quarantined));
+    when(warehouseLocationPort.validateQcLocation(target))
+        .thenReturn(new QcLocationValidationResult(target, "QC-HOLD", true));
+
+    StockUnit result = service.relocateForQuality(quarantined.getId(), target, "  Lab review  ");
+
+    assertThat(result.getLocationId()).isEqualTo(target);
+    assertThat(result.getPreviousLocationId()).isEqualTo(source);
+    assertThat(result.getStatus()).isEqualTo(StockUnitStatus.QUARANTINE);
+    assertThat(result.getQualityDisposition()).isEqualTo(QualityDisposition.QUARANTINED);
+    ArgumentCaptor<StockUnitAuditLog> audit = ArgumentCaptor.forClass(StockUnitAuditLog.class);
+    verify(auditLogRepository).save(audit.capture());
+    assertThat(audit.getValue().getOperationType()).isEqualTo(StockUnitAuditLog.OP_QC_RELOCATE);
+    assertThat(audit.getValue().getOldValue()).isEqualTo(source.toString());
+    assertThat(audit.getValue().getNewValue()).isEqualTo(target.toString());
+    assertThat(audit.getValue().getReason()).isEqualTo("Lab review");
+  }
+
+  @Test
+  void invalidQcTargetIsRejectedBeforeMutation() {
+    UUID source = UUID.randomUUID();
+    UUID target = UUID.randomUUID();
+    StockUnit pending = unit(QualityDisposition.PENDING_INSPECTION, source);
+    when(stockUnitRepository.findById(pending.getId())).thenReturn(Optional.of(pending));
+    when(warehouseLocationPort.validateQcLocation(target))
+        .thenReturn(new QcLocationValidationResult(target, "GENERAL", false));
+
+    assertThatThrownBy(() -> service.relocateForQuality(pending.getId(), target, "Inspection"))
+        .isInstanceOf(QcRelocationException.class)
+        .extracting(error -> ((QcRelocationException) error).getErrorCode())
+        .isEqualTo("QC_RELOCATE_TARGET_INVALID");
+
+    assertThat(pending.getLocationId()).isEqualTo(source);
+    verify(stockUnitRepository, never()).save(any());
+  }
+
+  @Test
+  void disposedUnitIsRejectedBeforeQcLocationLookup() {
+    StockUnit disposed = unit(QualityDisposition.NONCONFORMING, UUID.randomUUID());
+    disposed.hold();
+    disposed.dispose();
+    when(stockUnitRepository.findById(disposed.getId())).thenReturn(Optional.of(disposed));
+
+    assertThatThrownBy(
+            () -> service.relocateForQuality(disposed.getId(), UUID.randomUUID(), "Move reject"))
+        .isInstanceOf(QcRelocationException.class)
+        .extracting(error -> ((QcRelocationException) error).getErrorCode())
+        .isEqualTo("QC_RELOCATE_STATUS_INVALID");
+
+    verify(warehouseLocationPort, never()).validateQcLocation(any());
+  }
+
+  @Test
+  void releasedUnitMustUseStandardTransferPath() {
+    StockUnit released = unit(QualityDisposition.RELEASED, UUID.randomUUID());
+    when(stockUnitRepository.findById(released.getId())).thenReturn(Optional.of(released));
+
+    assertThatThrownBy(
+            () -> service.relocateForQuality(released.getId(), UUID.randomUUID(), "QC move"))
+        .isInstanceOf(QcRelocationException.class)
+        .extracting(error -> ((QcRelocationException) error).getErrorCode())
+        .isEqualTo("QC_RELOCATE_RELEASED_UNIT");
+
+    verify(warehouseLocationPort, never()).validateQcLocation(any());
+  }
+
+  @Test
+  void relocationToCurrentLocationIsRejectedBeforeQcLocationLookup() {
+    UUID currentLocation = UUID.randomUUID();
+    StockUnit pending = unit(QualityDisposition.PENDING_INSPECTION, currentLocation);
+    when(stockUnitRepository.findById(pending.getId())).thenReturn(Optional.of(pending));
+
+    assertThatThrownBy(
+            () -> service.relocateForQuality(pending.getId(), currentLocation, "Remain in QC"))
+        .isInstanceOf(QcRelocationException.class)
+        .extracting(error -> ((QcRelocationException) error).getErrorCode())
+        .isEqualTo("QC_RELOCATE_SAME_LOCATION");
+
+    verify(warehouseLocationPort, never()).validateQcLocation(any());
+  }
+
+  private void givenUnitAndBatch(StockUnit unit, Batch batch) {
+    when(stockUnitRepository.findById(unit.getId())).thenReturn(Optional.of(unit));
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+  }
+
+  private StockUnit unit(QualityDisposition disposition, UUID locationId) {
+    StockUnit unit =
+        StockUnit.create(
+            TENANT_ID,
+            BATCH_ID,
+            ProductType.FABRIC,
+            "ROLL-" + UUID.randomUUID(),
+            null,
+            PackageType.ROLL,
+            new BigDecimal("10.000"),
+            null,
+            "KG",
+            locationId,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            disposition);
+    unit.setId(UUID.randomUUID());
+    return unit;
+  }
+
+  private Batch batch(BatchStatus status) {
+    Batch batch =
+        Batch.builder()
+            .productId(UUID.randomUUID())
+            .productType(ProductType.FABRIC)
+            .batchCode("LOT-QC-MIXED")
+            .quantity(new BigDecimal("20.000"))
+            .reservedQuantity(BigDecimal.ZERO)
+            .consumedQuantity(BigDecimal.ZERO)
+            .wasteQuantity(BigDecimal.ZERO)
+            .unit("KG")
+            .status(status)
+            .build();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    return batch;
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/listener/ProductionOutputConfirmedEventListenerTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/listener/ProductionOutputConfirmedEventListenerTest.java
@@ -1,0 +1,102 @@
+package com.fabricmanagement.production.execution.stockunit.app.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.output.domain.event.ProductionOutputConfirmedEvent;
+import com.fabricmanagement.production.execution.stockunit.app.StockUnitService;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProductionOutputConfirmedEventListenerTest {
+
+  @Mock private StockUnitService stockUnitService;
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+  @InjectMocks private ProductionOutputConfirmedEventListener listener;
+
+  @Test
+  void confirmedOutputUsesTrustedProductionBulkCreationPath() {
+    executeHandlerBody();
+    UUID batchId = UUID.randomUUID();
+    UUID itemId = UUID.randomUUID();
+    ProductionOutputConfirmedEvent event = event(batchId, itemId);
+
+    listener.onProductionOutputConfirmed(event);
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<List<StockUnitService.CreateStockUnitRequest>> requestsCaptor =
+        ArgumentCaptor.forClass(List.class);
+    verify(stockUnitService)
+        .createBulk(eq(batchId), requestsCaptor.capture(), eq(TenantContext.SYSTEM_ACTOR_ID));
+    assertThat(requestsCaptor.getValue())
+        .singleElement()
+        .satisfies(
+            request -> {
+              assertThat(request.sourceType()).isEqualTo(StockUnitSourceType.PRODUCTION);
+              assertThat(request.sourceId()).isEqualTo(itemId);
+            });
+  }
+
+  @Test
+  void creationFailureEscapesSoIdempotentDeliveryCanRetry() {
+    executeHandlerBody();
+    ProductionOutputConfirmedEvent event = event(UUID.randomUUID(), UUID.randomUUID());
+    doThrow(new IllegalStateException("creation failed"))
+        .when(stockUnitService)
+        .createBulk(any(), any(), any());
+
+    assertThatThrownBy(() -> listener.onProductionOutputConfirmed(event))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("creation failed");
+  }
+
+  private ProductionOutputConfirmedEvent event(UUID batchId, UUID itemId) {
+    return new ProductionOutputConfirmedEvent(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        batchId,
+        UUID.randomUUID(),
+        ProductType.FABRIC,
+        "KG",
+        UUID.randomUUID(),
+        List.of(
+            new ProductionOutputConfirmedEvent.OutputItemData(
+                itemId,
+                "OUTPUT-ROLL-1",
+                PackageType.ROLL,
+                new BigDecimal("25"),
+                null,
+                UUID.randomUUID())));
+  }
+
+  private void executeHandlerBody() {
+    doAnswer(
+            invocation -> {
+              invocation.<Runnable>getArgument(3).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(), any(), any(), any());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/app/listener/PurchaseOrderReceiptMaterializationIT.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/app/listener/PurchaseOrderReceiptMaterializationIT.java
@@ -16,11 +16,15 @@ import com.fabricmanagement.production.execution.batch.dto.StockAvailabilityDtos
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionUnitRepository;
 import java.math.BigDecimal;
 import java.sql.DriverManager;
 import java.time.Duration;
@@ -82,6 +86,8 @@ class PurchaseOrderReceiptMaterializationIT {
   @Autowired private TransactionTemplate transactionTemplate;
   @Autowired private BatchService batchService;
   @Autowired private StockAvailabilityQueryService availabilityQueryService;
+  @Autowired private QualityDecisionRepository qualityDecisionRepository;
+  @Autowired private QualityDecisionUnitRepository qualityDecisionUnitRepository;
 
   @MockBean private PurchaseOrderQueryService purchaseOrderQueryService;
 
@@ -168,6 +174,8 @@ class PurchaseOrderReceiptMaterializationIT {
                         assertThat(unit.getUnit()).isEqualTo("KG");
                         assertThat(unit.getLengthUnit()).isEqualTo("M");
                         assertThat(unit.getQualityGradeId()).isNull();
+                        assertThat(unit.getQualityDisposition())
+                            .isEqualTo(QualityDisposition.PENDING_INSPECTION);
                         assertThat(unit.getStatus()).isEqualTo(StockUnitStatus.AVAILABLE);
                       });
             });
@@ -179,6 +187,28 @@ class PurchaseOrderReceiptMaterializationIT {
         .isEmpty();
 
     batchService.releaseFromQc(batch.getId());
+
+    var decisions =
+        qualityDecisionRepository
+            .findByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(
+                TENANT_ID, batch.getId(), PageRequest.of(0, 20))
+            .getContent();
+    assertThat(decisions)
+        .singleElement()
+        .satisfies(
+            decision -> {
+              assertThat(decision.getActorId()).isEqualTo(TenantContext.SYSTEM_ACTOR_ID);
+              assertThat(decision.getOrigin()).isEqualTo(QualityDecisionOrigin.SYSTEM_RELEASE);
+              assertThat(
+                      qualityDecisionUnitRepository.countByTenantIdAndDecisionId(
+                          TENANT_ID, decision.getId()))
+                  .isEqualTo(2);
+            });
+    assertThat(
+            stockUnitRepository.findByTenantIdAndBatchIdInAndIsActiveTrue(
+                TENANT_ID, List.of(batch.getId())))
+        .extracting(unit -> unit.getQualityDisposition())
+        .containsOnly(QualityDisposition.RELEASED);
 
     var lots =
         availabilityQueryService.lots(

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitTest.java
@@ -43,6 +43,7 @@ class StockUnitTest {
         "KG",
         UUID.randomUUID(),
         StockUnitSourceType.PRODUCTION,
-        UUID.randomUUID());
+        UUID.randomUUID(),
+        QualityDisposition.PENDING_INSPECTION);
   }
 }

--- a/src/test/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnitTest.java
@@ -1,9 +1,12 @@
 package com.fabricmanagement.production.execution.stockunit.domain;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fabricmanagement.production.execution.stockunit.domain.exception.QcRelocationException;
 import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitDomainException;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.StockUnitNotReleasedException;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import java.math.BigDecimal;
 import java.util.UUID;
@@ -30,7 +33,87 @@ class StockUnitTest {
     assertThrows(StockUnitDomainException.class, () -> unit.recordLength(null, "M"));
   }
 
+  @Test
+  void unreleasedDispositionsCannotBeReservedConsumedOrTransferred() {
+    for (QualityDisposition disposition :
+        new QualityDisposition[] {
+          QualityDisposition.PENDING_INSPECTION,
+          QualityDisposition.QUARANTINED,
+          QualityDisposition.NONCONFORMING
+        }) {
+      StockUnit unit = stockUnit(disposition, UUID.randomUUID());
+
+      StockUnitNotReleasedException reserveError =
+          assertThrows(StockUnitNotReleasedException.class, unit::reserve);
+      assertEquals("STOCK_UNIT_NOT_RELEASED", reserveError.getErrorCode());
+      assertThrows(StockUnitNotReleasedException.class, () -> unit.consume(BigDecimal.ONE));
+      assertThrows(
+          StockUnitNotReleasedException.class, () -> unit.startTransfer(UUID.randomUUID()));
+    }
+  }
+
+  @Test
+  void releasedDispositionPassesCommitmentQualityGate() {
+    StockUnit reservable = stockUnit(QualityDisposition.RELEASED, UUID.randomUUID());
+    StockUnit consumable = stockUnit(QualityDisposition.RELEASED, UUID.randomUUID());
+    StockUnit transferable = stockUnit(QualityDisposition.RELEASED, UUID.randomUUID());
+
+    reservable.reserve();
+    consumable.consume(BigDecimal.ONE);
+    transferable.startTransfer(UUID.randomUUID());
+
+    assertEquals(StockUnitStatus.RESERVED, reservable.getStatus());
+    assertEquals(StockUnitStatus.PARTIAL, consumable.getStatus());
+    assertEquals(StockUnitStatus.IN_TRANSIT, transferable.getStatus());
+  }
+
+  @Test
+  void qualityRelocationChangesOnlyLocation() {
+    UUID source = UUID.randomUUID();
+    UUID target = UUID.randomUUID();
+    StockUnit quarantined = stockUnit(QualityDisposition.QUARANTINED, source);
+    quarantined.quarantine();
+    StockUnitStatus status = quarantined.getStatus();
+    QualityDisposition disposition = quarantined.getQualityDisposition();
+
+    quarantined.relocateForQuality(target);
+
+    assertEquals(source, quarantined.getPreviousLocationId());
+    assertEquals(target, quarantined.getLocationId());
+    assertSame(status, quarantined.getStatus());
+    assertSame(disposition, quarantined.getQualityDisposition());
+  }
+
+  @Test
+  void disposedNonconformingUnitCannotBeRelocated() {
+    StockUnit nonconforming = stockUnit(QualityDisposition.NONCONFORMING, UUID.randomUUID());
+    nonconforming.hold();
+    nonconforming.dispose();
+
+    QcRelocationException error =
+        assertThrows(
+            QcRelocationException.class, () -> nonconforming.relocateForQuality(UUID.randomUUID()));
+
+    assertEquals("QC_RELOCATE_STATUS_INVALID", error.getErrorCode());
+    assertEquals(StockUnitStatus.DISPOSED, nonconforming.getStatus());
+  }
+
+  @Test
+  void relocationToCurrentLocationIsRejected() {
+    UUID location = UUID.randomUUID();
+    StockUnit pending = stockUnit(QualityDisposition.PENDING_INSPECTION, location);
+
+    QcRelocationException error =
+        assertThrows(QcRelocationException.class, () -> pending.relocateForQuality(location));
+
+    assertEquals("QC_RELOCATE_SAME_LOCATION", error.getErrorCode());
+  }
+
   private StockUnit stockUnit() {
+    return stockUnit(QualityDisposition.PENDING_INSPECTION, UUID.randomUUID());
+  }
+
+  private StockUnit stockUnit(QualityDisposition disposition, UUID locationId) {
     return StockUnit.create(
         UUID.randomUUID(),
         UUID.randomUUID(),
@@ -41,9 +124,9 @@ class StockUnitTest {
         new BigDecimal("45.000"),
         null,
         "KG",
-        UUID.randomUUID(),
+        locationId,
         StockUnitSourceType.PRODUCTION,
         UUID.randomUUID(),
-        QualityDisposition.PENDING_INSPECTION);
+        disposition);
   }
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
@@ -1,0 +1,153 @@
+package com.fabricmanagement.production.quality.decision.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionQueryService;
+import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
+import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(QualityDecisionController.class)
+@EnableMethodSecurity
+class QualityDecisionControllerSecurityTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private QualityDecisionService decisionService;
+  @MockBean private QualityDecisionQueryService queryService;
+  @MockBean private QualityDecisionMapper mapper;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  @BeforeEach
+  void setUpTenantContext() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(ACTOR_ID);
+  }
+
+  @AfterEach
+  void clearTenantContext() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void queueRequiresAuthentication() throws Exception {
+    mockMvc.perform(get("/api/v1/production/quality/queue")).andExpect(status().isUnauthorized());
+  }
+
+  @Test
+  @WithMockUser
+  void workerWithoutApproveCannotRecordDecision() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("approve")))
+        .thenReturn(false);
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/quality/batches/{batchId}/decisions", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"scope":"FULL_LOT","outcome":"RELEASED"}
+                    """))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @WithMockUser
+  void supervisorWithApproveCanRecordDecision() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("approve")))
+        .thenReturn(true);
+    QualityDecision decision =
+        QualityDecision.create(
+            TENANT_ID,
+            BATCH_ID,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            null,
+            ACTOR_ID,
+            QualityDecisionOrigin.MANUAL,
+            null,
+            null,
+            1,
+            Instant.now());
+    QualityDecisionDto dto =
+        new QualityDecisionDto(
+            decision.getId(),
+            BATCH_ID,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            null,
+            ACTOR_ID,
+            QualityDecisionOrigin.MANUAL,
+            null,
+            null,
+            decision.getDecidedAt(),
+            1);
+    when(decisionService.recordDecision(any(), any())).thenReturn(decision);
+    when(mapper.toDto(decision)).thenReturn(dto);
+
+    mockMvc
+        .perform(
+            post("/api/v1/production/quality/batches/{batchId}/decisions", BATCH_ID)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {"scope":"FULL_LOT","outcome":"RELEASED"}
+                    """))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.data.actorId").value(ACTOR_ID.toString()))
+        .andExpect(jsonPath("$.data.origin").value("MANUAL"));
+  }
+
+  @Test
+  @WithMockUser
+  void qualityReadAllowsPendingQueue() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("read"))).thenReturn(true);
+    when(queryService.getQueue(any())).thenReturn(Page.empty());
+
+    mockMvc
+        .perform(get("/api/v1/production/quality/queue"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.content").isArray());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityRbacContractTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityRbacContractTest.java
@@ -1,0 +1,46 @@
+package com.fabricmanagement.production.quality.decision.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.production.execution.batch.api.controller.BatchController;
+import com.fabricmanagement.production.masterdata.qualitygrade.api.QualityGradeController;
+import com.fabricmanagement.production.quality.decision.dto.RecordQualityDecisionRequest;
+import com.fabricmanagement.production.quality.result.api.controller.FiberTestResultController;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+class QualityRbacContractTest {
+
+  @Test
+  void approvalAndMasterDataMutationsUseElevatedQualityActions() {
+    assertAction(FiberTestResultController.class, "updateApproval", "quality', 'approve");
+    assertAction(QualityGradeController.class, "create", "quality', 'manage");
+    assertAction(QualityGradeController.class, "update", "quality', 'manage");
+    assertAction(QualityGradeController.class, "deactivate", "quality', 'manage");
+    assertAction(BatchController.class, "overrideStatus", "quality', 'approve");
+  }
+
+  @Test
+  void httpDecisionContractCannotAcceptTrustedProvenanceFields() {
+    var componentNames =
+        Arrays.stream(RecordQualityDecisionRequest.class.getRecordComponents())
+            .map(component -> component.getName())
+            .collect(Collectors.toSet());
+
+    assertThat(componentNames).doesNotContain("actorId", "origin", "sourceEventId", "decidedAt");
+  }
+
+  private void assertAction(Class<?> controller, String methodName, String expectedFragment) {
+    Method method =
+        Arrays.stream(controller.getDeclaredMethods())
+            .filter(candidate -> candidate.getName().equals(methodName))
+            .findFirst()
+            .orElseThrow();
+    PreAuthorize annotation = method.getAnnotation(PreAuthorize.class);
+    assertThat(annotation).isNotNull();
+    assertThat(annotation.value()).contains(expectedFragment);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionServiceTest.java
@@ -189,6 +189,85 @@ class QualityDecisionServiceTest {
   }
 
   @Test
+  void selectedDecisionCanInspectUntouchedUnitAfterEarlierConsumptionAndSkipsProjection() {
+    Batch batch = batch(BatchStatus.IN_PROGRESS);
+    batch.setConsumedQuantity(new BigDecimal("5.000"));
+    StockUnit selected = unit("ROLL-AFTER-CONSUMPTION");
+    UUID selectedId = selected.getId();
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.lockSelectedDecisionPopulation(
+            eq(TENANT_ID), eq(BATCH_ID), eq(Set.of(selectedId)), anyCollection()))
+        .thenReturn(List.of(selected));
+    when(decisionRepository.findMaxSeq(TENANT_ID, BATCH_ID)).thenReturn(2L);
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            eq(List.of(selectedId)),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(1);
+
+    QualityDecision decision =
+        service.recordDecision(
+            TrustedDecisionContext.manual(ACTOR_ID),
+            new QualityDecisionCommand(
+                BATCH_ID,
+                QualityDecisionScope.SELECTED_UNITS,
+                QualityDecisionOutcome.RELEASED,
+                null,
+                "Remaining roll passed inspection",
+                Set.of(selectedId),
+                null));
+
+    assertThat(decision.getSeq()).isEqualTo(3);
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.IN_PROGRESS);
+    verify(stockUnitRepository, never()).countQualityDispositions(any(), any());
+    verify(batchRepository, never()).save(batch);
+  }
+
+  @Test
+  void unresolvedBatchReservationStillBlocksSelectedUnitDecision() {
+    Batch batch = batch(BatchStatus.AVAILABLE);
+    batch.setReservedQuantity(BigDecimal.ONE);
+    UUID selectedId = UUID.randomUUID();
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+
+    assertThatThrownBy(
+            () ->
+                service.recordDecision(
+                    TrustedDecisionContext.manual(ACTOR_ID),
+                    new QualityDecisionCommand(
+                        BATCH_ID,
+                        QualityDecisionScope.SELECTED_UNITS,
+                        QualityDecisionOutcome.RELEASED,
+                        null,
+                        null,
+                        Set.of(selectedId),
+                        null)))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("AVAILABLE");
+
+    verify(stockUnitRepository, never())
+        .lockSelectedDecisionPopulation(any(), any(), anyCollection(), anyCollection());
+  }
+
+  @Test
+  void fullLotDecisionRemainsBlockedAfterConsumption() {
+    Batch batch = batch(BatchStatus.QUARANTINE);
+    batch.setConsumedQuantity(BigDecimal.ONE);
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+
+    assertThatThrownBy(() -> service.releaseFromQc(BATCH_ID))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("QUARANTINE");
+
+    verify(stockUnitRepository, never()).lockDecisionPopulation(any(), any(), anyCollection());
+  }
+
+  @Test
   void liveReservationBlocksDecisionEvenWhenLegacyBatchStatusStillAvailable() {
     Batch batch = batch(BatchStatus.AVAILABLE);
     batch.setReservedQuantity(BigDecimal.ONE);

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionServiceTest.java
@@ -1,0 +1,450 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
+import com.fabricmanagement.production.quality.decision.domain.exception.QualityDecisionException;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionUnitRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class QualityDecisionServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID ACTOR_ID = UUID.randomUUID();
+  private static final UUID BATCH_ID = UUID.randomUUID();
+
+  @Mock private BatchRepository batchRepository;
+  @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private QualityDecisionRepository decisionRepository;
+  @Mock private QualityDecisionUnitRepository decisionUnitRepository;
+  @InjectMocks private QualityDecisionService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    TenantContext.setCurrentUserId(ACTOR_ID);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void fullLotReleaseWritesLedgerUpdatesEveryUnitAndProjectsAvailable() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    StockUnit first = unit("ROLL-1");
+    StockUnit second = unit("ROLL-2");
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, BATCH_ID))
+        .thenReturn(2L);
+    when(stockUnitRepository.lockDecisionPopulation(eq(TENANT_ID), eq(BATCH_ID), anyCollection()))
+        .thenReturn(List.of(first, second));
+    when(decisionRepository.findMaxSeq(TENANT_ID, BATCH_ID)).thenReturn(4L);
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            anyCollection(),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(2);
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, BATCH_ID))
+        .thenReturn(List.of(dispositionCount(QualityDisposition.RELEASED, 2)));
+
+    QualityDecision result =
+        service.recordDecision(
+            TrustedDecisionContext.manual(ACTOR_ID),
+            new QualityDecisionCommand(
+                BATCH_ID,
+                QualityDecisionScope.FULL_LOT,
+                QualityDecisionOutcome.RELEASED,
+                null,
+                "accepted",
+                Set.of(),
+                null));
+
+    assertThat(result.getSeq()).isEqualTo(5);
+    assertThat(result.getActorId()).isEqualTo(ACTOR_ID);
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+    verify(decisionRepository).save(result);
+    verify(decisionUnitRepository).saveAll(any());
+    verify(batchRepository).save(batch);
+  }
+
+  @Test
+  void selectedDecisionRejectsUnitOutsideEligiblePopulation() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    UUID requestedId = UUID.randomUUID();
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.lockSelectedDecisionPopulation(
+            eq(TENANT_ID), eq(BATCH_ID), eq(Set.of(requestedId)), anyCollection()))
+        .thenReturn(List.of());
+
+    assertThatThrownBy(
+            () ->
+                service.recordDecision(
+                    TrustedDecisionContext.manual(ACTOR_ID),
+                    new QualityDecisionCommand(
+                        BATCH_ID,
+                        QualityDecisionScope.SELECTED_UNITS,
+                        QualityDecisionOutcome.QUARANTINED,
+                        QualityReasonCode.AWAITING_LAB,
+                        null,
+                        Set.of(requestedId),
+                        null)))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("Selected StockUnits");
+    verify(decisionRepository, never()).save(any());
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = BatchStatus.class,
+      names = {"RESERVED", "IN_PROGRESS", "ON_HOLD", "DEPLETED", "RETURNED", "DESTROYED"})
+  void activeAndTerminalBatchesCannotBeRewrittenByQualityProjection(BatchStatus status) {
+    Batch batch = batch(status);
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+
+    assertThatThrownBy(() -> service.releaseFromQc(BATCH_ID))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining(status.name());
+    verify(stockUnitRepository, never()).lockDecisionPopulation(any(), any(), anyCollection());
+  }
+
+  @Test
+  void selectedDecisionUpdatesOnlyFrozenUnitsAndProjectsMixedLotToQuarantine() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    StockUnit selected = unit("ROLL-SELECTED");
+    UUID selectedId = selected.getId();
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.lockSelectedDecisionPopulation(
+            eq(TENANT_ID), eq(BATCH_ID), eq(Set.of(selectedId)), anyCollection()))
+        .thenReturn(List.of(selected));
+    when(decisionRepository.findMaxSeq(TENANT_ID, BATCH_ID)).thenReturn(0L);
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            eq(List.of(selectedId)),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(1);
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, BATCH_ID))
+        .thenReturn(
+            List.of(
+                dispositionCount(QualityDisposition.RELEASED, 1),
+                dispositionCount(QualityDisposition.PENDING_INSPECTION, 1)));
+
+    service.recordDecision(
+        TrustedDecisionContext.manual(ACTOR_ID),
+        new QualityDecisionCommand(
+            BATCH_ID,
+            QualityDecisionScope.SELECTED_UNITS,
+            QualityDecisionOutcome.RELEASED,
+            null,
+            null,
+            Set.of(selectedId),
+            null));
+
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.QUARANTINE);
+    verify(decisionUnitRepository).saveAll(any());
+  }
+
+  @Test
+  void liveReservationBlocksDecisionEvenWhenLegacyBatchStatusStillAvailable() {
+    Batch batch = batch(BatchStatus.AVAILABLE);
+    batch.setReservedQuantity(BigDecimal.ONE);
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+
+    assertThatThrownBy(() -> service.releaseFromQc(BATCH_ID))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("AVAILABLE");
+    verify(stockUnitRepository, never()).lockDecisionPopulation(any(), any(), anyCollection());
+  }
+
+  @Test
+  void bulkRowCountMismatchRejectsPopulationDriftBeforeProjection() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    StockUnit unit = unit("ROLL-DRIFT");
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, BATCH_ID))
+        .thenReturn(1L);
+    when(stockUnitRepository.lockDecisionPopulation(eq(TENANT_ID), eq(BATCH_ID), anyCollection()))
+        .thenReturn(List.of(unit));
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            anyCollection(),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(0);
+
+    assertThatThrownBy(
+            () ->
+                service.recordDecision(
+                    TrustedDecisionContext.manual(ACTOR_ID),
+                    new QualityDecisionCommand(
+                        BATCH_ID,
+                        QualityDecisionScope.FULL_LOT,
+                        QualityDecisionOutcome.RELEASED,
+                        null,
+                        null,
+                        Set.of(),
+                        null)))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("population changed");
+    verify(batchRepository, never()).save(batch);
+  }
+
+  @Test
+  void fullLotRejectsWhenConcurrentOperationalChangeRemovesAUnitFromEligiblePopulation() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, BATCH_ID))
+        .thenReturn(2L);
+    when(stockUnitRepository.lockDecisionPopulation(eq(TENANT_ID), eq(BATCH_ID), anyCollection()))
+        .thenReturn(List.of(unit("ROLL-STILL-ELIGIBLE")));
+
+    assertThatThrownBy(() -> service.releaseFromQc(BATCH_ID))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("population changed");
+    verify(decisionRepository, never()).save(any());
+  }
+
+  @Test
+  void manualOriginCannotSubmitSystemReasonCode() {
+    assertThatThrownBy(
+            () ->
+                service.recordDecision(
+                    TrustedDecisionContext.manual(ACTOR_ID),
+                    new QualityDecisionCommand(
+                        BATCH_ID,
+                        QualityDecisionScope.FULL_LOT,
+                        QualityDecisionOutcome.RELEASED,
+                        QualityReasonCode.SYSTEM_QC_PASSED,
+                        null,
+                        Set.of(),
+                        null)))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("Reason code");
+    verify(batchRepository, never()).findByIdAndTenantIdForUpdate(any(), any());
+  }
+
+  @Test
+  void releaseFromQcUsesSystemActorAndSystemReason() {
+    Batch batch = batch(BatchStatus.PENDING_QC);
+    StockUnit unit = unit("ROLL-SYSTEM");
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, BATCH_ID))
+        .thenReturn(1L);
+    when(stockUnitRepository.lockDecisionPopulation(eq(TENANT_ID), eq(BATCH_ID), anyCollection()))
+        .thenReturn(List.of(unit));
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            anyCollection(),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(1);
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, BATCH_ID))
+        .thenReturn(List.of(dispositionCount(QualityDisposition.RELEASED, 1)));
+
+    QualityDecision decision = service.releaseFromQc(BATCH_ID);
+
+    assertThat(decision.getActorId()).isEqualTo(TenantContext.SYSTEM_ACTOR_ID);
+    assertThat(decision.getReasonCode()).isEqualTo(QualityReasonCode.SYSTEM_QC_PASSED);
+  }
+
+  @Test
+  void legacyOverrideWritesAReleasedDecisionThatSupersedesLatestLedgerEntry() {
+    Batch batch = batch(BatchStatus.QC_REJECTED);
+    StockUnit unit = unit("ROLL-OVERRIDE");
+    QualityDecision rejected =
+        QualityDecision.create(
+            TENANT_ID,
+            BATCH_ID,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.NONCONFORMING,
+            QualityReasonCode.DAMAGE,
+            "Damaged",
+            ACTOR_ID,
+            com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin.MANUAL,
+            null,
+            null,
+            1,
+            java.time.Instant.now());
+    when(batchRepository.findByIdAndTenantIdForUpdate(BATCH_ID, TENANT_ID))
+        .thenReturn(Optional.of(batch));
+    when(decisionRepository.findFirstByTenantIdAndBatchIdOrderByDecidedAtDescSeqDesc(
+            TENANT_ID, BATCH_ID))
+        .thenReturn(Optional.of(rejected));
+    when(decisionRepository.findByIdAndTenantId(rejected.getId(), TENANT_ID))
+        .thenReturn(Optional.of(rejected));
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, BATCH_ID))
+        .thenReturn(1L);
+    when(stockUnitRepository.lockDecisionPopulation(eq(TENANT_ID), eq(BATCH_ID), anyCollection()))
+        .thenReturn(List.of(unit));
+    when(decisionRepository.findMaxSeq(TENANT_ID, BATCH_ID)).thenReturn(1L);
+    when(stockUnitRepository.applyQualityDisposition(
+            eq(TENANT_ID),
+            eq(BATCH_ID),
+            anyCollection(),
+            anyCollection(),
+            eq(QualityDisposition.RELEASED)))
+        .thenReturn(1);
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, BATCH_ID))
+        .thenReturn(List.of(dispositionCount(QualityDisposition.RELEASED, 1)));
+
+    QualityDecision override =
+        service.overrideToReleased(BATCH_ID, "Manager reviewed and accepted the lot");
+
+    assertThat(override.getSupersedesDecisionId()).isEqualTo(rejected.getId());
+    assertThat(override.getRemarks()).isEqualTo("Manager reviewed and accepted the lot");
+    assertThat(override.getActorId()).isEqualTo(ACTOR_ID);
+    assertThat(batch.getStatus()).isEqualTo(BatchStatus.AVAILABLE);
+  }
+
+  @Test
+  void otherReasonRequiresRemarks() {
+    assertThatThrownBy(
+            () ->
+                service.recordDecision(
+                    TrustedDecisionContext.manual(ACTOR_ID),
+                    new QualityDecisionCommand(
+                        BATCH_ID,
+                        QualityDecisionScope.FULL_LOT,
+                        QualityDecisionOutcome.NONCONFORMING,
+                        QualityReasonCode.OTHER,
+                        " ",
+                        Set.of(),
+                        null)))
+        .isInstanceOf(QualityDecisionException.class)
+        .hasMessageContaining("Remarks");
+    verify(batchRepository, never()).findByIdAndTenantIdForUpdate(any(), any());
+  }
+
+  @Test
+  void duplicateQcEventReturnsExistingDecisionWithoutApplyingAgain() {
+    UUID eventId = UUID.randomUUID();
+    QualityDecision existing =
+        QualityDecision.create(
+            TENANT_ID,
+            BATCH_ID,
+            QualityDecisionScope.FULL_LOT,
+            QualityDecisionOutcome.RELEASED,
+            QualityReasonCode.SYSTEM_QC_PASSED,
+            null,
+            ACTOR_ID,
+            com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin
+                .SYSTEM_QC_EVENT,
+            eventId,
+            null,
+            1,
+            java.time.Instant.now());
+    when(decisionRepository.findByTenantIdAndSourceEventId(TENANT_ID, eventId))
+        .thenReturn(Optional.of(existing));
+
+    QualityDecision result =
+        service.recordDecision(
+            TrustedDecisionContext.qcEvent(ACTOR_ID, eventId),
+            new QualityDecisionCommand(
+                BATCH_ID,
+                QualityDecisionScope.FULL_LOT,
+                QualityDecisionOutcome.RELEASED,
+                QualityReasonCode.SYSTEM_QC_PASSED,
+                null,
+                Set.of(),
+                null));
+
+    assertThat(result).isSameAs(existing);
+    verify(batchRepository, never()).findByIdAndTenantIdForUpdate(any(), any());
+  }
+
+  private Batch batch(BatchStatus status) {
+    Batch batch = new Batch();
+    batch.setId(BATCH_ID);
+    batch.setTenantId(TENANT_ID);
+    batch.setBatchCode("LOT-QC-1");
+    batch.setStatus(status);
+    batch.setReservedQuantity(BigDecimal.ZERO);
+    batch.setConsumedQuantity(BigDecimal.ZERO);
+    return batch;
+  }
+
+  private StockUnit unit(String barcode) {
+    StockUnit unit =
+        StockUnit.create(
+            TENANT_ID,
+            BATCH_ID,
+            ProductType.FABRIC,
+            barcode,
+            null,
+            PackageType.ROLL,
+            new BigDecimal("25.000"),
+            null,
+            "KG",
+            UUID.randomUUID(),
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            QualityDisposition.PENDING_INSPECTION);
+    unit.setId(UUID.randomUUID());
+    return unit;
+  }
+
+  private StockUnitRepository.QualityDispositionCount dispositionCount(
+      QualityDisposition disposition, long count) {
+    return new StockUnitRepository.QualityDispositionCount() {
+      @Override
+      public QualityDisposition getDisposition() {
+        return disposition;
+      }
+
+      @Override
+      public long getUnitCount() {
+        return count;
+      }
+    };
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/infra/QualityDecisionMigrationIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/infra/QualityDecisionMigrationIT.java
@@ -1,0 +1,179 @@
+package com.fabricmanagement.production.quality.decision.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class QualityDecisionMigrationIT {
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("quality_decision_migration")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @BeforeAll
+  static void migrateToPreCutoverAndSeedLegacyRows() throws SQLException {
+    migrateTo("20260719120000");
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          INSERT INTO common_tenant.common_tenant (id, uid, slug, name, status)
+          VALUES ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'QC-MIGRATION',
+                  'qc-migration', 'QC Migration', 'ACTIVE');
+
+          INSERT INTO production.prod_product (id, tenant_id, uid, product_type, unit)
+          VALUES ('aaaaaaaa-0000-4000-8000-000000000001',
+                  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'QC-PRODUCT', 'FIBER', 'KG');
+
+          INSERT INTO production.production_execution_batch
+            (id, tenant_id, uid, product_id, product_type, batch_code, quantity,
+             reserved_quantity, consumed_quantity, waste_quantity, unit, status)
+          VALUES
+            ('aaaaaaaa-0000-4000-8000-000000000011', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'QC-BATCH-PENDING', 'aaaaaaaa-0000-4000-8000-000000000001', 'FIBER',
+             'QC-PENDING', 10, 0, 0, 0, 'KG', 'PENDING_QC'),
+            ('aaaaaaaa-0000-4000-8000-000000000012', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'QC-BATCH-AVAILABLE', 'aaaaaaaa-0000-4000-8000-000000000001', 'FIBER',
+             'QC-AVAILABLE', 10, 0, 0, 0, 'KG', 'AVAILABLE'),
+            ('aaaaaaaa-0000-4000-8000-000000000013', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'QC-BATCH-QUARANTINE', 'aaaaaaaa-0000-4000-8000-000000000001', 'FIBER',
+             'QC-QUARANTINE', 10, 0, 0, 0, 'KG', 'QUARANTINE'),
+            ('aaaaaaaa-0000-4000-8000-000000000014', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'QC-BATCH-REJECTED', 'aaaaaaaa-0000-4000-8000-000000000001', 'FIBER',
+             'QC-REJECTED', 10, 0, 0, 0, 'KG', 'QC_REJECTED'),
+            ('aaaaaaaa-0000-4000-8000-000000000015', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+             'QC-BATCH-UNIT-OVERRIDE', 'aaaaaaaa-0000-4000-8000-000000000001', 'FIBER',
+             'QC-UNIT-OVERRIDE', 10, 0, 0, 0, 'KG', 'AVAILABLE');
+
+          INSERT INTO production.stock_unit
+            (id, uid, created_at, updated_at, tenant_id, is_active, version, barcode, batch_id,
+             package_type, product_type, initial_weight, current_weight, unit, status,
+             source_type, source_id, flagged)
+          VALUES
+            ('aaaaaaaa-0000-4000-8000-000000000021', 'QC-UNIT-PENDING', now(), now(),
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, 0, 'QC-UNIT-PENDING',
+             'aaaaaaaa-0000-4000-8000-000000000011', 'BALE', 'FIBER', 10, 10, 'KG',
+             'AVAILABLE', 'GOODS_RECEIPT', gen_random_uuid(), false),
+            ('aaaaaaaa-0000-4000-8000-000000000022', 'QC-UNIT-AVAILABLE', now(), now(),
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, 0, 'QC-UNIT-AVAILABLE',
+             'aaaaaaaa-0000-4000-8000-000000000012', 'BALE', 'FIBER', 10, 10, 'KG',
+             'AVAILABLE', 'GOODS_RECEIPT', gen_random_uuid(), false),
+            ('aaaaaaaa-0000-4000-8000-000000000023', 'QC-UNIT-QUARANTINE-BATCH', now(), now(),
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, 0, 'QC-UNIT-QUARANTINE-BATCH',
+             'aaaaaaaa-0000-4000-8000-000000000013', 'BALE', 'FIBER', 10, 10, 'KG',
+             'AVAILABLE', 'GOODS_RECEIPT', gen_random_uuid(), false),
+            ('aaaaaaaa-0000-4000-8000-000000000024', 'QC-UNIT-REJECTED', now(), now(),
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, 0, 'QC-UNIT-REJECTED',
+             'aaaaaaaa-0000-4000-8000-000000000014', 'BALE', 'FIBER', 10, 10, 'KG',
+             'AVAILABLE', 'GOODS_RECEIPT', gen_random_uuid(), false),
+            ('aaaaaaaa-0000-4000-8000-000000000025', 'QC-UNIT-STATUS-OVERRIDE', now(), now(),
+             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true, 0, 'QC-UNIT-STATUS-OVERRIDE',
+             'aaaaaaaa-0000-4000-8000-000000000015', 'BALE', 'FIBER', 10, 10, 'KG',
+             'QUARANTINE', 'GOODS_RECEIPT', gen_random_uuid(), false);
+          """);
+    }
+  }
+
+  @Test
+  void backfillsDispositionLedgerPopulationAndEnforcesAppendOnlyTables() throws SQLException {
+    migrateTo("20260721120000");
+
+    Map<String, String> dispositionByBarcode = new HashMap<>();
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result =
+            statement.executeQuery(
+                "SELECT barcode, quality_disposition FROM production.stock_unit ORDER BY barcode")) {
+      while (result.next()) {
+        dispositionByBarcode.put(result.getString(1), result.getString(2));
+      }
+    }
+
+    assertThat(dispositionByBarcode)
+        .containsEntry("QC-UNIT-PENDING", "PENDING_INSPECTION")
+        .containsEntry("QC-UNIT-AVAILABLE", "RELEASED")
+        .containsEntry("QC-UNIT-QUARANTINE-BATCH", "QUARANTINED")
+        .containsEntry("QC-UNIT-REJECTED", "NONCONFORMING")
+        .containsEntry("QC-UNIT-STATUS-OVERRIDE", "QUARANTINED");
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.quality_decision "
+                    + "WHERE origin = 'MIGRATION_BACKFILL'"))
+        .isEqualTo(4);
+    assertThat(
+            count(
+                "SELECT count(*) FROM production.quality_decision "
+                    + "WHERE origin = 'MIGRATION_BACKFILL' AND decision_scope = 'FULL_LOT'"))
+        .isEqualTo(4);
+    assertThat(count("SELECT count(*) FROM production.quality_decision_unit")).isEqualTo(4);
+    assertThat(
+            count(
+                """
+                SELECT count(*)
+                FROM production.stock_unit su
+                JOIN production.quality_decision_unit qdu ON qdu.stock_unit_id = su.id
+                JOIN production.quality_decision qd ON qd.id = qdu.decision_id
+                WHERE su.quality_disposition <> 'PENDING_INSPECTION'
+                  AND qd.origin = 'MIGRATION_BACKFILL'
+                """))
+        .isEqualTo(4);
+
+    assertAppendOnly("UPDATE production.quality_decision SET remarks = 'mutated'");
+    assertAppendOnly("DELETE FROM production.quality_decision_unit");
+  }
+
+  private static void assertAppendOnly(String sql) {
+    assertThatThrownBy(
+            () -> {
+              try (Connection connection = ownerConnection();
+                  Statement statement = connection.createStatement()) {
+                statement.execute(sql);
+              }
+            })
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("append-only");
+  }
+
+  private static long count(String sql) throws SQLException {
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery(sql)) {
+      result.next();
+      return result.getLong(1);
+    }
+  }
+
+  private static void migrateTo(String target) {
+    Flyway.configure()
+        .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+        .locations("classpath:db/migration")
+        .schemas("common_tenant")
+        .defaultSchema("common_tenant")
+        .target(target)
+        .load()
+        .migrate();
+  }
+
+  private static Connection ownerConnection() throws SQLException {
+    return DriverManager.getConnection(
+        POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/infra/QualityDecisionMigrationIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/infra/QualityDecisionMigrationIT.java
@@ -140,6 +140,50 @@ class QualityDecisionMigrationIT {
     assertAppendOnly("DELETE FROM production.quality_decision_unit");
   }
 
+  @Test
+  void tenantPurgeGuardAllowsOnlyMatchingScopedDeletesAndRollsBackCleanly() throws SQLException {
+    migrateTo("20260721125000");
+
+    assertAppendOnly("DELETE FROM production.quality_decision_unit");
+    assertAppendOnlyWithPurgeTenant(
+        "DELETE FROM production.quality_decision_unit", "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    assertAppendOnlyWithPurgeTenant(
+        "UPDATE production.quality_decision SET remarks = 'mutated'",
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      connection.setAutoCommit(false);
+      statement.execute(
+          "SELECT set_config('app.quality_decision_purge_tenant', "
+              + "'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', true)");
+      assertThat(statement.executeUpdate("DELETE FROM production.quality_decision_unit"))
+          .isEqualTo(4);
+      assertThat(statement.executeUpdate("DELETE FROM production.quality_decision")).isEqualTo(4);
+      connection.rollback();
+    }
+
+    assertThat(count("SELECT count(*) FROM production.quality_decision_unit")).isEqualTo(4);
+    assertThat(count("SELECT count(*) FROM production.quality_decision")).isEqualTo(4);
+  }
+
+  private static void assertAppendOnlyWithPurgeTenant(String sql, String purgeTenant) {
+    assertThatThrownBy(
+            () -> {
+              try (Connection connection = ownerConnection();
+                  Statement statement = connection.createStatement()) {
+                connection.setAutoCommit(false);
+                statement.execute(
+                    "SELECT set_config('app.quality_decision_purge_tenant', '"
+                        + purgeTenant
+                        + "', true)");
+                statement.execute(sql);
+              }
+            })
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("append-only");
+  }
+
   private static void assertAppendOnly(String sql) {
     assertThatThrownBy(
             () -> {


### PR DESCRIPTION
…ase path

Implements ADR-0011 Faz 1 slice 1a (docs/production/tickets/QC-RELEASE-1a.md). Establishes the append-only quality-decision ledger and the single release path so purchased/produced PENDING_QC stock becomes available only through an immutable QualityDecision.

Model & migration:
- quality_decision + quality_decision_unit (population freeze), tenant-owned with composite tenant-safe FKs, UNIQUE(tenant_id,batch_id,seq) and UNIQUE(tenant_id,source_event_id); append-only enforced by a BEFORE UPDATE/DELETE trigger plus GRANT SELECT,INSERT only, and RLS FORCE.
- StockUnit.qualityDisposition column + deterministic backfill (fails loudly on any unmapped row) + MIGRATION_BACKFILL baseline ledger for every non-pending unit, so "no RELEASED without a decision" holds at baseline. Legacy status=QUARANTINE retained for manual operational review (logged).
- DB CHECK constraints mirror the outcome/origin/reason matrix.

Service:
- QualityDecisionService: FULL_LOT + SELECTED_UNITS, per-unit supersede, actor/origin from a server-owned TrustedDecisionContext (never the HTTP DTO), source_event_id idempotency (double-checked around the batch FOR UPDATE), deterministic ORDER BY id pessimistic locking of the target units, rowcount == frozen population check, and a 409 guard rejecting active or terminal batches (RESERVED/IN_PROGRESS/ON_HOLD/DEPLETED/RETURNED/DESTROYED or reserved/consumed > 0). Fail-closed BatchStatus projection via a dedicated Batch.applyQualityProjection that bypasses the transition matrix and refuses to overwrite committed state.

Single gate & birth:
- releaseFromQc, the QC event listener and the legacy batch override all route through the decision service. CONDITIONAL_ACCEPT no longer auto-maps to QUARANTINED — it leaves PENDING_INSPECTION and raises a concession-review notification. Goods receipt, manual create and production output all born PENDING_INSPECTION; disposition is never driven by client sourceType. Production confirmation projects the batch to PENDING_QC synchronously.

RBAC:
- quality:* seeded via PermissionTemplateSeeder catalog + backfill runner (not a migration). Escalation closed: fiber-test approval -> quality:approve, QualityGrade CRUD -> quality:manage, batch override-status -> quality:approve.

Endpoints: POST decision (quality:approve); paginated queue / history / units reads (quality:read). OpenAPI regenerated.

Tests: migration/backfill IT, RBAC contract + security, decision service (supersede, drift, locking, matrix, idempotency), listener, birth disposition, and PO receipt -> QC -> availability integration. Full suite green.

Ref: docs/architecture/ADR-0011-quality-decision-architecture.md.