### PR TITLE
feat(production): enrich pending-QC queue read model (QC-RELEASE-1c-1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -58628,28 +58628,63 @@ components:
       properties:
         batchCode:
           type: string
+          description: Internal batch or lot code
+        batchCreatedAt:
+          type: string
+          format: date-time
+          description: Batch creation timestamp
         batchId:
           type: string
           format: uuid
+          description: Batch identifier
+        colorId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Assigned tenant color-card identifier
+        colorName:
+          type:
+          - string
+          - "null"
+          description: Assigned tenant color-card name
         pendingUnitCount:
           type: integer
           format: int64
+          description: Number of active stock units awaiting inspection
+        productDisplayName:
+          type: string
+          description: Human-readable product name with the canonical UID as fallback
         productId:
           type: string
           format: uuid
+          description: Product identifier
         productType:
           type: string
+          description: Product type
           enum:
           - FIBER
           - YARN
           - FABRIC
           - CHEMICAL
           - CONSUMABLE
-        receivedAt:
+        productUid:
           type: string
-          format: date-time
+          description: Canonical product UID
         supplierBatchCode:
-          type: string
+          type:
+          - string
+          - "null"
+          description: Supplier batch or lot code
+      required:
+      - batchCode
+      - batchCreatedAt
+      - batchId
+      - pendingUnitCount
+      - productDisplayName
+      - productId
+      - productType
+      - productUid
     QuickCreateCustomerContactRequest:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34540,9 +34540,80 @@ paths:
       summary: Record a quality decision
       tags:
       - Quality Decisions
+  /api/v1/production/quality/batches/{batchId}/summary:
+    get:
+      operationId: getQualityBatchSummary
+      parameters:
+      - in: path
+        name: batchId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseQualityBatchSummaryDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get a QC batch summary
+      tags:
+      - Quality Decisions
   /api/v1/production/quality/batches/{batchId}/units:
     get:
-      operationId: listQualityDecisionUnits
+      operationId: listActiveQualityBatchUnits
       parameters:
       - in: path
         name: batchId
@@ -34635,7 +34706,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ApiProblemDetail"
           description: Internal Server Error
-      summary: List batch units for QC
+      summary: List all active batch units for QC
       tags:
       - Quality Decisions
   /api/v1/production/quality/fiber-tests:
@@ -48715,6 +48786,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponseQualityBatchSummaryDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/QualityBatchSummaryDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseQualityDecisionDto:
       type: object
       properties:
@@ -58483,6 +58572,83 @@ components:
           type: string
       required:
       - specType
+    QualityBatchSummaryDto:
+      type: object
+      properties:
+        batchCode:
+          type: string
+          description: Internal batch or lot code
+        batchCreatedAt:
+          type: string
+          format: date-time
+          description: Batch creation timestamp
+        batchId:
+          type: string
+          format: uuid
+          description: Batch identifier
+        colorId:
+          type:
+          - string
+          - "null"
+          format: uuid
+          description: Assigned tenant color-card identifier
+        colorName:
+          type:
+          - string
+          - "null"
+          description: Assigned tenant color-card name
+        nonconformingCount:
+          type: integer
+          format: int64
+          description: Active nonconforming units
+        pendingInspectionCount:
+          type: integer
+          format: int64
+          description: Active units awaiting inspection
+        productDisplayName:
+          type: string
+          description: Human-readable product name with the canonical UID as fallback
+        productId:
+          type: string
+          format: uuid
+          description: Product identifier
+        productType:
+          type: string
+          description: Product type
+          enum:
+          - FIBER
+          - YARN
+          - FABRIC
+          - CHEMICAL
+          - CONSUMABLE
+        productUid:
+          type: string
+          description: Canonical product UID
+        quarantinedCount:
+          type: integer
+          format: int64
+          description: Active quarantined units
+        releasedCount:
+          type: integer
+          format: int64
+          description: Active released units
+        totalCount:
+          type: integer
+          format: int64
+          description: Total active units
+      required:
+      - batchCode
+      - batchCreatedAt
+      - batchId
+      - nonconformingCount
+      - pendingInspectionCount
+      - productDisplayName
+      - productId
+      - productType
+      - productUid
+      - quarantinedCount
+      - releasedCount
+      - totalCount
     QualityDecisionDto:
       type: object
       properties:
@@ -58590,6 +58756,11 @@ components:
           - DISPOSED
         unit:
           type: string
+        unitStatusEligible:
+          type: boolean
+          description: Whether the unit status is eligible for a quality decision
+      required:
+      - unitStatusEligible
     QualityGradeDto:
       type: object
       properties:

--- a/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
@@ -45,6 +45,33 @@ public interface BatchRepository
 
   Optional<Batch> findByTenantIdAndBatchCode(UUID tenantId, String batchCode);
 
+  @Query(
+      value =
+          """
+          SELECT b.id AS batchId,
+                 b.batch_code AS batchCode,
+                 b.product_id AS productId,
+                 p.uid AS productUid,
+                 COALESCE(f.fiber_name, p.uid) AS productDisplayName,
+                 b.product_type AS productType,
+                 c.id AS colorId,
+                 c.name AS colorName,
+                 b.created_at AS batchCreatedAt
+          FROM production.production_execution_batch b
+          JOIN production.prod_product p
+            ON p.id = b.product_id
+          LEFT JOIN production.prod_fiber f
+            ON f.product_id = p.id
+          LEFT JOIN production.color c
+            ON c.id = b.color_id AND c.tenant_id = b.tenant_id
+          WHERE b.id = :batchId
+            AND b.tenant_id = :tenantId
+            AND b.is_active = TRUE
+          """,
+      nativeQuery = true)
+  Optional<QualityBatchSummaryRow> findQualityBatchSummary(
+      @Param("tenantId") UUID tenantId, @Param("batchId") UUID batchId);
+
   boolean existsByTenantIdAndBatchCode(UUID tenantId, String batchCode);
 
   /**
@@ -135,5 +162,25 @@ public interface BatchRepository
     String getColorName();
 
     String getColorHex();
+  }
+
+  interface QualityBatchSummaryRow {
+    UUID getBatchId();
+
+    String getBatchCode();
+
+    UUID getProductId();
+
+    String getProductUid();
+
+    String getProductDisplayName();
+
+    String getProductType();
+
+    UUID getColorId();
+
+    String getColorName();
+
+    java.time.Instant getBatchCreatedAt();
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
@@ -69,19 +69,29 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
           SELECT b.id AS batchId,
                  b.batch_code AS batchCode,
                  b.product_id AS productId,
+                 p.uid AS productUid,
                  b.product_type AS productType,
+                 COALESCE(f.fiber_name, p.uid) AS productDisplayName,
+                 c.id AS colorId,
+                 c.name AS colorName,
                  b.supplier_batch_code AS supplierBatchCode,
                  COUNT(s.id) AS pendingUnitCount,
-                 b.created_at AS createdAt
+                 b.created_at AS batchCreatedAt
           FROM production.stock_unit s
           JOIN production.production_execution_batch b
             ON b.id = s.batch_id AND b.tenant_id = s.tenant_id
+          JOIN production.prod_product p
+            ON p.id = b.product_id
+          LEFT JOIN production.prod_fiber f
+            ON f.product_id = p.id
+          LEFT JOIN production.color c
+            ON c.id = b.color_id AND c.tenant_id = b.tenant_id
           WHERE s.tenant_id = :tenantId
             AND s.is_active = TRUE
             AND b.is_active = TRUE
             AND s.quality_disposition = 'PENDING_INSPECTION'
-          GROUP BY b.id, b.batch_code, b.product_id, b.product_type,
-                   b.supplier_batch_code, b.created_at
+          GROUP BY b.id, b.batch_code, b.product_id, p.uid, b.product_type,
+                   f.fiber_name, c.id, c.name, b.supplier_batch_code, b.created_at
           ORDER BY b.created_at ASC, b.id ASC
           """,
       countQuery =
@@ -326,12 +336,20 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
 
     UUID getProductId();
 
+    String getProductUid();
+
     String getProductType();
+
+    String getProductDisplayName();
+
+    UUID getColorId();
+
+    String getColorName();
 
     String getSupplierBatchCode();
 
     long getPendingUnitCount();
 
-    java.time.Instant getCreatedAt();
+    java.time.Instant getBatchCreatedAt();
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
@@ -6,6 +6,7 @@ import com.fabricmanagement.common.infrastructure.web.PagedResponse;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionQueryService;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
+import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
@@ -71,14 +72,23 @@ public class QualityDecisionController {
             PagedResponse.from(queryService.getHistory(batchId, pageable), mapper::toDto)));
   }
 
+  @GetMapping("/batches/{batchId}/summary")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(operationId = "getQualityBatchSummary", summary = "Get a QC batch summary")
+  public ResponseEntity<ApiResponse<QualityBatchSummaryDto>> summary(@PathVariable UUID batchId) {
+    return ResponseEntity.ok(ApiResponse.success(queryService.getSummary(batchId)));
+  }
+
   @GetMapping("/batches/{batchId}/units")
   @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
-  @Operation(operationId = "listQualityDecisionUnits", summary = "List batch units for QC")
+  @Operation(
+      operationId = "listActiveQualityBatchUnits",
+      summary = "List all active batch units for QC")
   public ResponseEntity<ApiResponse<PagedResponse<QualityDecisionUnitDto>>> units(
       @PathVariable UUID batchId,
       @ParameterObject @PageableDefault(size = 20, sort = "barcode") Pageable pageable) {
     return ResponseEntity.ok(
         ApiResponse.success(
-            PagedResponse.from(queryService.getUnits(batchId, pageable), mapper::toUnitDto)));
+            PagedResponse.from(queryService.getActiveUnits(batchId, pageable), mapper::toUnitDto)));
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
@@ -46,10 +46,14 @@ public class QualityDecisionQueryService {
                     row.getBatchId(),
                     row.getBatchCode(),
                     row.getProductId(),
+                    row.getProductUid(),
                     ProductType.valueOf(row.getProductType()),
+                    row.getProductDisplayName(),
+                    row.getColorId(),
+                    row.getColorName(),
                     row.getSupplierBatchCode(),
                     row.getPendingUnitCount(),
-                    row.getCreatedAt()));
+                    row.getBatchCreatedAt()));
   }
 
   public Page<QualityDecision> getHistory(UUID batchId, Pageable pageable) {

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
@@ -1,16 +1,19 @@
 package com.fabricmanagement.production.quality.decision.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
-import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
-import java.util.EnumSet;
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -20,20 +23,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class QualityDecisionQueryService {
 
-  private static final Set<StockUnitStatus> DECISION_ELIGIBLE_STATUSES =
-      EnumSet.of(
-          StockUnitStatus.AVAILABLE,
-          StockUnitStatus.PARTIAL,
-          StockUnitStatus.QUARANTINE,
-          StockUnitStatus.ON_HOLD);
-
   private final QualityDecisionRepository decisionRepository;
   private final StockUnitRepository stockUnitRepository;
+  private final BatchRepository batchRepository;
 
   public QualityDecisionQueryService(
-      QualityDecisionRepository decisionRepository, StockUnitRepository stockUnitRepository) {
+      QualityDecisionRepository decisionRepository,
+      StockUnitRepository stockUnitRepository,
+      BatchRepository batchRepository) {
     this.decisionRepository = decisionRepository;
     this.stockUnitRepository = stockUnitRepository;
+    this.batchRepository = batchRepository;
   }
 
   public Page<QualityQueueItemDto> getQueue(Pageable pageable) {
@@ -61,8 +61,39 @@ public class QualityDecisionQueryService {
         TenantContext.requireTenantId(), batchId, pageable);
   }
 
-  public Page<StockUnit> getUnits(UUID batchId, Pageable pageable) {
-    return stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
-        TenantContext.requireTenantId(), batchId, DECISION_ELIGIBLE_STATUSES, pageable);
+  public QualityBatchSummaryDto getSummary(UUID batchId) {
+    UUID tenantId = TenantContext.requireTenantId();
+    var row =
+        batchRepository
+            .findQualityBatchSummary(tenantId, batchId)
+            .orElseThrow(() -> new NotFoundException("Batch not found: " + batchId));
+    Map<QualityDisposition, Long> counts =
+        stockUnitRepository.countQualityDispositions(tenantId, batchId).stream()
+            .collect(
+                Collectors.toMap(
+                    StockUnitRepository.QualityDispositionCount::getDisposition,
+                    StockUnitRepository.QualityDispositionCount::getUnitCount));
+    long totalCount = counts.values().stream().mapToLong(Long::longValue).sum();
+
+    return new QualityBatchSummaryDto(
+        row.getBatchId(),
+        row.getBatchCode(),
+        row.getProductId(),
+        row.getProductUid(),
+        row.getProductDisplayName(),
+        ProductType.valueOf(row.getProductType()),
+        row.getColorId(),
+        row.getColorName(),
+        row.getBatchCreatedAt(),
+        counts.getOrDefault(QualityDisposition.PENDING_INSPECTION, 0L),
+        counts.getOrDefault(QualityDisposition.RELEASED, 0L),
+        counts.getOrDefault(QualityDisposition.QUARANTINED, 0L),
+        counts.getOrDefault(QualityDisposition.NONCONFORMING, 0L),
+        totalCount);
+  }
+
+  public Page<StockUnit> getActiveUnits(UUID batchId, Pageable pageable) {
+    return stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(
+        TenantContext.requireTenantId(), batchId, pageable);
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
@@ -10,6 +10,7 @@ import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
@@ -35,11 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QualityDecisionService {
 
   private static final Set<StockUnitStatus> DECISION_ELIGIBLE_STATUSES =
-      EnumSet.of(
-          StockUnitStatus.AVAILABLE,
-          StockUnitStatus.PARTIAL,
-          StockUnitStatus.QUARANTINE,
-          StockUnitStatus.ON_HOLD);
+      QualityDecisionEligibility.unitStatusEligibleStatuses();
 
   private static final Set<BatchStatus> FULL_LOT_BLOCKED_BATCH_STATUSES =
       EnumSet.of(

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibility.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibility.java
@@ -1,0 +1,25 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import java.util.Set;
+
+/** Shared unit-status policy used by quality decision reads and writes. */
+public final class QualityDecisionEligibility {
+
+  private static final Set<StockUnitStatus> UNIT_STATUS_ELIGIBLE =
+      Set.of(
+          StockUnitStatus.AVAILABLE,
+          StockUnitStatus.PARTIAL,
+          StockUnitStatus.QUARANTINE,
+          StockUnitStatus.ON_HOLD);
+
+  private QualityDecisionEligibility() {}
+
+  public static Set<StockUnitStatus> unitStatusEligibleStatuses() {
+    return UNIT_STATUS_ELIGIBLE;
+  }
+
+  public static boolean isUnitStatusEligible(StockUnitStatus status) {
+    return UNIT_STATUS_ELIGIBLE.contains(status);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityBatchSummaryDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityBatchSummaryDto.java
@@ -1,0 +1,38 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record QualityBatchSummaryDto(
+    @Schema(description = "Batch identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID batchId,
+    @Schema(description = "Internal batch or lot code", requiredMode = Schema.RequiredMode.REQUIRED)
+        String batchCode,
+    @Schema(description = "Product identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID productId,
+    @Schema(description = "Canonical product UID", requiredMode = Schema.RequiredMode.REQUIRED)
+        String productUid,
+    @Schema(
+            description = "Human-readable product name with the canonical UID as fallback",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String productDisplayName,
+    @Schema(description = "Product type", requiredMode = Schema.RequiredMode.REQUIRED)
+        ProductType productType,
+    @Schema(description = "Assigned tenant color-card identifier", nullable = true) UUID colorId,
+    @Schema(description = "Assigned tenant color-card name", nullable = true) String colorName,
+    @Schema(description = "Batch creation timestamp", requiredMode = Schema.RequiredMode.REQUIRED)
+        Instant batchCreatedAt,
+    @Schema(
+            description = "Active units awaiting inspection",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        long pendingInspectionCount,
+    @Schema(description = "Active released units", requiredMode = Schema.RequiredMode.REQUIRED)
+        long releasedCount,
+    @Schema(description = "Active quarantined units", requiredMode = Schema.RequiredMode.REQUIRED)
+        long quarantinedCount,
+    @Schema(description = "Active nonconforming units", requiredMode = Schema.RequiredMode.REQUIRED)
+        long nonconformingCount,
+    @Schema(description = "Total active units", requiredMode = Schema.RequiredMode.REQUIRED)
+        long totalCount) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.production.quality.decision.dto;
 import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.util.UUID;
 
@@ -15,4 +16,8 @@ public record QualityDecisionUnitDto(
     BigDecimal length,
     String lengthUnit,
     StockUnitStatus status,
-    QualityDisposition qualityDisposition) {}
+    QualityDisposition qualityDisposition,
+    @Schema(
+            description = "Whether the unit status is eligible for a quality decision",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean unitStatusEligible) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityQueueItemDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityQueueItemDto.java
@@ -1,14 +1,31 @@
 package com.fabricmanagement.production.quality.decision.dto;
 
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
 
 public record QualityQueueItemDto(
-    UUID batchId,
-    String batchCode,
-    UUID productId,
-    ProductType productType,
-    String supplierBatchCode,
-    long pendingUnitCount,
-    Instant receivedAt) {}
+    @Schema(description = "Batch identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID batchId,
+    @Schema(description = "Internal batch or lot code", requiredMode = Schema.RequiredMode.REQUIRED)
+        String batchCode,
+    @Schema(description = "Product identifier", requiredMode = Schema.RequiredMode.REQUIRED)
+        UUID productId,
+    @Schema(description = "Canonical product UID", requiredMode = Schema.RequiredMode.REQUIRED)
+        String productUid,
+    @Schema(description = "Product type", requiredMode = Schema.RequiredMode.REQUIRED)
+        ProductType productType,
+    @Schema(
+            description = "Human-readable product name with the canonical UID as fallback",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        String productDisplayName,
+    @Schema(description = "Assigned tenant color-card identifier", nullable = true) UUID colorId,
+    @Schema(description = "Assigned tenant color-card name", nullable = true) String colorName,
+    @Schema(description = "Supplier batch or lot code", nullable = true) String supplierBatchCode,
+    @Schema(
+            description = "Number of active stock units awaiting inspection",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        long pendingUnitCount,
+    @Schema(description = "Batch creation timestamp", requiredMode = Schema.RequiredMode.REQUIRED)
+        Instant batchCreatedAt) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
@@ -3,17 +3,21 @@ package com.fabricmanagement.production.quality.decision.mapper;
 import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
-@Mapper(config = MapStructConfig.class)
+@Mapper(config = MapStructConfig.class, imports = QualityDecisionEligibility.class)
 public interface QualityDecisionMapper {
 
   @Mapping(target = "scope", source = "decisionScope")
   @Mapping(target = "sequence", source = "seq")
   QualityDecisionDto toDto(QualityDecision decision);
 
+  @Mapping(
+      target = "unitStatusEligible",
+      expression = "java(QualityDecisionEligibility.isUnitStatusEligible(stockUnit.getStatus()))")
   QualityDecisionUnitDto toUnitDto(StockUnit stockUnit);
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
@@ -11,12 +11,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionQueryService;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
+import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
 import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
 import java.time.Instant;
@@ -149,5 +151,34 @@ class QualityDecisionControllerSecurityTest {
         .perform(get("/api/v1/production/quality/queue"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.content").isArray());
+  }
+
+  @Test
+  @WithMockUser
+  void qualityReadAllowsBatchSummary() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("read"))).thenReturn(true);
+    when(queryService.getSummary(BATCH_ID))
+        .thenReturn(
+            new QualityBatchSummaryDto(
+                BATCH_ID,
+                "LOT-QC-001",
+                UUID.randomUUID(),
+                "SYS-MAT-000001",
+                "Cotton (100%)",
+                ProductType.FIBER,
+                null,
+                null,
+                Instant.parse("2026-07-21T08:00:00Z"),
+                2,
+                1,
+                0,
+                0,
+                3));
+
+    mockMvc
+        .perform(get("/api/v1/production/quality/batches/{batchId}/summary", BATCH_ID))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.batchCode").value("LOT-QC-001"))
+        .andExpect(jsonPath("$.data.totalCount").value(3));
   }
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
@@ -1,16 +1,22 @@
 package com.fabricmanagement.production.quality.decision.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,13 +34,15 @@ class QualityDecisionQueryServiceTest {
 
   @Mock private QualityDecisionRepository decisionRepository;
   @Mock private StockUnitRepository stockUnitRepository;
+  @Mock private BatchRepository batchRepository;
 
   private QualityDecisionQueryService service;
 
   @BeforeEach
   void setUp() {
     TenantContext.setCurrentTenantId(TENANT_ID);
-    service = new QualityDecisionQueryService(decisionRepository, stockUnitRepository);
+    service =
+        new QualityDecisionQueryService(decisionRepository, stockUnitRepository, batchRepository);
   }
 
   @AfterEach
@@ -83,5 +91,73 @@ class QualityDecisionQueryServiceTest {
               assertThat(item.batchCreatedAt()).isEqualTo(createdAt);
             });
     verify(stockUnitRepository).findQualityQueue(TENANT_ID, pageable);
+  }
+
+  @Test
+  void mapsTheTenantSafeBatchSummaryAndAllDispositionCounts() {
+    var batchId = UUID.randomUUID();
+    var productId = UUID.randomUUID();
+    var colorId = UUID.randomUUID();
+    var createdAt = Instant.parse("2026-07-21T08:00:00Z");
+    var row = mock(BatchRepository.QualityBatchSummaryRow.class);
+    when(row.getBatchId()).thenReturn(batchId);
+    when(row.getBatchCode()).thenReturn("LOT-QC-001");
+    when(row.getProductId()).thenReturn(productId);
+    when(row.getProductUid()).thenReturn("SYS-MAT-000001");
+    when(row.getProductDisplayName()).thenReturn("Cotton (100%)");
+    when(row.getProductType()).thenReturn(ProductType.FIBER.name());
+    when(row.getColorId()).thenReturn(colorId);
+    when(row.getColorName()).thenReturn("Navy");
+    when(row.getBatchCreatedAt()).thenReturn(createdAt);
+    when(batchRepository.findQualityBatchSummary(TENANT_ID, batchId)).thenReturn(Optional.of(row));
+    var dispositionCounts =
+        List.of(
+            dispositionCount(QualityDisposition.PENDING_INSPECTION, 2),
+            dispositionCount(QualityDisposition.RELEASED, 3),
+            dispositionCount(QualityDisposition.QUARANTINED, 1),
+            dispositionCount(QualityDisposition.NONCONFORMING, 4));
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, batchId))
+        .thenReturn(dispositionCounts);
+
+    var result = service.getSummary(batchId);
+
+    assertThat(result.batchId()).isEqualTo(batchId);
+    assertThat(result.productId()).isEqualTo(productId);
+    assertThat(result.productDisplayName()).isEqualTo("Cotton (100%)");
+    assertThat(result.colorId()).isEqualTo(colorId);
+    assertThat(result.pendingInspectionCount()).isEqualTo(2);
+    assertThat(result.releasedCount()).isEqualTo(3);
+    assertThat(result.quarantinedCount()).isEqualTo(1);
+    assertThat(result.nonconformingCount()).isEqualTo(4);
+    assertThat(result.totalCount()).isEqualTo(10);
+  }
+
+  @Test
+  void summaryRejectsMissingOrCrossTenantBatchWithoutCountingUnits() {
+    var batchId = UUID.randomUUID();
+    when(batchRepository.findQualityBatchSummary(TENANT_ID, batchId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.getSummary(batchId)).isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void activeUnitsReadDoesNotApplyTheDecisionStatusFilter() {
+    var batchId = UUID.randomUUID();
+    var pageable = PageRequest.of(0, 20);
+    var stockUnit = mock(StockUnit.class);
+    when(stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId, pageable))
+        .thenReturn(new PageImpl<>(List.of(stockUnit), pageable, 1));
+
+    assertThat(service.getActiveUnits(batchId, pageable)).containsExactly(stockUnit);
+    verify(stockUnitRepository)
+        .findByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId, pageable);
+  }
+
+  private static StockUnitRepository.QualityDispositionCount dispositionCount(
+      QualityDisposition disposition, long unitCount) {
+    var count = mock(StockUnitRepository.QualityDispositionCount.class);
+    when(count.getDisposition()).thenReturn(disposition);
+    when(count.getUnitCount()).thenReturn(unitCount);
+    return count;
   }
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
@@ -1,0 +1,87 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class QualityDecisionQueryServiceTest {
+
+  private static final UUID TENANT_ID = UUID.fromString("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1");
+
+  @Mock private QualityDecisionRepository decisionRepository;
+  @Mock private StockUnitRepository stockUnitRepository;
+
+  private QualityDecisionQueryService service;
+
+  @BeforeEach
+  void setUp() {
+    TenantContext.setCurrentTenantId(TENANT_ID);
+    service = new QualityDecisionQueryService(decisionRepository, stockUnitRepository);
+  }
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void mapsTheSelfContainedQueueProjectionWithOneRepositoryCall() {
+    var pageable = PageRequest.of(0, 20);
+    var batchId = UUID.randomUUID();
+    var productId = UUID.randomUUID();
+    var colorId = UUID.randomUUID();
+    var createdAt = Instant.parse("2026-07-21T08:00:00Z");
+    var row = mock(StockUnitRepository.QualityQueueRow.class);
+    when(row.getBatchId()).thenReturn(batchId);
+    when(row.getBatchCode()).thenReturn("LOT-QC-001");
+    when(row.getProductId()).thenReturn(productId);
+    when(row.getProductUid()).thenReturn("SYS-MAT-000001");
+    when(row.getProductType()).thenReturn(ProductType.FIBER.name());
+    when(row.getProductDisplayName()).thenReturn("Cotton (100%)");
+    when(row.getColorId()).thenReturn(colorId);
+    when(row.getColorName()).thenReturn("Navy");
+    when(row.getSupplierBatchCode()).thenReturn("SUP-LOT-9");
+    when(row.getPendingUnitCount()).thenReturn(3L);
+    when(row.getBatchCreatedAt()).thenReturn(createdAt);
+    when(stockUnitRepository.findQualityQueue(TENANT_ID, pageable))
+        .thenReturn(new PageImpl<>(List.of(row), pageable, 1));
+
+    var result = service.getQueue(pageable);
+
+    assertThat(result)
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.batchId()).isEqualTo(batchId);
+              assertThat(item.batchCode()).isEqualTo("LOT-QC-001");
+              assertThat(item.productId()).isEqualTo(productId);
+              assertThat(item.productUid()).isEqualTo("SYS-MAT-000001");
+              assertThat(item.productType()).isEqualTo(ProductType.FIBER);
+              assertThat(item.productDisplayName()).isEqualTo("Cotton (100%)");
+              assertThat(item.colorId()).isEqualTo(colorId);
+              assertThat(item.colorName()).isEqualTo("Navy");
+              assertThat(item.supplierBatchCode()).isEqualTo("SUP-LOT-9");
+              assertThat(item.pendingUnitCount()).isEqualTo(3);
+              assertThat(item.batchCreatedAt()).isEqualTo(createdAt);
+            });
+    verify(stockUnitRepository).findQualityQueue(TENANT_ID, pageable);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
@@ -1,8 +1,12 @@
 package com.fabricmanagement.production.quality.decision.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.tenant.domain.Tenant;
+import com.fabricmanagement.platform.tenant.infra.repository.TenantRepository;
 import com.fabricmanagement.production.execution.batch.domain.Batch;
 import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
@@ -11,6 +15,7 @@ import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.color.domain.Color;
 import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
@@ -20,6 +25,7 @@ import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
@@ -27,15 +33,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 class QualityQueueReadModelIT extends AbstractIntegrationTest {
 
   @Autowired private QualityDecisionQueryService service;
+  @Autowired private TenantRepository tenantRepository;
   @Autowired private ProductRepository productRepository;
   @Autowired private FiberRepository fiberRepository;
   @Autowired private ColorRepository colorRepository;
   @Autowired private BatchRepository batchRepository;
   @Autowired private StockUnitRepository stockUnitRepository;
+  @Autowired private JdbcTemplate jdbcTemplate;
 
   private UUID tenantId;
   private UUID otherTenantId;
@@ -44,8 +54,8 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
 
   @BeforeEach
   void setUp() {
-    tenantId = UUID.randomUUID();
-    otherTenantId = UUID.randomUUID();
+    tenantId = saveTenant("primary");
+    otherTenantId = saveTenant("other");
     TenantContext.setCurrentTenantId(tenantId);
     TenantContext.setCurrentUserId(UUID.randomUUID());
 
@@ -129,6 +139,88 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
         .doesNotContain(otherTenant.getId());
   }
 
+  @Test
+  void returnsTenantSafeSummaryWithTheCompleteActiveDispositionBreakdown() {
+    Color navy =
+        colorRepository.saveAndFlush(
+            Color.create(tenantId, randomCode("DETAIL"), "QC detail navy", "#1F2A44"));
+    Batch batch =
+        saveBatch(
+            tenantId,
+            "LOT-QC-DETAIL-" + suffix(),
+            null,
+            navy.getId(),
+            Instant.parse("2026-07-21T09:00:00Z"));
+    saveUnit(tenantId, batch, QualityDisposition.PENDING_INSPECTION);
+    saveUnit(tenantId, batch, QualityDisposition.PENDING_INSPECTION);
+    saveUnit(tenantId, batch, QualityDisposition.RELEASED);
+    saveUnit(tenantId, batch, QualityDisposition.QUARANTINED);
+    saveUnit(tenantId, batch, QualityDisposition.NONCONFORMING);
+    StockUnit inactive = saveUnit(tenantId, batch, QualityDisposition.NONCONFORMING);
+    inactive.delete();
+    stockUnitRepository.saveAndFlush(inactive);
+
+    var summary = service.getSummary(batch.getId());
+
+    assertThat(summary.batchCode()).isEqualTo(batch.getBatchCode());
+    assertThat(summary.productId()).isEqualTo(sharedProduct.getId());
+    assertThat(summary.productUid()).isEqualTo(sharedProduct.getUid());
+    assertThat(summary.productDisplayName()).isEqualTo(sharedProductDisplayName);
+    assertThat(summary.colorId()).isEqualTo(navy.getId());
+    assertThat(summary.colorName()).isEqualTo("QC detail navy");
+    assertThat(summary.pendingInspectionCount()).isEqualTo(2);
+    assertThat(summary.releasedCount()).isEqualTo(1);
+    assertThat(summary.quarantinedCount()).isEqualTo(1);
+    assertThat(summary.nonconformingCount()).isEqualTo(1);
+    assertThat(summary.totalCount()).isEqualTo(5);
+
+    Batch colourless =
+        saveBatch(
+            tenantId,
+            "LOT-QC-COLOURLESS-" + suffix(),
+            null,
+            null,
+            Instant.parse("2026-07-21T09:30:00Z"));
+    var colourlessSummary = service.getSummary(colourless.getId());
+    assertThat(colourlessSummary.colorId()).isNull();
+    assertThat(colourlessSummary.colorName()).isNull();
+    assertThat(colourlessSummary.totalCount()).isZero();
+
+    TenantContext.setCurrentTenantId(otherTenantId);
+    assertThatThrownBy(() -> service.getSummary(batch.getId()))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void activeUnitsReadIncludesOperationallyIneligibleStatusesAndExcludesInactiveUnits() {
+    Batch batch =
+        saveBatch(
+            tenantId,
+            "LOT-QC-UNITS-" + suffix(),
+            null,
+            null,
+            Instant.parse("2026-07-21T10:00:00Z"));
+    for (StockUnitStatus status : StockUnitStatus.values()) {
+      saveUnitWithStatus(tenantId, batch, status);
+    }
+    StockUnit inactive = saveUnitWithStatus(tenantId, batch, StockUnitStatus.AVAILABLE);
+    String inactiveBarcode = inactive.getBarcode();
+    inactive.delete();
+    stockUnitRepository.saveAndFlush(inactive);
+
+    var units =
+        service.getActiveUnits(
+            batch.getId(), PageRequest.of(0, 20, Sort.by(Sort.Direction.ASC, "barcode")));
+
+    assertThat(units).hasSize(StockUnitStatus.values().length);
+    assertThat(units.getContent())
+        .extracting(StockUnit::getStatus)
+        .containsExactlyInAnyOrder(StockUnitStatus.values());
+    assertThat(units.getContent())
+        .extracting(StockUnit::getBarcode)
+        .doesNotContain(inactiveBarcode);
+  }
+
   private Batch saveBatch(
       UUID ownerTenantId,
       String batchCode,
@@ -151,26 +243,62 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
             .sourceType(BatchSourceType.INITIAL_STOCK)
             .build();
     batch.setTenantId(ownerTenantId);
-    batch.setCreatedAt(createdAt);
-    return batchRepository.saveAndFlush(batch);
+    Batch saved = batchRepository.saveAndFlush(batch);
+    jdbcTemplate.update(
+        "UPDATE production.production_execution_batch SET created_at = ? WHERE id = ?",
+        Timestamp.from(createdAt),
+        saved.getId());
+    return saved;
   }
 
-  private void saveUnit(UUID ownerTenantId, Batch batch, QualityDisposition qualityDisposition) {
-    stockUnitRepository.saveAndFlush(
-        StockUnit.create(
-            ownerTenantId,
-            batch.getId(),
-            ProductType.FIBER,
-            "QC-" + suffix(),
-            null,
-            PackageType.BALE,
-            BigDecimal.TEN,
-            null,
-            "KG",
-            null,
-            StockUnitSourceType.GOODS_RECEIPT,
-            UUID.randomUUID(),
-            qualityDisposition));
+  private StockUnit saveUnit(
+      UUID ownerTenantId, Batch batch, QualityDisposition qualityDisposition) {
+    return stockUnitRepository.saveAndFlush(newUnit(ownerTenantId, batch, qualityDisposition));
+  }
+
+  private StockUnit saveUnitWithStatus(UUID ownerTenantId, Batch batch, StockUnitStatus status) {
+    StockUnit unit = newUnit(ownerTenantId, batch, QualityDisposition.RELEASED);
+    switch (status) {
+      case AVAILABLE -> {
+        // Factory default.
+      }
+      case PARTIAL -> unit.consume(BigDecimal.ONE);
+      case RESERVED -> unit.reserve();
+      case IN_TRANSIT -> unit.startTransfer(UUID.randomUUID());
+      case ON_HOLD -> unit.hold();
+      case QUARANTINE -> unit.quarantine();
+      case DEPLETED -> unit.consume(BigDecimal.TEN);
+      case DISPOSED -> {
+        unit.hold();
+        unit.dispose();
+      }
+    }
+    return stockUnitRepository.saveAndFlush(unit);
+  }
+
+  private StockUnit newUnit(
+      UUID ownerTenantId, Batch batch, QualityDisposition qualityDisposition) {
+    return StockUnit.create(
+        ownerTenantId,
+        batch.getId(),
+        ProductType.FIBER,
+        "QC-" + suffix(),
+        null,
+        PackageType.BALE,
+        BigDecimal.TEN,
+        null,
+        "KG",
+        null,
+        StockUnitSourceType.GOODS_RECEIPT,
+        UUID.randomUUID(),
+        qualityDisposition);
+  }
+
+  private UUID saveTenant(String label) {
+    String suffix = suffix();
+    Tenant tenant = Tenant.create("Quality read model " + label + " " + suffix, "QRM-" + suffix);
+    tenant.activate("test");
+    return tenantRepository.saveAndFlush(tenant).getId();
   }
 
   private static String randomCode(String prefix) {

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
@@ -1,0 +1,183 @@
+package com.fabricmanagement.production.quality.decision.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.production.execution.batch.domain.Batch;
+import com.fabricmanagement.production.execution.batch.domain.BatchSourceType;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
+import com.fabricmanagement.production.execution.stockunit.domain.PackageType;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitSourceType;
+import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
+import com.fabricmanagement.production.masterdata.color.domain.Color;
+import com.fabricmanagement.production.masterdata.color.infra.repository.ColorRepository;
+import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRepository;
+import com.fabricmanagement.production.masterdata.product.domain.Product;
+import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+class QualityQueueReadModelIT extends AbstractIntegrationTest {
+
+  @Autowired private QualityDecisionQueryService service;
+  @Autowired private ProductRepository productRepository;
+  @Autowired private FiberRepository fiberRepository;
+  @Autowired private ColorRepository colorRepository;
+  @Autowired private BatchRepository batchRepository;
+  @Autowired private StockUnitRepository stockUnitRepository;
+
+  private UUID tenantId;
+  private UUID otherTenantId;
+  private Product sharedProduct;
+  private String sharedProductDisplayName;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    otherTenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    TenantContext.setCurrentUserId(UUID.randomUUID());
+
+    sharedProduct =
+        productRepository
+            .findByTenantIdAndProductTypeAndIsActiveTrue(
+                TenantContext.TEMPLATE_TENANT_ID, ProductType.FIBER)
+            .stream()
+            .findFirst()
+            .orElseThrow();
+    sharedProductDisplayName =
+        fiberRepository.findByProductId(sharedProduct.getId()).orElseThrow().getFiberName();
+  }
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void returnsSharedProductIdentityTenantColorColourlessRowsAndStablePagination() {
+    Color navy =
+        colorRepository.saveAndFlush(
+            Color.create(tenantId, randomCode("NAVY"), "Inspection navy", "#1F2A44"));
+    Batch oldest =
+        saveBatch(
+            tenantId,
+            "LOT-QC-OLD-" + suffix(),
+            "SUP-OLD",
+            navy.getId(),
+            Instant.parse("2026-07-20T08:00:00Z"));
+    saveUnit(tenantId, oldest, QualityDisposition.PENDING_INSPECTION);
+    saveUnit(tenantId, oldest, QualityDisposition.PENDING_INSPECTION);
+    saveUnit(tenantId, oldest, QualityDisposition.RELEASED);
+
+    Batch colourless =
+        saveBatch(
+            tenantId, "LOT-QC-NEW-" + suffix(), null, null, Instant.parse("2026-07-21T08:00:00Z"));
+    saveUnit(tenantId, colourless, QualityDisposition.PENDING_INSPECTION);
+
+    TenantContext.setCurrentTenantId(otherTenantId);
+    Batch otherTenant =
+        saveBatch(
+            otherTenantId,
+            "LOT-QC-OTHER-" + suffix(),
+            null,
+            null,
+            Instant.parse("2026-07-19T08:00:00Z"));
+    saveUnit(otherTenantId, otherTenant, QualityDisposition.PENDING_INSPECTION);
+
+    TenantContext.setCurrentTenantId(tenantId);
+    var firstPage = service.getQueue(PageRequest.of(0, 1));
+    var secondPage = service.getQueue(PageRequest.of(1, 1));
+
+    assertThat(firstPage.getTotalElements()).isEqualTo(2);
+    assertThat(firstPage.getTotalPages()).isEqualTo(2);
+    assertThat(firstPage)
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.batchId()).isEqualTo(oldest.getId());
+              assertThat(item.productId()).isEqualTo(sharedProduct.getId());
+              assertThat(item.productUid()).isEqualTo(sharedProduct.getUid());
+              assertThat(item.productDisplayName()).isEqualTo(sharedProductDisplayName);
+              assertThat(item.colorId()).isEqualTo(navy.getId());
+              assertThat(item.colorName()).isEqualTo("Inspection navy");
+              assertThat(item.supplierBatchCode()).isEqualTo("SUP-OLD");
+              assertThat(item.pendingUnitCount()).isEqualTo(2);
+              assertThat(item.batchCreatedAt()).isEqualTo(Instant.parse("2026-07-20T08:00:00Z"));
+            });
+    assertThat(secondPage)
+        .singleElement()
+        .satisfies(
+            item -> {
+              assertThat(item.batchId()).isEqualTo(colourless.getId());
+              assertThat(item.colorId()).isNull();
+              assertThat(item.colorName()).isNull();
+            });
+    assertThat(firstPage.getContent())
+        .extracting(item -> item.batchId())
+        .doesNotContain(otherTenant.getId());
+  }
+
+  private Batch saveBatch(
+      UUID ownerTenantId,
+      String batchCode,
+      String supplierBatchCode,
+      UUID colorId,
+      Instant createdAt) {
+    Batch batch =
+        Batch.builder()
+            .productId(sharedProduct.getId())
+            .colorId(colorId)
+            .productType(ProductType.FIBER)
+            .batchCode(batchCode)
+            .supplierBatchCode(supplierBatchCode)
+            .quantity(new BigDecimal("100"))
+            .reservedQuantity(BigDecimal.ZERO)
+            .consumedQuantity(BigDecimal.ZERO)
+            .wasteQuantity(BigDecimal.ZERO)
+            .unit("KG")
+            .status(BatchStatus.PENDING_QC)
+            .sourceType(BatchSourceType.INITIAL_STOCK)
+            .build();
+    batch.setTenantId(ownerTenantId);
+    batch.setCreatedAt(createdAt);
+    return batchRepository.saveAndFlush(batch);
+  }
+
+  private void saveUnit(UUID ownerTenantId, Batch batch, QualityDisposition qualityDisposition) {
+    stockUnitRepository.saveAndFlush(
+        StockUnit.create(
+            ownerTenantId,
+            batch.getId(),
+            ProductType.FIBER,
+            "QC-" + suffix(),
+            null,
+            PackageType.BALE,
+            BigDecimal.TEN,
+            null,
+            "KG",
+            null,
+            StockUnitSourceType.GOODS_RECEIPT,
+            UUID.randomUUID(),
+            qualityDisposition));
+  }
+
+  private static String randomCode(String prefix) {
+    return prefix + "-" + suffix();
+  }
+
+  private static String suffix() {
+    return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapperTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapperTest.java
@@ -1,0 +1,27 @@
+package com.fabricmanagement.production.quality.decision.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
+import java.util.EnumSet;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+
+class QualityDecisionMapperTest {
+
+  private final QualityDecisionMapper mapper = Mappers.getMapper(QualityDecisionMapper.class);
+
+  @Test
+  void exposesUnitStatusEligibilityWithoutClaimingBatchLevelDecidability() {
+    EnumSet.allOf(StockUnitStatus.class)
+        .forEach(
+            status -> {
+              StockUnit unit = StockUnit.builder().status(status).build();
+
+              assertThat(mapper.toUnitDto(unit).unitStatusEligible())
+                  .isEqualTo(QualityDecisionEligibility.isUnitStatusEligible(status));
+            });
+  }
+}


### PR DESCRIPTION
Backend half of ADR-0011 Faz 1 FE slice 1c-1. The QC queue read model now renders its own row without per-row FE lookups: QualityQueueItemDto gains productUid, productDisplayName, tenant-safe colorId/colorName and renames the timestamp to batchCreatedAt (the queue also holds production-output batches, so "received" was misleading).

findQualityQueue resolves the display name the same way ProductService does — COALESCE(prod_fiber.fiber_name, prod_product.uid) — via a single query that JOINs prod_product (no p.tenant_id filter, since canonical fiber products are shared from the TEMPLATE tenant), LEFT JOINs prod_fiber, and LEFT JOINs color tenant-safely. OpenAPI required/nullable contract pinned via @Schema (identity/type/display/count/timestamp required; supplier code + color nullable) and regenerated.

Tests: QualityDecisionQueryServiceTest plus a real-PostgreSQL QualityQueueReadModelIT covering the shared TEMPLATE product, tenant-local colour, a colourless batch, tenant isolation and pagination order.

Ref: docs/production/tickets/QC-RELEASE-1c-1.md.