### PR TITLE
feat(production): quality decision capability + options policy (QC-RE…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -35354,6 +35354,70 @@ paths:
       summary: List batches awaiting QC
       tags:
       - Quality Decisions
+  /api/v1/production/quality/relocation-targets:
+    get:
+      operationId: listQualityRelocationTargets
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseListQualityRelocationTargetDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List eligible QC relocation targets
+      tags:
+      - Quality Decisions
   /api/v1/production/recipes:
     post:
       operationId: createRecipe
@@ -47165,6 +47229,26 @@ components:
           type: array
           items:
             type: string
+    ApiResponseListQualityRelocationTargetDto:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityRelocationTargetDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseListRecurringTaskTemplateDto:
       type: object
       properties:
@@ -58690,7 +58774,6 @@ components:
           - BATCH_STATUS_BLOCKED
           - NO_ELIGIBLE_UNITS
           - INELIGIBLE_ACTIVE_UNITS
-          - null
         fullLotDecisionAllowed:
           type: boolean
           description: Whether a full-lot quality decision is currently allowed
@@ -58740,7 +58823,6 @@ components:
           - BATCH_STATUS_BLOCKED
           - NO_ELIGIBLE_UNITS
           - INELIGIBLE_ACTIVE_UNITS
-          - null
         selectedUnitsDecisionAllowed:
           type: boolean
           description: Whether a selected-units quality decision is currently allowed
@@ -58886,6 +58968,19 @@ components:
           type: number
         lengthUnit:
           type: string
+        locationCode:
+          type:
+          - string
+          - "null"
+        locationId:
+          type:
+          - string
+          - "null"
+          format: uuid
+        locationName:
+          type:
+          - string
+          - "null"
         packageType:
           type: string
           enum:
@@ -58906,6 +59001,9 @@ components:
           - RELEASED
           - QUARANTINED
           - NONCONFORMING
+        qualityRelocationAllowed:
+          type: boolean
+          description: Whether the unit can currently be relocated into QC custody
         status:
           type: string
           enum:
@@ -58924,6 +59022,7 @@ components:
           description: Whether the unit status is eligible for a quality decision
       required:
       - id
+      - qualityRelocationAllowed
       - unitStatusEligible
     QualityGradeDto:
       type: object
@@ -59020,6 +59119,23 @@ components:
       - productId
       - productType
       - productUid
+    QualityRelocationTargetDto:
+      type: object
+      properties:
+        code:
+          type: string
+        id:
+          type: string
+          format: uuid
+        name:
+          type: string
+        path:
+          type: string
+      required:
+      - code
+      - id
+      - name
+      - path
     QuickCreateCustomerContactRequest:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34709,6 +34709,70 @@ paths:
       summary: List all active batch units for QC
       tags:
       - Quality Decisions
+  /api/v1/production/quality/decision-options:
+    get:
+      operationId: getQualityDecisionOptions
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseQualityDecisionOptionsDto"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get manual quality decision options
+      tags:
+      - Quality Decisions
   /api/v1/production/quality/fiber-tests:
     get:
       operationId: getAllTestResults
@@ -48822,6 +48886,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponseQualityDecisionOptionsDto:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/QualityDecisionOptionsDto"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseQualityGradeDto:
       type: object
       properties:
@@ -58597,6 +58679,21 @@ components:
           - string
           - "null"
           description: Assigned tenant color-card name
+        fullLotBlockedReason:
+          type:
+          - string
+          - "null"
+          description: Reason a full-lot quality decision is blocked
+          enum:
+          - BATCH_RESERVED
+          - BATCH_CONSUMED
+          - BATCH_STATUS_BLOCKED
+          - NO_ELIGIBLE_UNITS
+          - INELIGIBLE_ACTIVE_UNITS
+          - null
+        fullLotDecisionAllowed:
+          type: boolean
+          description: Whether a full-lot quality decision is currently allowed
         nonconformingCount:
           type: integer
           format: int64
@@ -58632,6 +58729,21 @@ components:
           type: integer
           format: int64
           description: Active released units
+        selectedUnitsBlockedReason:
+          type:
+          - string
+          - "null"
+          description: Reason a selected-units quality decision is blocked
+          enum:
+          - BATCH_RESERVED
+          - BATCH_CONSUMED
+          - BATCH_STATUS_BLOCKED
+          - NO_ELIGIBLE_UNITS
+          - INELIGIBLE_ACTIVE_UNITS
+          - null
+        selectedUnitsDecisionAllowed:
+          type: boolean
+          description: Whether a selected-units quality decision is currently allowed
         totalCount:
           type: integer
           format: int64
@@ -58640,6 +58752,7 @@ components:
       - batchCode
       - batchCreatedAt
       - batchId
+      - fullLotDecisionAllowed
       - nonconformingCount
       - pendingInspectionCount
       - productDisplayName
@@ -58648,6 +58761,7 @@ components:
       - productUid
       - quarantinedCount
       - releasedCount
+      - selectedUnitsDecisionAllowed
       - totalCount
     QualityDecisionDto:
       type: object
@@ -58709,6 +58823,55 @@ components:
         supersedesDecisionId:
           type: string
           format: uuid
+    QualityDecisionOptionsDto:
+      type: object
+      properties:
+        options:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityDecisionOutcomeOptionDto"
+      required:
+      - options
+    QualityDecisionOutcomeOptionDto:
+      type: object
+      properties:
+        outcome:
+          type: string
+          enum:
+          - RELEASED
+          - QUARANTINED
+          - NONCONFORMING
+        reasonRequired:
+          type: boolean
+        reasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityDecisionReasonOptionDto"
+      required:
+      - outcome
+      - reasonRequired
+      - reasons
+    QualityDecisionReasonOptionDto:
+      type: object
+      properties:
+        code:
+          type: string
+          enum:
+          - SUSPECTED_DAMAGE
+          - AWAITING_LAB
+          - SUPPLIER_DISPUTE
+          - SHADE_CHECK
+          - DAMAGE
+          - STAIN
+          - SHADE_VARIATION
+          - SHORT_LENGTH
+          - MEASURE_MISMATCH
+          - OTHER
+        remarksRequired:
+          type: boolean
+      required:
+      - code
+      - remarksRequired
     QualityDecisionUnitDto:
       type: object
       properties:
@@ -58760,6 +58923,7 @@ components:
           type: boolean
           description: Whether the unit status is eligible for a quality decision
       required:
+      - id
       - unitStatusEligible
     QualityGradeDto:
       type: object

--- a/src/main/java/com/fabricmanagement/iwm/location/app/QcRelocationTargetPolicy.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/app/QcRelocationTargetPolicy.java
@@ -1,0 +1,16 @@
+package com.fabricmanagement.iwm.location.app;
+
+import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
+
+/** Single IWM policy used by both QC target discovery and relocation validation. */
+public final class QcRelocationTargetPolicy {
+
+  private QcRelocationTargetPolicy() {}
+
+  public static boolean isEligible(WarehouseLocationDto location) {
+    return location.isActive()
+        && location.isOperational()
+        && location.isStorageLocation()
+        && location.isQualityArea();
+  }
+}

--- a/src/main/java/com/fabricmanagement/iwm/location/app/WarehouseLocationService.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/app/WarehouseLocationService.java
@@ -16,6 +16,7 @@ import com.fabricmanagement.iwm.location.dto.WarehouseLocationTreeDto;
 import com.fabricmanagement.iwm.location.infra.repository.WarehouseLocationRepository;
 import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -215,6 +216,24 @@ public class WarehouseLocationService {
   @Transactional(readOnly = true)
   public WarehouseLocationDto getById(UUID id) {
     return WarehouseLocationDto.from(findEntityById(id));
+  }
+
+  @Transactional(readOnly = true)
+  public List<WarehouseLocationDto> findQcRelocationTargets(UUID tenantId) {
+    return repository.findByTenantIdAndQualityAreaTrueOrderByPathAscCodeAsc(tenantId).stream()
+        .map(WarehouseLocationDto::from)
+        .filter(QcRelocationTargetPolicy::isEligible)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public List<WarehouseLocationDto> findByIds(UUID tenantId, Collection<UUID> ids) {
+    if (ids == null || ids.isEmpty()) {
+      return List.of();
+    }
+    return repository.findByTenantIdAndIdIn(tenantId, ids).stream()
+        .map(WarehouseLocationDto::from)
+        .toList();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapter.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapter.java
@@ -1,11 +1,16 @@
 package com.fabricmanagement.iwm.location.app.adapter;
 
+import com.fabricmanagement.iwm.location.app.QcRelocationTargetPolicy;
 import com.fabricmanagement.iwm.location.app.WarehouseLocationService;
 import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
 import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
 import com.fabricmanagement.production.execution.batch.domain.port.LocationValidationResult;
 import com.fabricmanagement.production.execution.batch.domain.port.QcLocationValidationResult;
+import com.fabricmanagement.production.execution.batch.domain.port.QualityRelocationTarget;
 import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationRef;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -38,11 +43,26 @@ public class ProductionLocationAdapter implements WarehouseLocationPort {
   @Override
   public QcLocationValidationResult validateQcLocation(UUID locationId) {
     WarehouseLocationDto location = warehouseLocationService.getById(locationId);
-    boolean validQcLocation =
-        location.isActive()
-            && location.isOperational()
-            && location.isStorageLocation()
-            && location.isQualityArea();
+    boolean validQcLocation = QcRelocationTargetPolicy.isEligible(location);
     return new QcLocationValidationResult(locationId, location.getCode(), validQcLocation);
+  }
+
+  @Override
+  public List<QualityRelocationTarget> findQualityRelocationTargets(UUID tenantId) {
+    return warehouseLocationService.findQcRelocationTargets(tenantId).stream()
+        .map(
+            location ->
+                new QualityRelocationTarget(
+                    location.getId(), location.getCode(), location.getName(), location.getPath()))
+        .toList();
+  }
+
+  @Override
+  public List<WarehouseLocationRef> findLocationRefs(UUID tenantId, Collection<UUID> locationIds) {
+    return warehouseLocationService.findByIds(tenantId, locationIds).stream()
+        .map(
+            location ->
+                new WarehouseLocationRef(location.getId(), location.getCode(), location.getName()))
+        .toList();
   }
 }

--- a/src/main/java/com/fabricmanagement/iwm/location/infra/repository/WarehouseLocationRepository.java
+++ b/src/main/java/com/fabricmanagement/iwm/location/infra/repository/WarehouseLocationRepository.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.iwm.location.infra.repository;
 import com.fabricmanagement.iwm.location.domain.LocationStatus;
 import com.fabricmanagement.iwm.location.domain.WarehouseLocation;
 import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,6 +27,10 @@ public interface WarehouseLocationRepository extends JpaRepository<WarehouseLoca
 
   List<WarehouseLocation> findByQualityAreaAndIsActiveTrueOrderBySortOrderAscNameAsc(
       boolean qualityArea);
+
+  List<WarehouseLocation> findByTenantIdAndQualityAreaTrueOrderByPathAscCodeAsc(UUID tenantId);
+
+  List<WarehouseLocation> findByTenantIdAndIdIn(UUID tenantId, Collection<UUID> ids);
 
   List<WarehouseLocation> findByTypeAndIsActiveTrue(WarehouseLocationType type);
 

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/QualityRelocationTarget.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/QualityRelocationTarget.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.production.execution.batch.domain.port;
+
+import java.util.UUID;
+
+/** Production-owned picker view of an eligible IWM location for QC relocation. */
+public record QualityRelocationTarget(UUID id, String code, String name, String path) {}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationPort.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationPort.java
@@ -1,5 +1,7 @@
 package com.fabricmanagement.production.execution.batch.domain.port;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -32,4 +34,10 @@ public interface WarehouseLocationPort {
    * @return minimal validation result translated from the IWM bounded context
    */
   QcLocationValidationResult validateQcLocation(UUID locationId);
+
+  /** Lists the active operational storage locations designated for QC custody. */
+  List<QualityRelocationTarget> findQualityRelocationTargets(UUID tenantId);
+
+  /** Resolves minimal location labels in one tenant-scoped bulk read. */
+  List<WarehouseLocationRef> findLocationRefs(UUID tenantId, Collection<UUID> locationIds);
 }

--- a/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationRef.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/domain/port/WarehouseLocationRef.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.production.execution.batch.domain.port;
+
+import java.util.UUID;
+
+/** Minimal production-owned label for a warehouse location. */
+public record WarehouseLocationRef(UUID id, String code, String name) {}

--- a/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/batch/infra/repository/BatchRepository.java
@@ -56,7 +56,10 @@ public interface BatchRepository
                  b.product_type AS productType,
                  c.id AS colorId,
                  c.name AS colorName,
-                 b.created_at AS batchCreatedAt
+                 b.created_at AS batchCreatedAt,
+                 b.status AS status,
+                 b.reserved_quantity AS reservedQuantity,
+                 b.consumed_quantity AS consumedQuantity
           FROM production.production_execution_batch b
           JOIN production.prod_product p
             ON p.id = b.product_id
@@ -182,5 +185,11 @@ public interface BatchRepository
     String getColorName();
 
     java.time.Instant getBatchCreatedAt();
+
+    String getStatus();
+
+    java.math.BigDecimal getReservedQuantity();
+
+    java.math.BigDecimal getConsumedQuantity();
   }
 }

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/domain/StockUnit.java
@@ -446,9 +446,15 @@ public class StockUnit extends BaseEntity {
     if (qualityDisposition == QualityDisposition.RELEASED) {
       throw QcRelocationException.releasedUnit(barcode);
     }
-    if (!QC_RELOCATION_STATUSES.contains(status)) {
+    if (!isQualityRelocationAllowed()) {
       throw QcRelocationException.sourceInvalid(barcode, status, qualityDisposition);
     }
+  }
+
+  /** Read-side capability backed by the same source predicate as relocation enforcement. */
+  public boolean isQualityRelocationAllowed() {
+    return qualityDisposition != QualityDisposition.RELEASED
+        && QC_RELOCATION_STATUSES.contains(status);
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/stockunit/infra/repository/StockUnitRepository.java
@@ -110,6 +110,9 @@ public interface StockUnitRepository extends JpaRepository<StockUnit, UUID> {
 
   long countByTenantIdAndBatchIdAndIsActiveTrue(UUID tenantId, UUID batchId);
 
+  long countByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+      UUID tenantId, UUID batchId, Collection<StockUnitStatus> statuses);
+
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @Query(
       """

--- a/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
@@ -11,11 +11,13 @@ import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityRelocationTargetDto;
 import com.fabricmanagement.production.quality.decision.dto.RecordQualityDecisionRequest;
 import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -72,6 +74,15 @@ public class QualityDecisionController {
     return ResponseEntity.ok(ApiResponse.success(queryService.getDecisionOptions()));
   }
 
+  @GetMapping("/relocation-targets")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(
+      operationId = "listQualityRelocationTargets",
+      summary = "List eligible QC relocation targets")
+  public ResponseEntity<ApiResponse<List<QualityRelocationTargetDto>>> relocationTargets() {
+    return ResponseEntity.ok(ApiResponse.success(queryService.getRelocationTargets()));
+  }
+
   @GetMapping("/batches/{batchId}/decisions")
   @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
   @Operation(operationId = "listQualityDecisionHistory", summary = "List batch decision history")
@@ -98,7 +109,6 @@ public class QualityDecisionController {
       @PathVariable UUID batchId,
       @ParameterObject @PageableDefault(size = 20, sort = "barcode") Pageable pageable) {
     return ResponseEntity.ok(
-        ApiResponse.success(
-            PagedResponse.from(queryService.getActiveUnits(batchId, pageable), mapper::toUnitDto)));
+        ApiResponse.success(PagedResponse.from(queryService.getActiveUnits(batchId, pageable))));
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionController.java
@@ -8,6 +8,7 @@ import com.fabricmanagement.production.quality.decision.app.QualityDecisionServi
 import com.fabricmanagement.production.quality.decision.app.TrustedDecisionContext;
 import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
 import com.fabricmanagement.production.quality.decision.dto.RecordQualityDecisionRequest;
@@ -60,6 +61,15 @@ public class QualityDecisionController {
       @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
     return ResponseEntity.ok(
         ApiResponse.success(PagedResponse.from(queryService.getQueue(pageable))));
+  }
+
+  @GetMapping("/decision-options")
+  @PreAuthorize("@auth.can(authentication, 'quality', 'read')")
+  @Operation(
+      operationId = "getQualityDecisionOptions",
+      summary = "Get manual quality decision options")
+  public ResponseEntity<ApiResponse<QualityDecisionOptionsDto>> decisionOptions() {
+    return ResponseEntity.ok(ApiResponse.success(queryService.getDecisionOptions()));
   }
 
   @GetMapping("/batches/{batchId}/decisions")

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
@@ -3,6 +3,8 @@ package com.fabricmanagement.production.quality.decision.app;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationRef;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
@@ -17,9 +19,14 @@ import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryD
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOutcomeOptionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionReasonOptionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityRelocationTargetDto;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
@@ -34,14 +41,20 @@ public class QualityDecisionQueryService {
   private final QualityDecisionRepository decisionRepository;
   private final StockUnitRepository stockUnitRepository;
   private final BatchRepository batchRepository;
+  private final WarehouseLocationPort warehouseLocationPort;
+  private final QualityDecisionMapper mapper;
 
   public QualityDecisionQueryService(
       QualityDecisionRepository decisionRepository,
       StockUnitRepository stockUnitRepository,
-      BatchRepository batchRepository) {
+      BatchRepository batchRepository,
+      WarehouseLocationPort warehouseLocationPort,
+      QualityDecisionMapper mapper) {
     this.decisionRepository = decisionRepository;
     this.stockUnitRepository = stockUnitRepository;
     this.batchRepository = batchRepository;
+    this.warehouseLocationPort = warehouseLocationPort;
+    this.mapper = mapper;
   }
 
   public Page<QualityQueueItemDto> getQueue(Pageable pageable) {
@@ -145,8 +158,29 @@ public class QualityDecisionQueryService {
             .toList());
   }
 
-  public Page<StockUnit> getActiveUnits(UUID batchId, Pageable pageable) {
-    return stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(
-        TenantContext.requireTenantId(), batchId, pageable);
+  public Page<QualityDecisionUnitDto> getActiveUnits(UUID batchId, Pageable pageable) {
+    UUID tenantId = TenantContext.requireTenantId();
+    Page<StockUnit> units =
+        stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(tenantId, batchId, pageable);
+    var locationIds =
+        units.getContent().stream()
+            .map(StockUnit::getLocationId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+    Map<UUID, WarehouseLocationRef> locations =
+        warehouseLocationPort.findLocationRefs(tenantId, locationIds).stream()
+            .collect(Collectors.toMap(WarehouseLocationRef::id, location -> location));
+    return units.map(unit -> mapper.toUnitDto(unit, locations.get(unit.getLocationId())));
+  }
+
+  public List<QualityRelocationTargetDto> getRelocationTargets() {
+    return warehouseLocationPort
+        .findQualityRelocationTargets(TenantContext.requireTenantId())
+        .stream()
+        .map(
+            target ->
+                new QualityRelocationTargetDto(
+                    target.id(), target.code(), target.name(), target.path()))
+        .toList();
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryService.java
@@ -2,13 +2,21 @@ package com.fabricmanagement.production.quality.decision.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionReasonPolicy;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
 import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOutcomeOptionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionReasonOptionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityQueueItemDto;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
 import java.util.Map;
@@ -74,6 +82,29 @@ public class QualityDecisionQueryService {
                     StockUnitRepository.QualityDispositionCount::getDisposition,
                     StockUnitRepository.QualityDispositionCount::getUnitCount));
     long totalCount = counts.values().stream().mapToLong(Long::longValue).sum();
+    long activeUnitCount =
+        stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(tenantId, batchId);
+    long statusEligibleUnitCount =
+        stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+            tenantId, batchId, QualityDecisionEligibility.unitStatusEligibleStatuses());
+    var fullLotCapability =
+        QualityDecisionEligibility.combine(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.FULL_LOT,
+                BatchStatus.valueOf(row.getStatus()),
+                row.getReservedQuantity(),
+                row.getConsumedQuantity()),
+            QualityDecisionEligibility.evaluatePopulation(
+                QualityDecisionScope.FULL_LOT, activeUnitCount, statusEligibleUnitCount));
+    var selectedUnitsCapability =
+        QualityDecisionEligibility.combine(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.SELECTED_UNITS,
+                BatchStatus.valueOf(row.getStatus()),
+                row.getReservedQuantity(),
+                row.getConsumedQuantity()),
+            QualityDecisionEligibility.evaluatePopulation(
+                QualityDecisionScope.SELECTED_UNITS, activeUnitCount, statusEligibleUnitCount));
 
     return new QualityBatchSummaryDto(
         row.getBatchId(),
@@ -89,7 +120,29 @@ public class QualityDecisionQueryService {
         counts.getOrDefault(QualityDisposition.RELEASED, 0L),
         counts.getOrDefault(QualityDisposition.QUARANTINED, 0L),
         counts.getOrDefault(QualityDisposition.NONCONFORMING, 0L),
-        totalCount);
+        totalCount,
+        fullLotCapability.allowed(),
+        fullLotCapability.blockedReason(),
+        selectedUnitsCapability.allowed(),
+        selectedUnitsCapability.blockedReason());
+  }
+
+  public QualityDecisionOptionsDto getDecisionOptions() {
+    return new QualityDecisionOptionsDto(
+        java.util.Arrays.stream(QualityDecisionOutcome.values())
+            .map(
+                outcome ->
+                    new QualityDecisionOutcomeOptionDto(
+                        outcome,
+                        QualityDecisionReasonPolicy.manualReasonRequired(outcome),
+                        QualityDecisionReasonPolicy.manualReasons(outcome).stream()
+                            .map(
+                                reason ->
+                                    new QualityDecisionReasonOptionDto(
+                                        reason,
+                                        QualityDecisionReasonPolicy.remarksRequired(reason)))
+                            .toList()))
+            .toList());
   }
 
   public Page<StockUnit> getActiveUnits(UUID batchId, Pageable pageable) {

--- a/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionService.java
@@ -10,9 +10,11 @@ import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionReasonPolicy;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionUnit;
 import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
@@ -37,19 +39,6 @@ public class QualityDecisionService {
 
   private static final Set<StockUnitStatus> DECISION_ELIGIBLE_STATUSES =
       QualityDecisionEligibility.unitStatusEligibleStatuses();
-
-  private static final Set<BatchStatus> FULL_LOT_BLOCKED_BATCH_STATUSES =
-      EnumSet.of(
-          BatchStatus.RESERVED,
-          BatchStatus.IN_PROGRESS,
-          BatchStatus.ON_HOLD,
-          BatchStatus.DEPLETED,
-          BatchStatus.RETURNED,
-          BatchStatus.DESTROYED);
-
-  private static final Set<BatchStatus> SELECTED_UNITS_BLOCKED_BATCH_STATUSES =
-      EnumSet.of(
-          BatchStatus.RESERVED, BatchStatus.DEPLETED, BatchStatus.RETURNED, BatchStatus.DESTROYED);
 
   private static final Set<BatchStatus> PROJECTION_BLOCKED_BATCH_STATUSES =
       EnumSet.of(
@@ -190,10 +179,14 @@ public class QualityDecisionService {
       List<StockUnit> population =
           stockUnitRepository.lockDecisionPopulation(
               tenantId, batch.getId(), DECISION_ELIGIBLE_STATUSES);
-      if (population.isEmpty()) {
-        throw QualityDecisionException.noUnits();
-      }
-      if (population.size() != activeCount) {
+      var populationCapability =
+          QualityDecisionEligibility.evaluatePopulation(
+              command.scope(), activeCount, population.size());
+      if (!populationCapability.allowed()) {
+        if (populationCapability.blockedReason()
+            == QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS) {
+          throw QualityDecisionException.noUnits();
+        }
         throw QualityDecisionException.populationDrift();
       }
       return population;
@@ -203,7 +196,10 @@ public class QualityDecisionService {
     List<StockUnit> population =
         stockUnitRepository.lockSelectedDecisionPopulation(
             tenantId, batch.getId(), requestedIds, DECISION_ELIGIBLE_STATUSES);
-    if (population.size() != requestedIds.size()) {
+    var populationCapability =
+        QualityDecisionEligibility.evaluatePopulation(
+            command.scope(), requestedIds.size(), population.size());
+    if (!populationCapability.allowed() || population.size() != requestedIds.size()) {
       throw QualityDecisionException.unitMismatch();
     }
     return population;
@@ -234,14 +230,10 @@ public class QualityDecisionService {
   }
 
   private void assertBatchAllowsDecision(Batch batch, QualityDecisionScope scope) {
-    boolean blocked =
-        scope == QualityDecisionScope.FULL_LOT
-            ? FULL_LOT_BLOCKED_BATCH_STATUSES.contains(batch.getStatus())
-                || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0
-                || batch.getConsumedQuantity().compareTo(BigDecimal.ZERO) > 0
-            : SELECTED_UNITS_BLOCKED_BATCH_STATUSES.contains(batch.getStatus())
-                || batch.getReservedQuantity().compareTo(BigDecimal.ZERO) > 0;
-    if (blocked) {
+    var capability =
+        QualityDecisionEligibility.evaluateBatch(
+            scope, batch.getStatus(), batch.getReservedQuantity(), batch.getConsumedQuantity());
+    if (!capability.allowed()) {
       throw QualityDecisionException.batchActive(batch.getStatus().name());
     }
   }
@@ -305,48 +297,10 @@ public class QualityDecisionService {
         && normalizedRemarks(command.remarks()) == null) {
       throw QualityDecisionException.remarksRequired();
     }
-    if (!reasonAllowed(context.origin(), command.outcome(), command.reasonCode())) {
+    if (!QualityDecisionReasonPolicy.reasonAllowed(
+        context.origin(), command.outcome(), command.reasonCode())) {
       throw QualityDecisionException.reasonInvalid();
     }
-  }
-
-  private boolean reasonAllowed(
-      QualityDecisionOrigin origin, QualityDecisionOutcome outcome, QualityReasonCode reasonCode) {
-    if (origin == QualityDecisionOrigin.SYSTEM_RELEASE) {
-      return outcome == QualityDecisionOutcome.RELEASED
-          && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED;
-    }
-    if (origin == QualityDecisionOrigin.SYSTEM_QC_EVENT) {
-      return (outcome == QualityDecisionOutcome.RELEASED
-              && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED)
-          || (outcome == QualityDecisionOutcome.NONCONFORMING
-              && reasonCode == QualityReasonCode.SYSTEM_QC_REJECTED);
-    }
-    if (origin != QualityDecisionOrigin.MANUAL) {
-      return false;
-    }
-    return switch (outcome) {
-      case RELEASED -> reasonCode == null;
-      case QUARANTINED ->
-          reasonCode != null
-              && Set.of(
-                      QualityReasonCode.SUSPECTED_DAMAGE,
-                      QualityReasonCode.AWAITING_LAB,
-                      QualityReasonCode.SUPPLIER_DISPUTE,
-                      QualityReasonCode.SHADE_CHECK,
-                      QualityReasonCode.OTHER)
-                  .contains(reasonCode);
-      case NONCONFORMING ->
-          reasonCode != null
-              && Set.of(
-                      QualityReasonCode.DAMAGE,
-                      QualityReasonCode.STAIN,
-                      QualityReasonCode.SHADE_VARIATION,
-                      QualityReasonCode.SHORT_LENGTH,
-                      QualityReasonCode.MEASURE_MISMATCH,
-                      QualityReasonCode.OTHER)
-                  .contains(reasonCode);
-    };
   }
 
   private String normalizedRemarks(String remarks) {

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/ManualQualityReasonCode.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/ManualQualityReasonCode.java
@@ -1,0 +1,19 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+/** Reason codes that a human quality approver may select. */
+public enum ManualQualityReasonCode {
+  SUSPECTED_DAMAGE,
+  AWAITING_LAB,
+  SUPPLIER_DISPUTE,
+  SHADE_CHECK,
+  DAMAGE,
+  STAIN,
+  SHADE_VARIATION,
+  SHORT_LENGTH,
+  MEASURE_MISMATCH,
+  OTHER;
+
+  public QualityReasonCode toDomainCode() {
+    return QualityReasonCode.valueOf(name());
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionBlockedReason.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionBlockedReason.java
@@ -1,0 +1,9 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+public enum QualityDecisionBlockedReason {
+  BATCH_RESERVED,
+  BATCH_CONSUMED,
+  BATCH_STATUS_BLOCKED,
+  NO_ELIGIBLE_UNITS,
+  INELIGIBLE_ACTIVE_UNITS
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionCapability.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionCapability.java
@@ -1,0 +1,23 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+public record QualityDecisionCapability(
+    boolean allowed, QualityDecisionBlockedReason blockedReason) {
+
+  public QualityDecisionCapability {
+    if (allowed == (blockedReason != null)) {
+      throw new IllegalArgumentException(
+          "Allowed quality-decision capabilities must not have a blocked reason");
+    }
+  }
+
+  public static QualityDecisionCapability permitted() {
+    return new QualityDecisionCapability(true, null);
+  }
+
+  public static QualityDecisionCapability blocked(QualityDecisionBlockedReason reason) {
+    if (reason == null) {
+      throw new IllegalArgumentException("A blocked quality-decision capability requires a reason");
+    }
+    return new QualityDecisionCapability(false, reason);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibility.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibility.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.production.quality.decision.domain;
 
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import java.math.BigDecimal;
 import java.util.Set;
 
 /** Shared unit-status policy used by quality decision reads and writes. */
@@ -13,6 +15,19 @@ public final class QualityDecisionEligibility {
           StockUnitStatus.QUARANTINE,
           StockUnitStatus.ON_HOLD);
 
+  private static final Set<BatchStatus> FULL_LOT_BLOCKED_BATCH_STATUSES =
+      Set.of(
+          BatchStatus.RESERVED,
+          BatchStatus.IN_PROGRESS,
+          BatchStatus.ON_HOLD,
+          BatchStatus.DEPLETED,
+          BatchStatus.RETURNED,
+          BatchStatus.DESTROYED);
+
+  private static final Set<BatchStatus> SELECTED_UNITS_BLOCKED_BATCH_STATUSES =
+      Set.of(
+          BatchStatus.RESERVED, BatchStatus.DEPLETED, BatchStatus.RETURNED, BatchStatus.DESTROYED);
+
   private QualityDecisionEligibility() {}
 
   public static Set<StockUnitStatus> unitStatusEligibleStatuses() {
@@ -21,5 +36,48 @@ public final class QualityDecisionEligibility {
 
   public static boolean isUnitStatusEligible(StockUnitStatus status) {
     return UNIT_STATUS_ELIGIBLE.contains(status);
+  }
+
+  public static QualityDecisionCapability evaluateBatch(
+      QualityDecisionScope scope,
+      BatchStatus status,
+      BigDecimal reservedQuantity,
+      BigDecimal consumedQuantity) {
+    if (reservedQuantity.compareTo(BigDecimal.ZERO) > 0) {
+      return QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_RESERVED);
+    }
+    if (scope == QualityDecisionScope.FULL_LOT && consumedQuantity.compareTo(BigDecimal.ZERO) > 0) {
+      return QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_CONSUMED);
+    }
+    Set<BatchStatus> blockedStatuses =
+        scope == QualityDecisionScope.FULL_LOT
+            ? FULL_LOT_BLOCKED_BATCH_STATUSES
+            : SELECTED_UNITS_BLOCKED_BATCH_STATUSES;
+    if (blockedStatuses.contains(status)) {
+      return QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_STATUS_BLOCKED);
+    }
+    return QualityDecisionCapability.permitted();
+  }
+
+  public static QualityDecisionCapability evaluatePopulation(
+      QualityDecisionScope scope, long activeUnitCount, long statusEligibleUnitCount) {
+    if (activeUnitCount < 0
+        || statusEligibleUnitCount < 0
+        || statusEligibleUnitCount > activeUnitCount) {
+      throw new IllegalArgumentException("Quality-decision population counts are inconsistent");
+    }
+    if (statusEligibleUnitCount == 0) {
+      return QualityDecisionCapability.blocked(QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS);
+    }
+    if (scope == QualityDecisionScope.FULL_LOT && statusEligibleUnitCount != activeUnitCount) {
+      return QualityDecisionCapability.blocked(
+          QualityDecisionBlockedReason.INELIGIBLE_ACTIVE_UNITS);
+    }
+    return QualityDecisionCapability.permitted();
+  }
+
+  public static QualityDecisionCapability combine(
+      QualityDecisionCapability batchCapability, QualityDecisionCapability populationCapability) {
+    return batchCapability.allowed() ? populationCapability : batchCapability;
   }
 }

--- a/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionReasonPolicy.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionReasonPolicy.java
@@ -1,0 +1,68 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import java.util.List;
+
+/** Single source of truth for quality-decision outcome and reason compatibility. */
+public final class QualityDecisionReasonPolicy {
+
+  private static final List<ManualQualityReasonCode> QUARANTINE_REASONS =
+      List.of(
+          ManualQualityReasonCode.SUSPECTED_DAMAGE,
+          ManualQualityReasonCode.AWAITING_LAB,
+          ManualQualityReasonCode.SUPPLIER_DISPUTE,
+          ManualQualityReasonCode.SHADE_CHECK,
+          ManualQualityReasonCode.OTHER);
+
+  private static final List<ManualQualityReasonCode> NONCONFORMING_REASONS =
+      List.of(
+          ManualQualityReasonCode.DAMAGE,
+          ManualQualityReasonCode.STAIN,
+          ManualQualityReasonCode.SHADE_VARIATION,
+          ManualQualityReasonCode.SHORT_LENGTH,
+          ManualQualityReasonCode.MEASURE_MISMATCH,
+          ManualQualityReasonCode.OTHER);
+
+  private QualityDecisionReasonPolicy() {}
+
+  public static List<ManualQualityReasonCode> manualReasons(QualityDecisionOutcome outcome) {
+    return switch (outcome) {
+      case RELEASED -> List.of();
+      case QUARANTINED -> QUARANTINE_REASONS;
+      case NONCONFORMING -> NONCONFORMING_REASONS;
+    };
+  }
+
+  public static boolean manualReasonRequired(QualityDecisionOutcome outcome) {
+    return !manualReasons(outcome).isEmpty();
+  }
+
+  public static boolean remarksRequired(QualityReasonCode reasonCode) {
+    return reasonCode == QualityReasonCode.OTHER;
+  }
+
+  public static boolean remarksRequired(ManualQualityReasonCode reasonCode) {
+    return reasonCode == ManualQualityReasonCode.OTHER;
+  }
+
+  public static boolean reasonAllowed(
+      QualityDecisionOrigin origin, QualityDecisionOutcome outcome, QualityReasonCode reasonCode) {
+    if (origin == QualityDecisionOrigin.SYSTEM_RELEASE) {
+      return outcome == QualityDecisionOutcome.RELEASED
+          && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED;
+    }
+    if (origin == QualityDecisionOrigin.SYSTEM_QC_EVENT) {
+      return (outcome == QualityDecisionOutcome.RELEASED
+              && reasonCode == QualityReasonCode.SYSTEM_QC_PASSED)
+          || (outcome == QualityDecisionOutcome.NONCONFORMING
+              && reasonCode == QualityReasonCode.SYSTEM_QC_REJECTED);
+    }
+    if (origin != QualityDecisionOrigin.MANUAL) {
+      return false;
+    }
+    return manualReasonRequired(outcome)
+        ? reasonCode != null
+            && manualReasons(outcome).stream()
+                .anyMatch(manualReason -> manualReason.toDomainCode() == reasonCode)
+        : reasonCode == null;
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityBatchSummaryDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityBatchSummaryDto.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.production.quality.decision.dto;
 
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.Instant;
 import java.util.UUID;
@@ -35,4 +36,16 @@ public record QualityBatchSummaryDto(
     @Schema(description = "Active nonconforming units", requiredMode = Schema.RequiredMode.REQUIRED)
         long nonconformingCount,
     @Schema(description = "Total active units", requiredMode = Schema.RequiredMode.REQUIRED)
-        long totalCount) {}
+        long totalCount,
+    @Schema(
+            description = "Whether a full-lot quality decision is currently allowed",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean fullLotDecisionAllowed,
+    @Schema(description = "Reason a full-lot quality decision is blocked", nullable = true)
+        QualityDecisionBlockedReason fullLotBlockedReason,
+    @Schema(
+            description = "Whether a selected-units quality decision is currently allowed",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean selectedUnitsDecisionAllowed,
+    @Schema(description = "Reason a selected-units quality decision is blocked", nullable = true)
+        QualityDecisionBlockedReason selectedUnitsBlockedReason) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionOptionsDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionOptionsDto.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record QualityDecisionOptionsDto(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        List<QualityDecisionOutcomeOptionDto> options) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionOutcomeOptionDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionOutcomeOptionDto.java
@@ -1,0 +1,11 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+public record QualityDecisionOutcomeOptionDto(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) QualityDecisionOutcome outcome,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean reasonRequired,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        List<QualityDecisionReasonOptionDto> reasons) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionReasonOptionDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionReasonOptionDto.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import com.fabricmanagement.production.quality.decision.domain.ManualQualityReasonCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record QualityDecisionReasonOptionDto(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) ManualQualityReasonCode code,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) boolean remarksRequired) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
@@ -8,7 +8,7 @@ import java.math.BigDecimal;
 import java.util.UUID;
 
 public record QualityDecisionUnitDto(
-    UUID id,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID id,
     String barcode,
     PackageType packageType,
     BigDecimal currentWeight,

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityDecisionUnitDto.java
@@ -17,7 +17,14 @@ public record QualityDecisionUnitDto(
     String lengthUnit,
     StockUnitStatus status,
     QualityDisposition qualityDisposition,
+    @Schema(nullable = true) UUID locationId,
+    @Schema(nullable = true) String locationCode,
+    @Schema(nullable = true) String locationName,
     @Schema(
             description = "Whether the unit status is eligible for a quality decision",
             requiredMode = Schema.RequiredMode.REQUIRED)
-        boolean unitStatusEligible) {}
+        boolean unitStatusEligible,
+    @Schema(
+            description = "Whether the unit can currently be relocated into QC custody",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        boolean qualityRelocationAllowed) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityRelocationTargetDto.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/dto/QualityRelocationTargetDto.java
@@ -1,0 +1,10 @@
+package com.fabricmanagement.production.quality.decision.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record QualityRelocationTargetDto(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID id,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String code,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String name,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String path) {}

--- a/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
+++ b/src/main/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapper.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.production.quality.decision.mapper;
 
 import com.fabricmanagement.common.infrastructure.mapping.MapStructConfig;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationRef;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
@@ -19,5 +20,30 @@ public interface QualityDecisionMapper {
   @Mapping(
       target = "unitStatusEligible",
       expression = "java(QualityDecisionEligibility.isUnitStatusEligible(stockUnit.getStatus()))")
+  @Mapping(
+      target = "qualityRelocationAllowed",
+      expression = "java(stockUnit.isQualityRelocationAllowed())")
+  @Mapping(target = "locationId", ignore = true)
+  @Mapping(target = "locationCode", ignore = true)
+  @Mapping(target = "locationName", ignore = true)
   QualityDecisionUnitDto toUnitDto(StockUnit stockUnit);
+
+  default QualityDecisionUnitDto toUnitDto(StockUnit stockUnit, WarehouseLocationRef locationRef) {
+    QualityDecisionUnitDto unit = toUnitDto(stockUnit);
+    return new QualityDecisionUnitDto(
+        unit.id(),
+        unit.barcode(),
+        unit.packageType(),
+        unit.currentWeight(),
+        unit.unit(),
+        unit.length(),
+        unit.lengthUnit(),
+        unit.status(),
+        unit.qualityDisposition(),
+        locationRef != null ? locationRef.id() : null,
+        locationRef != null ? locationRef.code() : null,
+        locationRef != null ? locationRef.name() : null,
+        unit.unitStatusEligible(),
+        unit.qualityRelocationAllowed());
+  }
 }

--- a/src/test/java/com/fabricmanagement/iwm/location/app/QcRelocationTargetPolicyTest.java
+++ b/src/test/java/com/fabricmanagement/iwm/location/app/QcRelocationTargetPolicyTest.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.iwm.location.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
+import org.junit.jupiter.api.Test;
+
+class QcRelocationTargetPolicyTest {
+
+  @Test
+  void acceptsOnlyActiveOperationalStorageQualityAreas() {
+    assertThat(QcRelocationTargetPolicy.isEligible(location(true, true, true, true))).isTrue();
+    assertThat(QcRelocationTargetPolicy.isEligible(location(false, true, true, true))).isFalse();
+    assertThat(QcRelocationTargetPolicy.isEligible(location(true, false, true, true))).isFalse();
+    assertThat(QcRelocationTargetPolicy.isEligible(location(true, true, false, true))).isFalse();
+    assertThat(QcRelocationTargetPolicy.isEligible(location(true, true, true, false))).isFalse();
+  }
+
+  private WarehouseLocationDto location(
+      boolean active, boolean operational, boolean storage, boolean qualityArea) {
+    return WarehouseLocationDto.builder()
+        .isActive(active)
+        .operational(operational)
+        .storageLocation(storage)
+        .qualityArea(qualityArea)
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/iwm/location/app/WarehouseLocationServiceQcRelocationTest.java
+++ b/src/test/java/com/fabricmanagement/iwm/location/app/WarehouseLocationServiceQcRelocationTest.java
@@ -1,0 +1,61 @@
+package com.fabricmanagement.iwm.location.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.iwm.location.domain.LocationStatus;
+import com.fabricmanagement.iwm.location.domain.WarehouseLocation;
+import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
+import com.fabricmanagement.iwm.location.infra.repository.WarehouseLocationRepository;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WarehouseLocationServiceQcRelocationTest {
+
+  @Mock private WarehouseLocationRepository repository;
+  @InjectMocks private WarehouseLocationService service;
+
+  @Test
+  void returnsOnlyEligibleTargetsInRepositoryPathOrderForTheTenant() {
+    UUID tenantId = UUID.randomUUID();
+    WarehouseLocation alpha = location("QC-A", true);
+    WarehouseLocation blocked = location("QC-BLOCKED", true);
+    blocked.changeStatus(LocationStatus.BLOCKED);
+    WarehouseLocation ordinary = location("STORAGE", false);
+    WarehouseLocation beta = location("QC-B", true);
+    when(repository.findByTenantIdAndQualityAreaTrueOrderByPathAscCodeAsc(tenantId))
+        .thenReturn(List.of(alpha, blocked, ordinary, beta));
+
+    assertThat(service.findQcRelocationTargets(tenantId))
+        .extracting(location -> location.getCode())
+        .containsExactly("QC-A", "QC-B");
+    verify(repository).findByTenantIdAndQualityAreaTrueOrderByPathAscCodeAsc(tenantId);
+  }
+
+  private WarehouseLocation location(String code, boolean qualityArea) {
+    WarehouseLocation location =
+        new WarehouseLocation(
+            null,
+            code,
+            code,
+            null,
+            WarehouseLocationType.BIN,
+            null,
+            null,
+            null,
+            null,
+            null,
+            0,
+            null,
+            qualityArea);
+    location.assignPath("MAIN/" + code, 1);
+    return location;
+  }
+}

--- a/src/test/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/iwm/location/app/adapter/ProductionLocationAdapterTest.java
@@ -1,11 +1,13 @@
 package com.fabricmanagement.iwm.location.app.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.iwm.location.app.WarehouseLocationService;
 import com.fabricmanagement.iwm.location.domain.WarehouseLocationType;
 import com.fabricmanagement.iwm.location.dto.WarehouseLocationDto;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -61,6 +63,42 @@ class ProductionLocationAdapterTest {
 
     assertThat(adapter.validateQcLocation(inactiveId).validQcLocation()).isFalse();
     assertThat(adapter.validateQcLocation(blockedId).validQcLocation()).isFalse();
+  }
+
+  @Test
+  void mapsTenantScopedTargetsAndLocationRefsWithoutLeakingIwmDtos() {
+    UUID tenantId = UUID.randomUUID();
+    UUID locationId = UUID.randomUUID();
+    WarehouseLocationDto location =
+        WarehouseLocationDto.builder()
+            .id(locationId)
+            .code("QC-HOLD")
+            .name("QC Hold")
+            .path("MAIN/QC-HOLD")
+            .build();
+    when(warehouseLocationService.findQcRelocationTargets(tenantId)).thenReturn(List.of(location));
+    when(warehouseLocationService.findByIds(tenantId, List.of(locationId)))
+        .thenReturn(List.of(location));
+
+    assertThat(adapter.findQualityRelocationTargets(tenantId))
+        .singleElement()
+        .satisfies(
+            target -> {
+              assertThat(target.id()).isEqualTo(locationId);
+              assertThat(target.code()).isEqualTo("QC-HOLD");
+              assertThat(target.name()).isEqualTo("QC Hold");
+              assertThat(target.path()).isEqualTo("MAIN/QC-HOLD");
+            });
+    assertThat(adapter.findLocationRefs(tenantId, List.of(locationId)))
+        .singleElement()
+        .satisfies(
+            ref -> {
+              assertThat(ref.id()).isEqualTo(locationId);
+              assertThat(ref.code()).isEqualTo("QC-HOLD");
+              assertThat(ref.name()).isEqualTo("QC Hold");
+            });
+    verify(warehouseLocationService).findQcRelocationTargets(tenantId);
+    verify(warehouseLocationService).findByIds(tenantId, List.of(locationId));
   }
 
   private WarehouseLocationDto location(

--- a/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
@@ -15,13 +15,17 @@ import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionQueryService;
 import com.fabricmanagement.production.quality.decision.app.QualityDecisionService;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecision;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOrigin;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionScope;
 import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOutcomeOptionDto;
 import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -173,12 +177,34 @@ class QualityDecisionControllerSecurityTest {
                 1,
                 0,
                 0,
-                3));
+                3,
+                false,
+                QualityDecisionBlockedReason.INELIGIBLE_ACTIVE_UNITS,
+                true,
+                null));
 
     mockMvc
         .perform(get("/api/v1/production/quality/batches/{batchId}/summary", BATCH_ID))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.batchCode").value("LOT-QC-001"))
         .andExpect(jsonPath("$.data.totalCount").value(3));
+  }
+
+  @Test
+  @WithMockUser
+  void qualityReadAllowsManualDecisionOptions() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("read"))).thenReturn(true);
+    when(queryService.getDecisionOptions())
+        .thenReturn(
+            new QualityDecisionOptionsDto(
+                List.of(
+                    new QualityDecisionOutcomeOptionDto(
+                        QualityDecisionOutcome.RELEASED, false, List.of()))));
+
+    mockMvc
+        .perform(get("/api/v1/production/quality/decision-options"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.options[0].outcome").value("RELEASED"))
+        .andExpect(jsonPath("$.data.options[0].reasons").isArray());
   }
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/api/controller/QualityDecisionControllerSecurityTest.java
@@ -23,6 +23,7 @@ import com.fabricmanagement.production.quality.decision.dto.QualityBatchSummaryD
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOptionsDto;
 import com.fabricmanagement.production.quality.decision.dto.QualityDecisionOutcomeOptionDto;
+import com.fabricmanagement.production.quality.decision.dto.QualityRelocationTargetDto;
 import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
 import java.time.Instant;
 import java.util.List;
@@ -206,5 +207,32 @@ class QualityDecisionControllerSecurityTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.data.options[0].outcome").value("RELEASED"))
         .andExpect(jsonPath("$.data.options[0].reasons").isArray());
+  }
+
+  @Test
+  @WithMockUser
+  void qualityReadAllowsRelocationTargetsWithoutApprove() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("read"))).thenReturn(true);
+    UUID locationId = UUID.randomUUID();
+    when(queryService.getRelocationTargets())
+        .thenReturn(
+            List.of(
+                new QualityRelocationTargetDto(locationId, "QC-HOLD", "QC Hold", "MAIN/QC-HOLD")));
+
+    mockMvc
+        .perform(get("/api/v1/production/quality/relocation-targets"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].id").value(locationId.toString()))
+        .andExpect(jsonPath("$.data[0].path").value("MAIN/QC-HOLD"));
+  }
+
+  @Test
+  @WithMockUser
+  void roleWithoutQualityReadCannotListRelocationTargets() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("quality"), eq("read"))).thenReturn(false);
+
+    mockMvc
+        .perform(get("/api/v1/production/quality/relocation-targets"))
+        .andExpect(status().isForbidden());
   }
 }

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
@@ -2,18 +2,26 @@ package com.fabricmanagement.production.quality.decision.app;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
+import com.fabricmanagement.production.quality.decision.domain.ManualQualityReasonCode;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
+import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -109,6 +117,9 @@ class QualityDecisionQueryServiceTest {
     when(row.getColorId()).thenReturn(colorId);
     when(row.getColorName()).thenReturn("Navy");
     when(row.getBatchCreatedAt()).thenReturn(createdAt);
+    when(row.getStatus()).thenReturn(BatchStatus.PENDING_QC.name());
+    when(row.getReservedQuantity()).thenReturn(BigDecimal.ZERO);
+    when(row.getConsumedQuantity()).thenReturn(BigDecimal.ZERO);
     when(batchRepository.findQualityBatchSummary(TENANT_ID, batchId)).thenReturn(Optional.of(row));
     var dispositionCounts =
         List.of(
@@ -118,6 +129,11 @@ class QualityDecisionQueryServiceTest {
             dispositionCount(QualityDisposition.NONCONFORMING, 4));
     when(stockUnitRepository.countQualityDispositions(TENANT_ID, batchId))
         .thenReturn(dispositionCounts);
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId))
+        .thenReturn(10L);
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+            eq(TENANT_ID), eq(batchId), anyCollection()))
+        .thenReturn(10L);
 
     var result = service.getSummary(batchId);
 
@@ -130,6 +146,65 @@ class QualityDecisionQueryServiceTest {
     assertThat(result.quarantinedCount()).isEqualTo(1);
     assertThat(result.nonconformingCount()).isEqualTo(4);
     assertThat(result.totalCount()).isEqualTo(10);
+    assertThat(result.fullLotDecisionAllowed()).isTrue();
+    assertThat(result.fullLotBlockedReason()).isNull();
+    assertThat(result.selectedUnitsDecisionAllowed()).isTrue();
+    assertThat(result.selectedUnitsBlockedReason()).isNull();
+  }
+
+  @Test
+  void summaryExposesTheBatchReasonBeforeThePopulationReason() {
+    var batchId = UUID.randomUUID();
+    var row = mock(BatchRepository.QualityBatchSummaryRow.class);
+    when(row.getProductType()).thenReturn(ProductType.FIBER.name());
+    when(row.getStatus()).thenReturn(BatchStatus.IN_PROGRESS.name());
+    when(row.getReservedQuantity()).thenReturn(BigDecimal.ZERO);
+    when(row.getConsumedQuantity()).thenReturn(BigDecimal.ONE);
+    when(batchRepository.findQualityBatchSummary(TENANT_ID, batchId)).thenReturn(Optional.of(row));
+    when(stockUnitRepository.countQualityDispositions(TENANT_ID, batchId)).thenReturn(List.of());
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId))
+        .thenReturn(0L);
+    when(stockUnitRepository.countByTenantIdAndBatchIdAndIsActiveTrueAndStatusIn(
+            eq(TENANT_ID), eq(batchId), anyCollection()))
+        .thenReturn(0L);
+
+    var result = service.getSummary(batchId);
+
+    assertThat(result.fullLotDecisionAllowed()).isFalse();
+    assertThat(result.fullLotBlockedReason())
+        .isEqualTo(QualityDecisionBlockedReason.BATCH_CONSUMED);
+    assertThat(result.selectedUnitsDecisionAllowed()).isFalse();
+    assertThat(result.selectedUnitsBlockedReason())
+        .isEqualTo(QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS);
+  }
+
+  @Test
+  void returnsDeterministicManualDecisionOptions() {
+    var options = service.getDecisionOptions().options();
+
+    assertThat(options)
+        .extracting(option -> option.outcome())
+        .containsExactly(
+            QualityDecisionOutcome.RELEASED,
+            QualityDecisionOutcome.QUARANTINED,
+            QualityDecisionOutcome.NONCONFORMING);
+    assertThat(options.getFirst().reasonRequired()).isFalse();
+    assertThat(options.getFirst().reasons()).isEmpty();
+    assertThat(options.get(1).reasons())
+        .extracting(reason -> reason.code())
+        .containsExactly(
+            ManualQualityReasonCode.SUSPECTED_DAMAGE,
+            ManualQualityReasonCode.AWAITING_LAB,
+            ManualQualityReasonCode.SUPPLIER_DISPUTE,
+            ManualQualityReasonCode.SHADE_CHECK,
+            ManualQualityReasonCode.OTHER);
+    assertThat(options.getLast().reasons().getLast().remarksRequired()).isTrue();
+    assertThat(options.stream().flatMap(option -> option.reasons().stream()))
+        .extracting(reason -> reason.code().name())
+        .doesNotContain(
+            QualityReasonCode.SYSTEM_QC_PASSED.name(),
+            QualityReasonCode.SYSTEM_QC_REJECTED.name(),
+            QualityReasonCode.MIGRATION_BASELINE.name());
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityDecisionQueryServiceTest.java
@@ -11,9 +11,13 @@ import static org.mockito.Mockito.when;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
 import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import com.fabricmanagement.production.execution.batch.domain.port.QualityRelocationTarget;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationPort;
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationRef;
 import com.fabricmanagement.production.execution.batch.infra.repository.BatchRepository;
 import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
+import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
 import com.fabricmanagement.production.execution.stockunit.infra.repository.StockUnitRepository;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.quality.decision.domain.ManualQualityReasonCode;
@@ -21,15 +25,18 @@ import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBl
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionOutcome;
 import com.fabricmanagement.production.quality.decision.domain.QualityReasonCode;
 import com.fabricmanagement.production.quality.decision.infra.repository.QualityDecisionRepository;
+import com.fabricmanagement.production.quality.decision.mapper.QualityDecisionMapper;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
@@ -43,6 +50,7 @@ class QualityDecisionQueryServiceTest {
   @Mock private QualityDecisionRepository decisionRepository;
   @Mock private StockUnitRepository stockUnitRepository;
   @Mock private BatchRepository batchRepository;
+  @Mock private WarehouseLocationPort warehouseLocationPort;
 
   private QualityDecisionQueryService service;
 
@@ -50,7 +58,12 @@ class QualityDecisionQueryServiceTest {
   void setUp() {
     TenantContext.setCurrentTenantId(TENANT_ID);
     service =
-        new QualityDecisionQueryService(decisionRepository, stockUnitRepository, batchRepository);
+        new QualityDecisionQueryService(
+            decisionRepository,
+            stockUnitRepository,
+            batchRepository,
+            warehouseLocationPort,
+            Mappers.getMapper(QualityDecisionMapper.class));
   }
 
   @AfterEach
@@ -216,16 +229,74 @@ class QualityDecisionQueryServiceTest {
   }
 
   @Test
-  void activeUnitsReadDoesNotApplyTheDecisionStatusFilter() {
+  void activeUnitsReadEnrichesLocationsWithOneBulkLookup() {
     var batchId = UUID.randomUUID();
     var pageable = PageRequest.of(0, 20);
-    var stockUnit = mock(StockUnit.class);
+    var locationId = UUID.randomUUID();
+    var stockUnit =
+        StockUnit.builder()
+            .barcode("ROLL-001")
+            .locationId(locationId)
+            .status(StockUnitStatus.AVAILABLE)
+            .qualityDisposition(QualityDisposition.PENDING_INSPECTION)
+            .build();
+    var locationRef = new WarehouseLocationRef(locationId, "QC-01", "QC Hold");
     when(stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId, pageable))
         .thenReturn(new PageImpl<>(List.of(stockUnit), pageable, 1));
+    when(warehouseLocationPort.findLocationRefs(TENANT_ID, Set.of(locationId)))
+        .thenReturn(List.of(locationRef));
 
-    assertThat(service.getActiveUnits(batchId, pageable)).containsExactly(stockUnit);
+    assertThat(service.getActiveUnits(batchId, pageable))
+        .singleElement()
+        .satisfies(
+            unit -> {
+              assertThat(unit.locationId()).isEqualTo(locationId);
+              assertThat(unit.locationCode()).isEqualTo("QC-01");
+              assertThat(unit.locationName()).isEqualTo("QC Hold");
+              assertThat(unit.qualityRelocationAllowed()).isTrue();
+            });
     verify(stockUnitRepository)
         .findByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId, pageable);
+    verify(warehouseLocationPort).findLocationRefs(TENANT_ID, Set.of(locationId));
+  }
+
+  @Test
+  void activeUnitsPreserveNullLocationWithoutLookupPerUnit() {
+    var batchId = UUID.randomUUID();
+    var pageable = PageRequest.of(0, 20);
+    var stockUnit =
+        StockUnit.builder()
+            .barcode("ROLL-NO-LOCATION")
+            .status(StockUnitStatus.DISPOSED)
+            .qualityDisposition(QualityDisposition.NONCONFORMING)
+            .build();
+    when(stockUnitRepository.findByTenantIdAndBatchIdAndIsActiveTrue(TENANT_ID, batchId, pageable))
+        .thenReturn(new PageImpl<>(List.of(stockUnit), pageable, 1));
+    when(warehouseLocationPort.findLocationRefs(TENANT_ID, Set.of())).thenReturn(List.of());
+
+    assertThat(service.getActiveUnits(batchId, pageable))
+        .singleElement()
+        .satisfies(
+            unit -> {
+              assertThat(unit.locationId()).isNull();
+              assertThat(unit.locationCode()).isNull();
+              assertThat(unit.locationName()).isNull();
+              assertThat(unit.qualityRelocationAllowed()).isFalse();
+            });
+    verify(warehouseLocationPort).findLocationRefs(TENANT_ID, Set.of());
+  }
+
+  @Test
+  void mapsDeterministicQualityRelocationTargetsFromThePort() {
+    var first = new QualityRelocationTarget(UUID.randomUUID(), "QC-A", "QC Alpha", "SITE/QC-A");
+    var second = new QualityRelocationTarget(UUID.randomUUID(), "QC-B", "QC Beta", "SITE/QC-B");
+    when(warehouseLocationPort.findQualityRelocationTargets(TENANT_ID))
+        .thenReturn(List.of(first, second));
+
+    assertThat(service.getRelocationTargets())
+        .extracting(target -> target.code())
+        .containsExactly("QC-A", "QC-B");
+    verify(warehouseLocationPort).findQualityRelocationTargets(TENANT_ID);
   }
 
   private static StockUnitRepository.QualityDispositionCount dispositionCount(

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
@@ -23,6 +23,7 @@ import com.fabricmanagement.production.masterdata.fiber.infra.repository.FiberRe
 import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
+import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -173,6 +174,8 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
     assertThat(summary.quarantinedCount()).isEqualTo(1);
     assertThat(summary.nonconformingCount()).isEqualTo(1);
     assertThat(summary.totalCount()).isEqualTo(5);
+    assertThat(summary.fullLotDecisionAllowed()).isTrue();
+    assertThat(summary.selectedUnitsDecisionAllowed()).isTrue();
 
     Batch colourless =
         saveBatch(
@@ -185,6 +188,10 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
     assertThat(colourlessSummary.colorId()).isNull();
     assertThat(colourlessSummary.colorName()).isNull();
     assertThat(colourlessSummary.totalCount()).isZero();
+    assertThat(colourlessSummary.fullLotDecisionAllowed()).isFalse();
+    assertThat(colourlessSummary.fullLotBlockedReason())
+        .isEqualTo(QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS);
+    assertThat(colourlessSummary.selectedUnitsDecisionAllowed()).isFalse();
 
     TenantContext.setCurrentTenantId(otherTenantId);
     assertThatThrownBy(() -> service.getSummary(batch.getId()))

--- a/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/app/QualityQueueReadModelIT.java
@@ -24,6 +24,7 @@ import com.fabricmanagement.production.masterdata.product.domain.Product;
 import com.fabricmanagement.production.masterdata.product.domain.ProductType;
 import com.fabricmanagement.production.masterdata.product.infra.repository.ProductRepository;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionBlockedReason;
+import com.fabricmanagement.production.quality.decision.dto.QualityDecisionUnitDto;
 import com.fabricmanagement.testsupport.AbstractIntegrationTest;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -221,10 +222,10 @@ class QualityQueueReadModelIT extends AbstractIntegrationTest {
 
     assertThat(units).hasSize(StockUnitStatus.values().length);
     assertThat(units.getContent())
-        .extracting(StockUnit::getStatus)
+        .extracting(QualityDecisionUnitDto::status)
         .containsExactlyInAnyOrder(StockUnitStatus.values());
     assertThat(units.getContent())
-        .extracting(StockUnit::getBarcode)
+        .extracting(QualityDecisionUnitDto::barcode)
         .doesNotContain(inactiveBarcode);
   }
 

--- a/src/test/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibilityTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionEligibilityTest.java
@@ -1,0 +1,96 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.production.execution.batch.domain.BatchStatus;
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+class QualityDecisionEligibilityTest {
+
+  @Test
+  void evaluatesFullLotBatchReasonsInDeterministicOrder() {
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.FULL_LOT,
+                BatchStatus.RESERVED,
+                BigDecimal.ONE,
+                BigDecimal.ONE))
+        .isEqualTo(QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_RESERVED));
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.SELECTED_UNITS,
+                BatchStatus.DESTROYED,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO))
+        .isEqualTo(
+            QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_STATUS_BLOCKED));
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.FULL_LOT,
+                BatchStatus.IN_PROGRESS,
+                BigDecimal.ZERO,
+                BigDecimal.ONE))
+        .isEqualTo(QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_CONSUMED));
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.FULL_LOT,
+                BatchStatus.IN_PROGRESS,
+                BigDecimal.ZERO,
+                BigDecimal.ZERO))
+        .isEqualTo(
+            QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_STATUS_BLOCKED));
+  }
+
+  @Test
+  void selectedUnitsAllowsConsumedInProgressBatchButNotReservation() {
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.SELECTED_UNITS,
+                BatchStatus.IN_PROGRESS,
+                BigDecimal.ZERO,
+                BigDecimal.ONE))
+        .isEqualTo(QualityDecisionCapability.permitted());
+    assertThat(
+            QualityDecisionEligibility.evaluatePopulation(
+                QualityDecisionScope.SELECTED_UNITS, 2, 0))
+        .isEqualTo(
+            QualityDecisionCapability.blocked(QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS));
+    assertThat(
+            QualityDecisionEligibility.evaluateBatch(
+                QualityDecisionScope.SELECTED_UNITS,
+                BatchStatus.IN_PROGRESS,
+                BigDecimal.ONE,
+                BigDecimal.ONE))
+        .isEqualTo(QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_RESERVED));
+  }
+
+  @Test
+  void evaluatesPopulationForBothDecisionScopes() {
+    assertThat(QualityDecisionEligibility.evaluatePopulation(QualityDecisionScope.FULL_LOT, 0, 0))
+        .isEqualTo(
+            QualityDecisionCapability.blocked(QualityDecisionBlockedReason.NO_ELIGIBLE_UNITS));
+    assertThat(QualityDecisionEligibility.evaluatePopulation(QualityDecisionScope.FULL_LOT, 2, 1))
+        .isEqualTo(
+            QualityDecisionCapability.blocked(
+                QualityDecisionBlockedReason.INELIGIBLE_ACTIVE_UNITS));
+    assertThat(QualityDecisionEligibility.evaluatePopulation(QualityDecisionScope.FULL_LOT, 2, 2))
+        .isEqualTo(QualityDecisionCapability.permitted());
+    assertThat(
+            QualityDecisionEligibility.evaluatePopulation(
+                QualityDecisionScope.SELECTED_UNITS, 2, 1))
+        .isEqualTo(QualityDecisionCapability.permitted());
+  }
+
+  @Test
+  void combinesBatchAndPopulationWithoutLosingBatchReason() {
+    var batch =
+        QualityDecisionCapability.blocked(QualityDecisionBlockedReason.BATCH_STATUS_BLOCKED);
+    var population = QualityDecisionCapability.permitted();
+
+    assertThat(QualityDecisionEligibility.combine(batch, population)).isEqualTo(batch);
+    assertThat(
+            QualityDecisionEligibility.combine(QualityDecisionCapability.permitted(), population))
+        .isEqualTo(population);
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionReasonPolicyTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/domain/QualityDecisionReasonPolicyTest.java
@@ -1,0 +1,56 @@
+package com.fabricmanagement.production.quality.decision.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class QualityDecisionReasonPolicyTest {
+
+  @Test
+  void exposesOnlyOrderedManualReasonsAndKeepsSystemReasonsPrivate() {
+    assertThat(QualityDecisionReasonPolicy.manualReasons(QualityDecisionOutcome.RELEASED))
+        .isEmpty();
+    assertThat(QualityDecisionReasonPolicy.manualReasons(QualityDecisionOutcome.QUARANTINED))
+        .containsExactly(
+            ManualQualityReasonCode.SUSPECTED_DAMAGE,
+            ManualQualityReasonCode.AWAITING_LAB,
+            ManualQualityReasonCode.SUPPLIER_DISPUTE,
+            ManualQualityReasonCode.SHADE_CHECK,
+            ManualQualityReasonCode.OTHER);
+    assertThat(QualityDecisionReasonPolicy.manualReasons(QualityDecisionOutcome.NONCONFORMING))
+        .containsExactly(
+            ManualQualityReasonCode.DAMAGE,
+            ManualQualityReasonCode.STAIN,
+            ManualQualityReasonCode.SHADE_VARIATION,
+            ManualQualityReasonCode.SHORT_LENGTH,
+            ManualQualityReasonCode.MEASURE_MISMATCH,
+            ManualQualityReasonCode.OTHER);
+  }
+
+  @Test
+  void validatesManualAndSystemReasonsFromTheSameCatalog() {
+    assertThat(
+            QualityDecisionReasonPolicy.reasonAllowed(
+                QualityDecisionOrigin.MANUAL, QualityDecisionOutcome.RELEASED, null))
+        .isTrue();
+    assertThat(
+            QualityDecisionReasonPolicy.reasonAllowed(
+                QualityDecisionOrigin.MANUAL,
+                QualityDecisionOutcome.QUARANTINED,
+                QualityReasonCode.AWAITING_LAB))
+        .isTrue();
+    assertThat(
+            QualityDecisionReasonPolicy.reasonAllowed(
+                QualityDecisionOrigin.MANUAL,
+                QualityDecisionOutcome.QUARANTINED,
+                QualityReasonCode.SYSTEM_QC_REJECTED))
+        .isFalse();
+    assertThat(
+            QualityDecisionReasonPolicy.reasonAllowed(
+                QualityDecisionOrigin.SYSTEM_RELEASE,
+                QualityDecisionOutcome.RELEASED,
+                QualityReasonCode.SYSTEM_QC_PASSED))
+        .isTrue();
+    assertThat(QualityDecisionReasonPolicy.remarksRequired(QualityReasonCode.OTHER)).isTrue();
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapperTest.java
+++ b/src/test/java/com/fabricmanagement/production/quality/decision/mapper/QualityDecisionMapperTest.java
@@ -1,11 +1,16 @@
 package com.fabricmanagement.production.quality.decision.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.fabricmanagement.production.execution.batch.domain.port.WarehouseLocationRef;
+import com.fabricmanagement.production.execution.stockunit.domain.QualityDisposition;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnit;
 import com.fabricmanagement.production.execution.stockunit.domain.StockUnitStatus;
+import com.fabricmanagement.production.execution.stockunit.domain.exception.QcRelocationException;
 import com.fabricmanagement.production.quality.decision.domain.QualityDecisionEligibility;
 import java.util.EnumSet;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
@@ -23,5 +28,44 @@ class QualityDecisionMapperTest {
               assertThat(mapper.toUnitDto(unit).unitStatusEligible())
                   .isEqualTo(QualityDecisionEligibility.isUnitStatusEligible(status));
             });
+  }
+
+  @Test
+  void exposesLocationAndQualityRelocationCapabilityFromTheDomainPredicate() {
+    UUID locationId = UUID.randomUUID();
+    StockUnit pendingAvailable =
+        StockUnit.builder()
+            .status(StockUnitStatus.AVAILABLE)
+            .qualityDisposition(QualityDisposition.PENDING_INSPECTION)
+            .build();
+
+    var dto =
+        mapper.toUnitDto(
+            pendingAvailable, new WarehouseLocationRef(locationId, "QC-01", "QC Hold"));
+
+    assertThat(dto.locationId()).isEqualTo(locationId);
+    assertThat(dto.locationCode()).isEqualTo("QC-01");
+    assertThat(dto.locationName()).isEqualTo("QC Hold");
+    assertThat(dto.qualityRelocationAllowed()).isTrue();
+  }
+
+  @Test
+  void relocationCapabilityAndAssertionUseTheSameMatrix() {
+    assertCapability(QualityDisposition.RELEASED, StockUnitStatus.AVAILABLE, false);
+    assertCapability(QualityDisposition.PENDING_INSPECTION, StockUnitStatus.AVAILABLE, true);
+    assertCapability(QualityDisposition.NONCONFORMING, StockUnitStatus.DISPOSED, false);
+    assertCapability(QualityDisposition.QUARANTINED, StockUnitStatus.QUARANTINE, true);
+  }
+
+  private void assertCapability(
+      QualityDisposition disposition, StockUnitStatus status, boolean expected) {
+    StockUnit unit = StockUnit.builder().status(status).qualityDisposition(disposition).build();
+
+    assertThat(mapper.toUnitDto(unit).qualityRelocationAllowed()).isEqualTo(expected);
+    if (expected) {
+      unit.assertAllowsQualityRelocation();
+    } else {
+      assertThrows(QcRelocationException.class, unit::assertAllowsQualityRelocation);
+    }
   }
 }


### PR DESCRIPTION
…LEASE-1c-3)

Backend half of ADR-0011 Faz 1 slice 1c-3 (first write path).

- QualityDecisionEligibility is extended into a two-phase shared policy: evaluateBatch(scope,status,reserved,consumed) and evaluatePopulation(scope,activeCount,eligibleCount), each returning a QualityDecisionCapability (allowed + QualityDecisionBlockedReason). The write service now delegates to them at their existing points — evaluateBatch before the population lock, evaluatePopulation inside lockPopulation — so no lockless pre-query is introduced and the prior 409/422 semantics are preserved exactly. The summary combines both phases for FULL_LOT and SELECTED_UNITS, so read capability and write enforcement share one source and cannot drift.
- Summary now returns fullLotDecisionAllowed / selectedUnitsDecisionAllowed plus a nullable blockedReason each; findQualityBatchSummary gains status, reserved_quantity and consumed_quantity, and the counts come from the existing active / status-eligible count queries (no invented Batch query).
- The reason matrix is extracted to QualityDecisionReasonPolicy (single source for both reasonAllowed and the options endpoint). A new GET /quality/decision-options (quality:read) publishes only the MANUAL matrix via a dedicated ManualQualityReasonCode enum, so system-only codes can't leak to OpenAPI; shape is outcome + reasonRequired + ordered reasons[{code, remarksRequired}].
- QualityDecisionUnitDto.id is now required.

Tests: QualityDecisionEligibilityTest (pure matrix, every blockedReason branch), QualityDecisionReasonPolicyTest, query service (capability + options), service, controller security, read-model IT. OpenAPI regenerated.

Ref: docs/production/tickets/QC-RELEASE-1c-3.md.