### PR TITLE
feat(procurement): derive PO receive status from goods receipts (F-20)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -58654,12 +58654,21 @@ components:
           format: uuid
         qty:
           type: number
+        receiveMismatch:
+          type: boolean
+          description: Whether one or more receipt items could not be counted due to unit mismatch
+        receivedQty:
+          type: number
+          description: Cumulative confirmed receipt quantity expressed in this line's unit
         totalPrice:
           type: number
         unit:
           type: string
         unitPrice:
           type: number
+      required:
+      - receiveMismatch
+      - receivedQty
     PurchaseOrderResponse:
       type: object
       properties:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -58656,10 +58656,12 @@ components:
           type: number
         receiveMismatch:
           type: boolean
-          description: Whether one or more receipt items could not be counted due to unit mismatch
+          description: Whether one or more receipt items could not be counted due
+            to unit mismatch
         receivedQty:
           type: number
-          description: Cumulative confirmed receipt quantity expressed in this line's unit
+          description: Cumulative confirmed receipt quantity expressed in this line's
+            unit
         totalPrice:
           type: number
         unit:

--- a/src/main/java/com/fabricmanagement/notification/hub/app/listener/ProcurementNotificationListener.java
+++ b/src/main/java/com/fabricmanagement/notification/hub/app/listener/ProcurementNotificationListener.java
@@ -195,8 +195,8 @@ public class ProcurementNotificationListener {
                 NotificationEventType.PO_PARTIALLY_RECEIVED,
                 Map.of(
                     "poNumber", event.getPoNumber() != null ? event.getPoNumber() : "",
-                    "received", String.valueOf(event.getReceivedItemCount()),
-                    "total", String.valueOf(event.getTotalItemCount())),
+                    "receivedItemCount", String.valueOf(event.getReceivedItemCount()),
+                    "totalItemCount", String.valueOf(event.getTotalItemCount())),
                 event.getPurchaseOrderId(),
                 "PO");
           } else {

--- a/src/main/java/com/fabricmanagement/procurement/common/exception/ProcurementDomainException.java
+++ b/src/main/java/com/fabricmanagement/procurement/common/exception/ProcurementDomainException.java
@@ -12,4 +12,8 @@ public class ProcurementDomainException extends DomainException {
   public ProcurementDomainException(String message, Throwable cause) {
     super(message, "PROCUREMENT_RULE_VIOLATION", 400, cause);
   }
+
+  public ProcurementDomainException(String message, String errorCode, int httpStatus) {
+    super(message, errorCode, httpStatus);
+  }
 }

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PoReceiveStatusService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PoReceiveStatusService.java
@@ -1,0 +1,169 @@
+package com.fabricmanagement.procurement.purchaseorder.app;
+
+import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort;
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort.LineReceiptTotal;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderLine;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.domain.event.PoPartiallyReceivedEvent;
+import com.fabricmanagement.procurement.purchaseorder.domain.event.PoReceivedEvent;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderLineRepository;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Derives persisted PO receive status and read-model coverage from confirmed goods receipts. */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PoReceiveStatusService {
+
+  private static final Set<PurchaseOrderStatus> ELIGIBLE_SOURCE_STATUSES =
+      Set.of(PurchaseOrderStatus.CONFIRMED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+
+  private final PurchaseOrderRepository purchaseOrderRepository;
+  private final PurchaseOrderLineRepository purchaseOrderLineRepository;
+  private final PoGoodsReceiptReadPort goodsReceiptReadPort;
+  private final ApplicationEventPublisher eventPublisher;
+
+  /**
+   * Fully re-derives receive status. No receipt event is incrementally applied, so redelivery
+   * converges on the same result.
+   */
+  @Transactional
+  public void recomputeReceiveStatus(UUID tenantId, UUID purchaseOrderId) {
+    PurchaseOrder purchaseOrder =
+        purchaseOrderRepository
+            .findByIdAndTenantIdAndIsActiveTrue(purchaseOrderId, tenantId)
+            .orElseThrow(
+                () ->
+                    new ProcurementDomainException(
+                        "PurchaseOrder not found with id: " + purchaseOrderId));
+
+    if (!ELIGIBLE_SOURCE_STATUSES.contains(purchaseOrder.getStatus())) {
+      log.warn(
+          "Skipping PO receive-status derivation for ineligible status: tenant={}, po={}, status={}",
+          tenantId,
+          purchaseOrderId,
+          purchaseOrder.getStatus());
+      return;
+    }
+
+    List<PurchaseOrderLine> lines =
+        purchaseOrderLineRepository
+            .findByTenantIdAndPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(
+                tenantId, purchaseOrderId);
+    if (lines.isEmpty()) {
+      log.warn(
+          "Skipping PO receive-status derivation because no active lines exist: tenant={}, po={}",
+          tenantId,
+          purchaseOrderId);
+      return;
+    }
+
+    CoverageSnapshot snapshot = coverageSnapshot(tenantId, purchaseOrderId, lines);
+    if (!snapshot.hasConfirmedReceipts()) {
+      return;
+    }
+
+    int completeLineCount =
+        Math.toIntExact(
+            lines.stream()
+                .filter(
+                    line ->
+                        snapshot
+                                .coverageByLine()
+                                .getOrDefault(line.getId(), LineCoverage.empty())
+                                .receivedQty()
+                                .compareTo(line.getQty())
+                            >= 0)
+                .count());
+    PurchaseOrderStatus targetStatus =
+        completeLineCount == lines.size()
+            ? PurchaseOrderStatus.RECEIVED
+            : PurchaseOrderStatus.PARTIALLY_RECEIVED;
+
+    if (purchaseOrder.getStatus() == targetStatus) {
+      return;
+    }
+    if (!purchaseOrder.getStatus().canTransitionTo(targetStatus)) {
+      log.warn(
+          "Skipping invalid derived PO transition: tenant={}, po={}, current={}, target={}",
+          tenantId,
+          purchaseOrderId,
+          purchaseOrder.getStatus(),
+          targetStatus);
+      return;
+    }
+
+    purchaseOrder.setStatus(targetStatus);
+    purchaseOrderRepository.saveAndFlush(purchaseOrder);
+
+    if (targetStatus == PurchaseOrderStatus.PARTIALLY_RECEIVED) {
+      eventPublisher.publishEvent(
+          new PoPartiallyReceivedEvent(
+              tenantId,
+              purchaseOrderId,
+              purchaseOrder.getPoNumber(),
+              completeLineCount,
+              lines.size()));
+    } else {
+      eventPublisher.publishEvent(
+          new PoReceivedEvent(
+              tenantId,
+              purchaseOrderId,
+              purchaseOrder.getPoNumber(),
+              completeLineCount,
+              lines.size()));
+    }
+  }
+
+  @Transactional(readOnly = true)
+  public Map<UUID, LineCoverage> getLineCoverage(
+      UUID tenantId, UUID purchaseOrderId, List<PurchaseOrderLine> lines) {
+    return coverageSnapshot(tenantId, purchaseOrderId, lines).coverageByLine();
+  }
+
+  private CoverageSnapshot coverageSnapshot(
+      UUID tenantId, UUID purchaseOrderId, List<PurchaseOrderLine> lines) {
+    Map<UUID, String> lineUnits = new LinkedHashMap<>();
+    lines.forEach(line -> lineUnits.put(line.getId(), line.getUnit()));
+
+    var totals = goodsReceiptReadPort.sumReceivedByLine(tenantId, purchaseOrderId, lineUnits);
+    Map<UUID, LineCoverage> coverageByLine = new LinkedHashMap<>();
+    lines.forEach(
+        line -> {
+          LineReceiptTotal total =
+              totals
+                  .receivedByLine()
+                  .getOrDefault(line.getId(), new LineReceiptTotal(BigDecimal.ZERO, 0, false));
+          coverageByLine.put(
+              line.getId(), new LineCoverage(total.receivedQty(), total.receiveMismatch()));
+        });
+    return new CoverageSnapshot(totals.hasConfirmedReceipts(), Map.copyOf(coverageByLine));
+  }
+
+  public record LineCoverage(BigDecimal receivedQty, boolean receiveMismatch) {
+
+    public LineCoverage {
+      receivedQty = receivedQty != null ? receivedQty : BigDecimal.ZERO;
+    }
+
+    public static LineCoverage empty() {
+      return new LineCoverage(BigDecimal.ZERO, false);
+    }
+  }
+
+  private record CoverageSnapshot(
+      boolean hasConfirmedReceipts, Map<UUID, LineCoverage> coverageByLine) {}
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderService.java
@@ -53,6 +53,7 @@ public class PurchaseOrderService {
   private final DataScopeGuard scopeGuard;
   private final ExchangeRateService exchangeRateService;
   private final TenantReportingCurrencyPort tenantReportingCurrencyPort;
+  private final PoReceiveStatusService receiveStatusService;
 
   public PurchaseOrderResponse getPurchaseOrder(UUID id) {
     PurchaseOrder po = findEntityById(id);
@@ -175,14 +176,22 @@ public class PurchaseOrderService {
    * Transitions the PurchaseOrder status. Validates against the state machine in
    * PurchaseOrderStatus.
    *
-   * <p>Special rule: CONFIRMED → PARTIALLY_RECEIVED / RECEIVED transitions are driven by
-   * GoodsReceipt confirmation (via event in Phase 3.2+). Manual status change here is for
-   * DRAFT→SENT, SENT→CONFIRMED, etc.
+   * <p>Special rule: CONFIRMED → PARTIALLY_RECEIVED / RECEIVED transitions are derived from
+   * confirmed GoodsReceipts by {@link PoReceiveStatusService}. Manual status change here is for
+   * DRAFT→SENT, SENT→CONFIRMED, etc.; derived receive targets are rejected.
    */
   @Transactional
   public PurchaseOrderResponse changeStatus(UUID id, PurchaseOrderStatus newStatus) {
     PurchaseOrder po = findEntityById(id);
     scopeGuard.assertCanAccess("procurement", "write", po);
+
+    if (newStatus == PurchaseOrderStatus.PARTIALLY_RECEIVED
+        || newStatus == PurchaseOrderStatus.RECEIVED) {
+      throw new ProcurementDomainException(
+          "PurchaseOrder receive status is derived from confirmed goods receipts",
+          "PO_RECEIVE_STATUS_DERIVED",
+          422);
+    }
 
     if (!po.getStatus().canTransitionTo(newStatus)) {
       throw new ProcurementDomainException(
@@ -268,21 +277,28 @@ public class PurchaseOrderService {
   }
 
   private PurchaseOrderResponse mapToResponse(PurchaseOrder po, List<PurchaseOrderLine> lines) {
+    var coverageByLine = receiveStatusService.getLineCoverage(po.getTenantId(), po.getId(), lines);
     List<PurchaseOrderResponse.PurchaseOrderLineResponse> lineResps =
         lines.stream()
             .map(
-                l ->
-                    PurchaseOrderResponse.PurchaseOrderLineResponse.builder()
-                        .id(l.getId())
-                        .productId(l.getProductId())
-                        .productDesc(l.getProductDesc())
-                        .qty(l.getQty())
-                        .unit(l.getUnit())
-                        .unitPrice(extractAmount(l.getUnitPrice()))
-                        .currency(extractCurrencyCode(l.getUnitPrice()))
-                        .totalPrice(l.getTotalPrice())
-                        .moduleSpecs(l.getModuleSpecs())
-                        .build())
+                line -> {
+                  var coverage =
+                      coverageByLine.getOrDefault(
+                          line.getId(), PoReceiveStatusService.LineCoverage.empty());
+                  return PurchaseOrderResponse.PurchaseOrderLineResponse.builder()
+                      .id(line.getId())
+                      .productId(line.getProductId())
+                      .productDesc(line.getProductDesc())
+                      .qty(line.getQty())
+                      .unit(line.getUnit())
+                      .unitPrice(extractAmount(line.getUnitPrice()))
+                      .currency(extractCurrencyCode(line.getUnitPrice()))
+                      .totalPrice(line.getTotalPrice())
+                      .moduleSpecs(line.getModuleSpecs())
+                      .receivedQty(coverage.receivedQty())
+                      .receiveMismatch(coverage.receiveMismatch())
+                      .build();
+                })
             .toList();
 
     return PurchaseOrderResponse.builder()

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/adapter/PurchaseOrderReceivabilityAdapter.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/adapter/PurchaseOrderReceivabilityAdapter.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.procurement.purchaseorder.app.adapter;
+
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.port.PoReceivabilityPort;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Procurement-owned adapter that answers the goods-receipt receivability question. */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PurchaseOrderReceivabilityAdapter implements PoReceivabilityPort {
+
+  private static final Set<PurchaseOrderStatus> RECEIVABLE_STATUSES =
+      Set.of(PurchaseOrderStatus.CONFIRMED, PurchaseOrderStatus.PARTIALLY_RECEIVED);
+
+  private final PurchaseOrderRepository purchaseOrderRepository;
+
+  @Override
+  public boolean isReceivable(UUID tenantId, UUID purchaseOrderId) {
+    return purchaseOrderRepository
+        .findByIdAndTenantIdAndIsActiveTrue(purchaseOrderId, tenantId)
+        .map(purchaseOrder -> RECEIVABLE_STATUSES.contains(purchaseOrder.getStatus()))
+        .orElse(false);
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/listener/GoodsReceiptConfirmedPoListener.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/listener/GoodsReceiptConfirmedPoListener.java
@@ -1,0 +1,59 @@
+package com.fabricmanagement.procurement.purchaseorder.app.listener;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.procurement.purchaseorder.app.PoReceiveStatusService;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+/**
+ * Re-derives PO receipt status after a confirmed goods receipt.
+ *
+ * <p>The processed-event guard follows the repository-wide listener convention. The derivation is
+ * independently idempotent, so duplicate delivery also converges by construction.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GoodsReceiptConfirmedPoListener {
+
+  private final PoReceiveStatusService receiveStatusService;
+  private final IdempotentEventHandler idempotentEventHandler;
+
+  @ApplicationModuleListener
+  public void onGoodsReceiptConfirmed(GoodsReceiptConfirmedEvent event) {
+    if (event.getSourceType() != GoodsReceiptSourceType.PURCHASE_ORDER) {
+      return;
+    }
+
+    try {
+      executeOnce(event);
+    } catch (OptimisticLockingFailureException exception) {
+      log.warn(
+          "Retrying PO receive-status derivation after optimistic-lock conflict: eventId={}, po={}",
+          event.getEventId(),
+          event.getSourceId());
+      executeOnce(event);
+    }
+  }
+
+  private void executeOnce(GoodsReceiptConfirmedEvent event) {
+    idempotentEventHandler.executeOnce(
+        event.getEventId(),
+        this.getClass(),
+        "onGoodsReceiptConfirmed",
+        () ->
+            TenantContext.executeInTenantContext(
+                event.getTenantId(),
+                () -> {
+                  receiveStatusService.recomputeReceiveStatus(
+                      event.getTenantId(), event.getSourceId());
+                  return null;
+                }));
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/port/PoGoodsReceiptReadPort.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/app/port/PoGoodsReceiptReadPort.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.procurement.purchaseorder.app.port;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.UUID;
+
+/** Consumer-owned read port for PO receipt coverage. */
+public interface PoGoodsReceiptReadPort {
+
+  PoReceiptTotals sumReceivedByLine(
+      UUID tenantId, UUID purchaseOrderId, Map<UUID, String> lineUnits);
+
+  record PoReceiptTotals(boolean hasConfirmedReceipts, Map<UUID, LineReceiptTotal> receivedByLine) {
+
+    public PoReceiptTotals {
+      receivedByLine = Map.copyOf(receivedByLine);
+    }
+  }
+
+  record LineReceiptTotal(BigDecimal receivedQty, int excludedItemCount, boolean unitSupported) {
+
+    public LineReceiptTotal {
+      receivedQty = receivedQty != null ? receivedQty : BigDecimal.ZERO;
+    }
+
+    public boolean receiveMismatch() {
+      return !unitSupported || excludedItemCount > 0;
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoReceivedEvent.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/domain/event/PoReceivedEvent.java
@@ -1,0 +1,54 @@
+package com.fabricmanagement.procurement.purchaseorder.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+/** Purchase order fully received. Domain event only; F-20 intentionally adds no notification. */
+@Getter
+public class PoReceivedEvent extends DomainEvent {
+
+  private final UUID purchaseOrderId;
+  private final String poNumber;
+  private final int receivedItemCount;
+  private final int totalItemCount;
+
+  @JsonCreator
+  public PoReceivedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("purchaseOrderId") UUID purchaseOrderId,
+      @JsonProperty("poNumber") String poNumber,
+      @JsonProperty("receivedItemCount") int receivedItemCount,
+      @JsonProperty("totalItemCount") int totalItemCount) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "PO_RECEIVED",
+        occurredAt,
+        correlationId);
+    this.purchaseOrderId = purchaseOrderId;
+    this.poNumber = poNumber;
+    this.receivedItemCount = receivedItemCount;
+    this.totalItemCount = totalItemCount;
+  }
+
+  public PoReceivedEvent(
+      UUID tenantId,
+      UUID purchaseOrderId,
+      String poNumber,
+      int receivedItemCount,
+      int totalItemCount) {
+    super(tenantId, "PO_RECEIVED");
+    this.purchaseOrderId = purchaseOrderId;
+    this.poNumber = poNumber;
+    this.receivedItemCount = receivedItemCount;
+    this.totalItemCount = totalItemCount;
+  }
+}

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/dto/PurchaseOrderResponse.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.domain.specs.PurchaseOrderSpecs;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
@@ -46,5 +47,15 @@ public class PurchaseOrderResponse {
     String currency;
     BigDecimal totalPrice;
     PurchaseOrderSpecs moduleSpecs;
+
+    @Schema(
+        description = "Cumulative confirmed receipt quantity expressed in this line's unit",
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    BigDecimal receivedQty;
+
+    @Schema(
+        description = "Whether one or more receipt items could not be counted due to unit mismatch",
+        requiredMode = Schema.RequiredMode.REQUIRED)
+    boolean receiveMismatch;
   }
 }

--- a/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderLineRepository.java
+++ b/src/main/java/com/fabricmanagement/procurement/purchaseorder/infra/repository/PurchaseOrderLineRepository.java
@@ -11,6 +11,9 @@ public interface PurchaseOrderLineRepository extends JpaRepository<PurchaseOrder
   List<PurchaseOrderLine> findByPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(
       UUID purchaseOrderId);
 
+  List<PurchaseOrderLine> findByTenantIdAndPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(
+      UUID tenantId, UUID purchaseOrderId);
+
   Optional<PurchaseOrderLine> findByIdAndTenantIdAndPurchaseOrderIdAndIsActiveTrue(
       UUID id, UUID tenantId, UUID purchaseOrderId);
 }

--- a/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/app/GoodsReceiptService.java
+++ b/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/app/GoodsReceiptService.java
@@ -12,6 +12,7 @@ import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceip
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptStatus;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.exception.GoodsReceiptDomainException;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.port.PoReceivabilityPort;
 import com.fabricmanagement.production.execution.goodsreceipt.dto.CreateGoodsReceiptRequest;
 import com.fabricmanagement.production.execution.goodsreceipt.dto.GoodsReceiptResponse;
 import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository;
@@ -45,6 +46,7 @@ public class GoodsReceiptService {
   private final SubcontractOrderQueryService scQueryService;
   private final ProductFacade productFacade;
   private final BatchPrimaryMeasureService primaryMeasureService;
+  private final PoReceivabilityPort poReceivabilityPort;
   private final ApplicationEventPublisher eventPublisher;
 
   /** Retrieves a GoodsReceipt with its items by ID. */
@@ -139,9 +141,8 @@ public class GoodsReceiptService {
   /**
    * Confirms a GoodsReceipt — transitions from DRAFT → CONFIRMED.
    *
-   * <p>Post-confirmation side effects (IWM stock entry, source order update) are handled via the
-   * GoodsReceiptConfirmed domain event in a future phase. For Phase 3.1 the transition itself is
-   * implemented here synchronously.
+   * <p>Post-confirmation side effects, including stock entry and purchase-order receipt-status
+   * derivation, are handled by idempotent listeners on the GoodsReceiptConfirmed domain event.
    */
   @Transactional
   public GoodsReceiptResponse confirmGoodsReceipt(UUID id) {
@@ -265,6 +266,10 @@ public class GoodsReceiptService {
     }
 
     UUID tenantId = TenantContext.requireTenantId();
+    if (!poReceivabilityPort.isReceivable(tenantId, sourceId)) {
+      throw unprocessable("Purchase order is not in a receivable status", "GR_PO_NOT_RECEIVABLE");
+    }
+
     PurchaseOrderQueryService.PurchaseOrderLineInfo lineInfo;
     try {
       lineInfo = poQueryService.getPurchaseOrderLineInfo(tenantId, sourceId, sourceLineId);

--- a/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/app/adapter/PoGoodsReceiptReadAdapter.java
+++ b/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/app/adapter/PoGoodsReceiptReadAdapter.java
@@ -1,0 +1,150 @@
+package com.fabricmanagement.production.execution.goodsreceipt.app.adapter;
+
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptStatus;
+import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository;
+import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository.PoReceiptMeasureBucket;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Goods-receipt adapter that converts physical receipt measures into each PO line's unit. */
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class PoGoodsReceiptReadAdapter implements PoGoodsReceiptReadPort {
+
+  private static final BigDecimal ONE_HUNDRED = new BigDecimal("100");
+  private static final BigDecimal ONE_THOUSAND = new BigDecimal("1000");
+  private static final Set<String> WEIGHT_UNITS = Set.of("KG", "G", "MT");
+  private static final Set<String> LENGTH_UNITS = Set.of("M", "CM", "MM");
+
+  private final GoodsReceiptItemRepository goodsReceiptItemRepository;
+
+  @Override
+  public PoReceiptTotals sumReceivedByLine(
+      UUID tenantId, UUID purchaseOrderId, Map<UUID, String> lineUnits) {
+    List<PoReceiptMeasureBucket> buckets =
+        goodsReceiptItemRepository.sumConfirmedPoReceiptMeasures(
+            tenantId,
+            GoodsReceiptSourceType.PURCHASE_ORDER,
+            purchaseOrderId,
+            GoodsReceiptStatus.CONFIRMED);
+
+    Map<UUID, List<PoReceiptMeasureBucket>> bucketsByLine =
+        buckets.stream()
+            .filter(bucket -> bucket.getSourceLineId() != null)
+            .collect(
+                java.util.stream.Collectors.groupingBy(PoReceiptMeasureBucket::getSourceLineId));
+
+    long orphanItemCount =
+        buckets.stream()
+            .filter(bucket -> bucket.getSourceLineId() == null)
+            .mapToLong(PoReceiptMeasureBucket::getItemCount)
+            .sum();
+    if (orphanItemCount > 0) {
+      log.warn(
+          "Ignoring {} confirmed PO receipt items without sourceLineId: tenant={}, po={}",
+          orphanItemCount,
+          tenantId,
+          purchaseOrderId);
+    }
+
+    Map<UUID, LineReceiptTotal> totals = new LinkedHashMap<>();
+    lineUnits.forEach(
+        (lineId, lineUnit) ->
+            totals.put(
+                lineId,
+                calculateLineTotal(
+                    normalizeUnit(lineUnit), bucketsByLine.getOrDefault(lineId, List.of()))));
+
+    bucketsByLine.keySet().stream()
+        .filter(lineId -> !lineUnits.containsKey(lineId))
+        .forEach(
+            lineId ->
+                log.warn(
+                    "Ignoring confirmed receipt measures for inactive/unknown PO line: tenant={}, po={}, line={}",
+                    tenantId,
+                    purchaseOrderId,
+                    lineId));
+
+    return new PoReceiptTotals(!buckets.isEmpty(), totals);
+  }
+
+  private LineReceiptTotal calculateLineTotal(
+      String targetUnit, List<PoReceiptMeasureBucket> buckets) {
+    if (WEIGHT_UNITS.contains(targetUnit)) {
+      BigDecimal totalKg =
+          buckets.stream()
+              .map(PoReceiptMeasureBucket::getNetWeightTotal)
+              .filter(java.util.Objects::nonNull)
+              .reduce(BigDecimal.ZERO, BigDecimal::add);
+      int excluded =
+          buckets.stream()
+              .mapToInt(
+                  bucket -> Math.toIntExact(bucket.getItemCount() - bucket.getNetWeightItemCount()))
+              .sum();
+      return new LineReceiptTotal(convertWeightFromKg(totalKg, targetUnit), excluded, true);
+    }
+
+    if (LENGTH_UNITS.contains(targetUnit)) {
+      BigDecimal total = BigDecimal.ZERO;
+      int excluded = 0;
+      for (PoReceiptMeasureBucket bucket : buckets) {
+        String sourceUnit = normalizeUnit(bucket.getLengthUnit());
+        if (!LENGTH_UNITS.contains(sourceUnit)) {
+          excluded += Math.toIntExact(bucket.getItemCount());
+          continue;
+        }
+        excluded += Math.toIntExact(bucket.getItemCount() - bucket.getLengthMeasureItemCount());
+        if (bucket.getLengthTotal() != null) {
+          total = total.add(convertLength(bucket.getLengthTotal(), sourceUnit, targetUnit));
+        }
+      }
+      return new LineReceiptTotal(total, excluded, true);
+    }
+
+    int excluded =
+        buckets.stream().mapToInt(bucket -> Math.toIntExact(bucket.getItemCount())).sum();
+    return new LineReceiptTotal(BigDecimal.ZERO, excluded, false);
+  }
+
+  private BigDecimal convertWeightFromKg(BigDecimal quantityKg, String targetUnit) {
+    return switch (targetUnit) {
+      case "KG" -> quantityKg;
+      case "G" -> quantityKg.multiply(ONE_THOUSAND);
+      case "MT" -> quantityKg.divide(ONE_THOUSAND);
+      default -> throw new IllegalArgumentException("Unsupported weight unit: " + targetUnit);
+    };
+  }
+
+  private BigDecimal convertLength(BigDecimal quantity, String sourceUnit, String targetUnit) {
+    BigDecimal meters =
+        switch (sourceUnit) {
+          case "M" -> quantity;
+          case "CM" -> quantity.divide(ONE_HUNDRED);
+          case "MM" -> quantity.divide(ONE_THOUSAND);
+          default -> throw new IllegalArgumentException("Unsupported length unit: " + sourceUnit);
+        };
+    return switch (targetUnit) {
+      case "M" -> meters;
+      case "CM" -> meters.multiply(ONE_HUNDRED);
+      case "MM" -> meters.multiply(ONE_THOUSAND);
+      default -> throw new IllegalArgumentException("Unsupported length unit: " + targetUnit);
+    };
+  }
+
+  private String normalizeUnit(String unit) {
+    return unit == null ? "" : unit.trim().toUpperCase(Locale.ROOT);
+  }
+}

--- a/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/domain/port/PoReceivabilityPort.java
+++ b/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/domain/port/PoReceivabilityPort.java
@@ -1,0 +1,9 @@
+package com.fabricmanagement.production.execution.goodsreceipt.domain.port;
+
+import java.util.UUID;
+
+/** Consumer-owned port for validating whether a purchase order can accept goods receipts. */
+public interface PoReceivabilityPort {
+
+  boolean isReceivable(UUID tenantId, UUID purchaseOrderId);
+}

--- a/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/infra/repository/GoodsReceiptItemRepository.java
+++ b/src/main/java/com/fabricmanagement/production/execution/goodsreceipt/infra/repository/GoodsReceiptItemRepository.java
@@ -1,9 +1,14 @@
 package com.fabricmanagement.production.execution.goodsreceipt.infra.repository;
 
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptItem;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptStatus;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface GoodsReceiptItemRepository extends JpaRepository<GoodsReceiptItem, UUID> {
 
@@ -13,4 +18,51 @@ public interface GoodsReceiptItemRepository extends JpaRepository<GoodsReceiptIt
 
   /** Barcode uniqueness check. */
   boolean existsByBarcodeAndIsActiveTrue(String barcode);
+
+  /**
+   * Returns one aggregate bucket per PO line and length unit. The adapter performs the final
+   * dimension-aware conversion into each PO line's requested unit.
+   */
+  @Query(
+      """
+      select
+        receipt.sourceLineId as sourceLineId,
+        item.lengthUnit as lengthUnit,
+        sum(item.netWeight) as netWeightTotal,
+        sum(item.length) as lengthTotal,
+        count(item.id) as itemCount,
+        count(item.netWeight) as netWeightItemCount,
+        count(item.length) as lengthMeasureItemCount
+      from GoodsReceipt receipt, GoodsReceiptItem item
+      where item.goodsReceiptId = receipt.id
+        and receipt.tenantId = :tenantId
+        and item.tenantId = :tenantId
+        and receipt.sourceType = :sourceType
+        and receipt.sourceId = :sourceId
+        and receipt.status = :status
+        and receipt.isActive = true
+        and item.isActive = true
+      group by receipt.sourceLineId, item.lengthUnit
+      """)
+  List<PoReceiptMeasureBucket> sumConfirmedPoReceiptMeasures(
+      @Param("tenantId") UUID tenantId,
+      @Param("sourceType") GoodsReceiptSourceType sourceType,
+      @Param("sourceId") UUID sourceId,
+      @Param("status") GoodsReceiptStatus status);
+
+  interface PoReceiptMeasureBucket {
+    UUID getSourceLineId();
+
+    String getLengthUnit();
+
+    BigDecimal getNetWeightTotal();
+
+    BigDecimal getLengthTotal();
+
+    long getItemCount();
+
+    long getNetWeightItemCount();
+
+    long getLengthMeasureItemCount();
+  }
 }

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
@@ -400,6 +400,8 @@ class ProcurementDemoSeederTest {
         .productDesc("Demo cotton")
         .qty(BigDecimal.TEN)
         .unit("KG")
+        .receivedQty(BigDecimal.ZERO)
+        .receiveMismatch(false)
         .build();
   }
 

--- a/src/test/java/com/fabricmanagement/notification/hub/app/listener/ProcurementNotificationListenerTest.java
+++ b/src/test/java/com/fabricmanagement/notification/hub/app/listener/ProcurementNotificationListenerTest.java
@@ -1,0 +1,58 @@
+package com.fabricmanagement.notification.hub.app.listener;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.notification.hub.app.NotificationHubService;
+import com.fabricmanagement.notification.hub.domain.NotificationEventType;
+import com.fabricmanagement.notification.hub.domain.port.DepartmentRecipientPort;
+import com.fabricmanagement.procurement.purchaseorder.domain.event.PoPartiallyReceivedEvent;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ProcurementNotificationListenerTest {
+
+  @Mock private NotificationHubService notificationHubService;
+  @Mock private DepartmentRecipientPort departmentRecipientPort;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void partialReceiptUsesTemplatePlaceholderNames() {
+    UUID tenantId = UUID.randomUUID();
+    UUID purchaseOrderId = UUID.randomUUID();
+    UUID recipientId = UUID.randomUUID();
+    when(departmentRecipientPort.findManagersByDepartmentKeyword(tenantId, "WAREHOUSE"))
+        .thenReturn(List.of(recipientId));
+    var listener =
+        new ProcurementNotificationListener(notificationHubService, departmentRecipientPort);
+
+    listener.onPoPartiallyReceived(
+        new PoPartiallyReceivedEvent(tenantId, purchaseOrderId, "PO-20260723-00001", 2, 4));
+
+    verify(notificationHubService)
+        .notifyAll(
+            eq(List.of(recipientId)),
+            eq(tenantId),
+            eq(NotificationEventType.PO_PARTIALLY_RECEIVED),
+            eq(
+                Map.of(
+                    "poNumber", "PO-20260723-00001",
+                    "receivedItemCount", "2",
+                    "totalItemCount", "4")),
+            eq(purchaseOrderId),
+            eq("PO"));
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PoReceiveStatusServiceTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PoReceiveStatusServiceTest.java
@@ -1,0 +1,198 @@
+package com.fabricmanagement.procurement.purchaseorder.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.util.Money;
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort;
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort.LineReceiptTotal;
+import com.fabricmanagement.procurement.purchaseorder.app.port.PoGoodsReceiptReadPort.PoReceiptTotals;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderLine;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.domain.event.PoPartiallyReceivedEvent;
+import com.fabricmanagement.procurement.purchaseorder.domain.event.PoReceivedEvent;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderLineRepository;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class PoReceiveStatusServiceTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID PO_ID = UUID.randomUUID();
+  private static final UUID LINE_ONE_ID = UUID.randomUUID();
+  private static final UUID LINE_TWO_ID = UUID.randomUUID();
+
+  @Mock private PurchaseOrderRepository purchaseOrderRepository;
+  @Mock private PurchaseOrderLineRepository lineRepository;
+  @Mock private PoGoodsReceiptReadPort receiptReadPort;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  private PoReceiveStatusService service;
+  private PurchaseOrder purchaseOrder;
+  private PurchaseOrderLine lineOne;
+
+  @BeforeEach
+  void setUp() {
+    service =
+        new PoReceiveStatusService(
+            purchaseOrderRepository, lineRepository, receiptReadPort, eventPublisher);
+    purchaseOrder = purchaseOrder(PurchaseOrderStatus.CONFIRMED);
+    lineOne = line(LINE_ONE_ID, "100", "KG");
+    when(purchaseOrderRepository.findByIdAndTenantIdAndIsActiveTrue(PO_ID, TENANT_ID))
+        .thenReturn(Optional.of(purchaseOrder));
+    when(lineRepository.findByTenantIdAndPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(
+            TENANT_ID, PO_ID))
+        .thenReturn(List.of(lineOne));
+  }
+
+  @Test
+  void shortReceiptTransitionsToPartiallyReceivedAndPublishesCompletedLineCounts() {
+    stubTotals(true, Map.of(LINE_ONE_ID, new LineReceiptTotal(new BigDecimal("40"), 0, true)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    assertThat(purchaseOrder.getStatus()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    verify(purchaseOrderRepository).saveAndFlush(purchaseOrder);
+    ArgumentCaptor<PoPartiallyReceivedEvent> eventCaptor =
+        ArgumentCaptor.forClass(PoPartiallyReceivedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getReceivedItemCount()).isZero();
+    assertThat(eventCaptor.getValue().getTotalItemCount()).isEqualTo(1);
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"100", "120"})
+  void exactAndOverReceiptTransitionDirectlyToReceived(String receivedQty) {
+    stubTotals(
+        true, Map.of(LINE_ONE_ID, new LineReceiptTotal(new BigDecimal(receivedQty), 0, true)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    assertThat(purchaseOrder.getStatus()).isEqualTo(PurchaseOrderStatus.RECEIVED);
+    verify(eventPublisher).publishEvent(any(PoReceivedEvent.class));
+  }
+
+  @Test
+  void partialPurchaseOrderTransitionsToReceivedAfterFreshFullDerivation() {
+    purchaseOrder.setStatus(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    stubTotals(true, Map.of(LINE_ONE_ID, new LineReceiptTotal(new BigDecimal("100"), 0, true)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    assertThat(purchaseOrder.getStatus()).isEqualTo(PurchaseOrderStatus.RECEIVED);
+    verify(purchaseOrderRepository).saveAndFlush(purchaseOrder);
+    verify(eventPublisher).publishEvent(any(PoReceivedEvent.class));
+  }
+
+  @Test
+  void mixedLinesRemainPartialUntilEveryLineIsComplete() {
+    PurchaseOrderLine lineTwo = line(LINE_TWO_ID, "50", "M");
+    when(lineRepository.findByTenantIdAndPurchaseOrderIdAndIsActiveTrueOrderByCreatedAtAsc(
+            TENANT_ID, PO_ID))
+        .thenReturn(List.of(lineOne, lineTwo));
+    stubTotals(
+        true,
+        Map.of(
+            LINE_ONE_ID, new LineReceiptTotal(new BigDecimal("110"), 0, true),
+            LINE_TWO_ID, new LineReceiptTotal(new BigDecimal("20"), 0, true)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    assertThat(purchaseOrder.getStatus()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    ArgumentCaptor<PoPartiallyReceivedEvent> eventCaptor =
+        ArgumentCaptor.forClass(PoPartiallyReceivedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getReceivedItemCount()).isEqualTo(1);
+    assertThat(eventCaptor.getValue().getTotalItemCount()).isEqualTo(2);
+  }
+
+  @Test
+  void mismatchCoverageRemainsZeroAndKeepsStatusTruthful() {
+    stubTotals(true, Map.of(LINE_ONE_ID, new LineReceiptTotal(BigDecimal.ZERO, 2, false)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+    var coverage = service.getLineCoverage(TENANT_ID, PO_ID, List.of(lineOne)).get(LINE_ONE_ID);
+
+    assertThat(purchaseOrder.getStatus()).isEqualTo(PurchaseOrderStatus.PARTIALLY_RECEIVED);
+    assertThat(coverage.receivedQty()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(coverage.receiveMismatch()).isTrue();
+  }
+
+  @Test
+  void rerunInSameDerivedStateDoesNotDuplicateTransitionOrEvent() {
+    stubTotals(true, Map.of(LINE_ONE_ID, new LineReceiptTotal(new BigDecimal("40"), 0, true)));
+
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    verify(purchaseOrderRepository, times(1)).saveAndFlush(purchaseOrder);
+    verify(eventPublisher, times(1)).publishEvent(any(PoPartiallyReceivedEvent.class));
+  }
+
+  @Test
+  void noConfirmedReceiptsOrIneligibleStatusCausesNoTransition() {
+    stubTotals(false, Map.of(LINE_ONE_ID, new LineReceiptTotal(BigDecimal.ZERO, 0, true)));
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    purchaseOrder.setStatus(PurchaseOrderStatus.CANCELLED);
+    service.recomputeReceiveStatus(TENANT_ID, PO_ID);
+
+    verify(purchaseOrderRepository, never()).saveAndFlush(any());
+    verify(eventPublisher, never()).publishEvent(any());
+  }
+
+  private void stubTotals(boolean hasReceipts, Map<UUID, LineReceiptTotal> totals) {
+    when(receiptReadPort.sumReceivedByLine(eq(TENANT_ID), eq(PO_ID), any()))
+        .thenReturn(new PoReceiptTotals(hasReceipts, totals));
+  }
+
+  private PurchaseOrder purchaseOrder(PurchaseOrderStatus status) {
+    PurchaseOrder po =
+        PurchaseOrder.builder()
+            .poNumber("PO-20260723-00001")
+            .workOrderId(UUID.randomUUID())
+            .tradingPartnerId(UUID.randomUUID())
+            .status(status)
+            .totalAmount(Money.of(BigDecimal.TEN, "GBP"))
+            .build();
+    po.setId(PO_ID);
+    po.setTenantId(TENANT_ID);
+    return po;
+  }
+
+  private PurchaseOrderLine line(UUID id, String qty, String unit) {
+    PurchaseOrderLine line =
+        PurchaseOrderLine.create(
+            PO_ID,
+            null,
+            UUID.randomUUID(),
+            null,
+            new BigDecimal(qty),
+            unit,
+            Money.of(BigDecimal.ONE, "GBP"),
+            null);
+    line.setId(id);
+    line.setTenantId(TENANT_ID);
+    return line;
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceDataScopeTest.java
@@ -16,8 +16,10 @@ import com.fabricmanagement.common.infrastructure.security.DataScopeGuard;
 import com.fabricmanagement.common.infrastructure.tenant.TenantReportingCurrencyPort;
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.costing.app.exchange.ExchangeRateService;
+import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderLine;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
@@ -53,6 +55,7 @@ class PurchaseOrderServiceDataScopeTest {
   @Mock private DataScopeGuard scopeGuard;
   @Mock private ExchangeRateService exchangeRateService;
   @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
+  @Mock private PoReceiveStatusService receiveStatusService;
 
   @AfterEach
   void clearTenantContext() {
@@ -144,6 +147,26 @@ class PurchaseOrderServiceDataScopeTest {
   }
 
   @Test
+  void changeStatusRejectsDerivedReceiveTargetsWithCoded422() {
+    PurchaseOrder po = purchaseOrder(PurchaseOrderStatus.CONFIRMED);
+    PurchaseOrderService service = service();
+    when(poRepository.findById(PO_ID)).thenReturn(Optional.of(po));
+
+    for (PurchaseOrderStatus target :
+        List.of(PurchaseOrderStatus.PARTIALLY_RECEIVED, PurchaseOrderStatus.RECEIVED)) {
+      assertThatThrownBy(() -> service.changeStatus(PO_ID, target))
+          .isInstanceOfSatisfying(
+              ProcurementDomainException.class,
+              exception -> {
+                assertThat(exception.getErrorCode()).isEqualTo("PO_RECEIVE_STATUS_DERIVED");
+                assertThat(exception.getHttpStatus()).isEqualTo(422);
+              });
+    }
+
+    verify(poRepository, never()).save(any(PurchaseOrder.class));
+  }
+
+  @Test
   void createPurchaseOrderDoesNotApplyRowScopeGuardButReturnsCanEdit() {
     TenantContext.setCurrentTenantId(TENANT_ID);
     PurchaseOrderService service = service();
@@ -155,9 +178,20 @@ class PurchaseOrderServiceDataScopeTest {
             invocation -> {
               PurchaseOrder po = invocation.getArgument(0);
               po.setId(PO_ID);
+              po.setTenantId(TENANT_ID);
               return po;
             });
-    when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(lineRepository.saveAll(any()))
+        .thenAnswer(
+            invocation -> {
+              List<PurchaseOrderLine> lines = invocation.getArgument(0);
+              lines.forEach(
+                  line -> {
+                    line.setId(UUID.randomUUID());
+                    line.setTenantId(TENANT_ID);
+                  });
+              return lines;
+            });
     when(scopeGuard.canAccess(eq("procurement"), eq("write"), any(PurchaseOrder.class)))
         .thenReturn(true);
     when(tenantReportingCurrencyPort.getReportingCurrency(TENANT_ID)).thenReturn("USD");
@@ -170,6 +204,9 @@ class PurchaseOrderServiceDataScopeTest {
   }
 
   private PurchaseOrderService service() {
+    org.mockito.Mockito.lenient()
+        .when(receiveStatusService.getLineCoverage(any(), any(), any()))
+        .thenReturn(java.util.Map.of());
     return new PurchaseOrderService(
         poRepository,
         lineRepository,
@@ -178,7 +215,8 @@ class PurchaseOrderServiceDataScopeTest {
         documentNumberGenerator,
         scopeGuard,
         exchangeRateService,
-        tenantReportingCurrencyPort);
+        tenantReportingCurrencyPort,
+        receiveStatusService);
   }
 
   private PurchaseOrder purchaseOrder(PurchaseOrderStatus status) {
@@ -194,6 +232,7 @@ class PurchaseOrderServiceDataScopeTest {
             .moduleType(PurchaseOrderModuleType.GENERIC)
             .build();
     po.setId(PO_ID);
+    po.setTenantId(TENANT_ID);
     return po;
   }
 

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceFxTotalTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/PurchaseOrderServiceFxTotalTest.java
@@ -20,6 +20,7 @@ import com.fabricmanagement.costing.domain.exception.ExchangeRateRequiredExcepti
 import com.fabricmanagement.procurement.common.exception.ProcurementDomainException;
 import com.fabricmanagement.procurement.purchaseorder.app.validation.PurchaseOrderValidationEngine;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderLine;
 import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderModuleType;
 import com.fabricmanagement.procurement.purchaseorder.dto.CreatePurchaseOrderRequest;
 import com.fabricmanagement.procurement.purchaseorder.dto.PurchaseOrderResponse;
@@ -53,12 +54,16 @@ class PurchaseOrderServiceFxTotalTest {
   @Mock private DataScopeGuard scopeGuard;
   @Mock private ExchangeRateService exchangeRateService;
   @Mock private TenantReportingCurrencyPort tenantReportingCurrencyPort;
+  @Mock private PoReceiveStatusService receiveStatusService;
 
   private PurchaseOrderService service;
 
   @BeforeEach
   void setUp() {
     TenantContext.setCurrentTenantId(TENANT_ID);
+    org.mockito.Mockito.lenient()
+        .when(receiveStatusService.getLineCoverage(any(), any(), any()))
+        .thenReturn(java.util.Map.of());
     service =
         new PurchaseOrderService(
             poRepository,
@@ -68,7 +73,8 @@ class PurchaseOrderServiceFxTotalTest {
             documentNumberGenerator,
             scopeGuard,
             exchangeRateService,
-            tenantReportingCurrencyPort);
+            tenantReportingCurrencyPort,
+            receiveStatusService);
     when(documentNumberGenerator.generate(
             eq(TENANT_ID), eq("PURCHASE_ORDER"), eq("PO"), any(), eq(5)))
         .thenReturn("PO-20260630-00001");
@@ -77,12 +83,23 @@ class PurchaseOrderServiceFxTotalTest {
             invocation -> {
               PurchaseOrder po = invocation.getArgument(0);
               po.setId(PO_ID);
+              po.setTenantId(TENANT_ID);
               if (po.getCreatedAt() == null) {
                 po.setCreatedAt(DOC_INSTANT);
               }
               return po;
             });
-    when(lineRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    when(lineRepository.saveAll(any()))
+        .thenAnswer(
+            invocation -> {
+              List<PurchaseOrderLine> lines = invocation.getArgument(0);
+              lines.forEach(
+                  line -> {
+                    line.setId(UUID.randomUUID());
+                    line.setTenantId(TENANT_ID);
+                  });
+              return lines;
+            });
   }
 
   @AfterEach

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/adapter/PurchaseOrderReceivabilityAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/adapter/PurchaseOrderReceivabilityAdapterTest.java
@@ -1,0 +1,70 @@
+package com.fabricmanagement.procurement.purchaseorder.app.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrder;
+import com.fabricmanagement.procurement.purchaseorder.domain.PurchaseOrderStatus;
+import com.fabricmanagement.procurement.purchaseorder.infra.repository.PurchaseOrderRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PurchaseOrderReceivabilityAdapterTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID PO_ID = UUID.randomUUID();
+
+  @Mock private PurchaseOrderRepository purchaseOrderRepository;
+
+  @ParameterizedTest
+  @EnumSource(
+      value = PurchaseOrderStatus.class,
+      names = {"CONFIRMED", "PARTIALLY_RECEIVED"})
+  void acceptsReceivableStatuses(PurchaseOrderStatus status) {
+    PurchaseOrder purchaseOrder = PurchaseOrder.builder().status(status).build();
+    when(purchaseOrderRepository.findByIdAndTenantIdAndIsActiveTrue(PO_ID, TENANT_ID))
+        .thenReturn(Optional.of(purchaseOrder));
+
+    boolean receivable =
+        new PurchaseOrderReceivabilityAdapter(purchaseOrderRepository)
+            .isReceivable(TENANT_ID, PO_ID);
+
+    assertThat(receivable).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = PurchaseOrderStatus.class,
+      names = {"CONFIRMED", "PARTIALLY_RECEIVED"},
+      mode = EnumSource.Mode.EXCLUDE)
+  void rejectsOtherStatuses(PurchaseOrderStatus status) {
+    PurchaseOrder purchaseOrder = PurchaseOrder.builder().status(status).build();
+    when(purchaseOrderRepository.findByIdAndTenantIdAndIsActiveTrue(PO_ID, TENANT_ID))
+        .thenReturn(Optional.of(purchaseOrder));
+
+    boolean receivable =
+        new PurchaseOrderReceivabilityAdapter(purchaseOrderRepository)
+            .isReceivable(TENANT_ID, PO_ID);
+
+    assertThat(receivable).isFalse();
+  }
+
+  @Test
+  void rejectsMissingOrWrongTenantPurchaseOrder() {
+    when(purchaseOrderRepository.findByIdAndTenantIdAndIsActiveTrue(PO_ID, TENANT_ID))
+        .thenReturn(Optional.empty());
+
+    boolean receivable =
+        new PurchaseOrderReceivabilityAdapter(purchaseOrderRepository)
+            .isReceivable(TENANT_ID, PO_ID);
+
+    assertThat(receivable).isFalse();
+  }
+}

--- a/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/listener/GoodsReceiptConfirmedPoListenerTest.java
+++ b/src/test/java/com/fabricmanagement/procurement/purchaseorder/app/listener/GoodsReceiptConfirmedPoListenerTest.java
@@ -1,0 +1,109 @@
+package com.fabricmanagement.procurement.purchaseorder.app.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.procurement.purchaseorder.app.PoReceiveStatusService;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.event.GoodsReceiptConfirmedEvent;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+@ExtendWith(MockitoExtension.class)
+class GoodsReceiptConfirmedPoListenerTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID PO_ID = UUID.randomUUID();
+
+  @Mock private PoReceiveStatusService receiveStatusService;
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void ignoresNonPurchaseOrderReceipts() {
+    var listener =
+        new GoodsReceiptConfirmedPoListener(receiveStatusService, idempotentEventHandler);
+
+    listener.onGoodsReceiptConfirmed(event(GoodsReceiptSourceType.BATCH));
+
+    verify(idempotentEventHandler, never()).executeOnce(any(), any(), any(), any());
+  }
+
+  @Test
+  void executesOnceUsingTenantFromEvent() {
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(3, Runnable.class).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(), any(), any(), any());
+    doAnswer(
+            invocation -> {
+              assertThat(TenantContext.requireTenantId()).isEqualTo(TENANT_ID);
+              return null;
+            })
+        .when(receiveStatusService)
+        .recomputeReceiveStatus(TENANT_ID, PO_ID);
+    var listener =
+        new GoodsReceiptConfirmedPoListener(receiveStatusService, idempotentEventHandler);
+
+    listener.onGoodsReceiptConfirmed(event(GoodsReceiptSourceType.PURCHASE_ORDER));
+
+    verify(idempotentEventHandler)
+        .executeOnce(
+            any(), eq(GoodsReceiptConfirmedPoListener.class), eq("onGoodsReceiptConfirmed"), any());
+    verify(receiveStatusService).recomputeReceiveStatus(TENANT_ID, PO_ID);
+  }
+
+  @Test
+  void retriesOnceAfterOptimisticLockFailure() {
+    doAnswer(
+            invocation -> {
+              invocation.getArgument(3, Runnable.class).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(), any(), any(), any());
+    org.mockito.Mockito.doThrow(new OptimisticLockingFailureException("conflict") {})
+        .doNothing()
+        .when(receiveStatusService)
+        .recomputeReceiveStatus(TENANT_ID, PO_ID);
+    var listener =
+        new GoodsReceiptConfirmedPoListener(receiveStatusService, idempotentEventHandler);
+
+    listener.onGoodsReceiptConfirmed(event(GoodsReceiptSourceType.PURCHASE_ORDER));
+
+    verify(idempotentEventHandler, times(2)).executeOnce(any(), any(), any(), any());
+    verify(receiveStatusService, times(2)).recomputeReceiveStatus(TENANT_ID, PO_ID);
+  }
+
+  private GoodsReceiptConfirmedEvent event(GoodsReceiptSourceType sourceType) {
+    return GoodsReceiptConfirmedEvent.builder()
+        .tenantId(TENANT_ID)
+        .receiptId(UUID.randomUUID())
+        .receiptNumber("GR-2026-0001")
+        .sourceType(sourceType)
+        .sourceId(PO_ID)
+        .sourceLineId(UUID.randomUUID())
+        .items(List.of())
+        .build();
+  }
+}

--- a/src/test/java/com/fabricmanagement/production/execution/goodsreceipt/app/GoodsReceiptServiceTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/goodsreceipt/app/GoodsReceiptServiceTest.java
@@ -16,6 +16,7 @@ import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceip
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptStatus;
 import com.fabricmanagement.production.execution.goodsreceipt.domain.exception.GoodsReceiptDomainException;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.port.PoReceivabilityPort;
 import com.fabricmanagement.production.execution.goodsreceipt.dto.CreateGoodsReceiptRequest;
 import com.fabricmanagement.production.execution.goodsreceipt.dto.GoodsReceiptResponse;
 import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository;
@@ -49,6 +50,7 @@ class GoodsReceiptServiceTest {
   @Mock private PurchaseOrderQueryService purchaseOrderQueryService;
   @Mock private SubcontractOrderQueryService subcontractOrderQueryService;
   @Mock private ProductFacade productFacade;
+  @Mock private PoReceivabilityPort poReceivabilityPort;
   @Mock private ApplicationEventPublisher eventPublisher;
 
   private GoodsReceiptService service;
@@ -56,6 +58,9 @@ class GoodsReceiptServiceTest {
   @BeforeEach
   void setUp() {
     TenantContext.setCurrentTenantId(TENANT_ID);
+    org.mockito.Mockito.lenient()
+        .when(poReceivabilityPort.isReceivable(TENANT_ID, PO_ID))
+        .thenReturn(true);
     service =
         new GoodsReceiptService(
             receiptRepository,
@@ -65,6 +70,7 @@ class GoodsReceiptServiceTest {
             subcontractOrderQueryService,
             productFacade,
             new BatchPrimaryMeasureService(),
+            poReceivabilityPort,
             eventPublisher);
   }
 
@@ -78,6 +84,38 @@ class GoodsReceiptServiceTest {
     CreateGoodsReceiptRequest request = purchaseRequest(null, item(null, null));
 
     assertCoded422(() -> service.createGoodsReceipt(request), "GR_SOURCE_LINE_REQUIRED");
+  }
+
+  @Test
+  void purchaseReceiptCreateRejectsNonReceivablePurchaseOrder() {
+    when(poReceivabilityPort.isReceivable(TENANT_ID, PO_ID)).thenReturn(false);
+
+    assertCoded422(
+        () -> service.createGoodsReceipt(purchaseRequest(LINE_ID, item(null, null))),
+        "GR_PO_NOT_RECEIVABLE");
+  }
+
+  @Test
+  void purchaseReceiptConfirmRechecksReceivability() {
+    GoodsReceipt draft =
+        GoodsReceipt.builder()
+            .receiptNumber("GR-STATUS-GUARD")
+            .sourceType(GoodsReceiptSourceType.PURCHASE_ORDER)
+            .sourceId(PO_ID)
+            .sourceLineId(LINE_ID)
+            .status(GoodsReceiptStatus.DRAFT)
+            .build();
+    when(receiptRepository.findById(any())).thenReturn(Optional.of(draft));
+    when(itemRepository.findByGoodsReceiptIdAndIsActiveTrueOrderBySequenceNoAsc(any()))
+        .thenReturn(
+            List.of(
+                GoodsReceiptItem.builder()
+                    .barcode("STATUS-001")
+                    .netWeight(BigDecimal.TEN)
+                    .build()));
+    when(poReceivabilityPort.isReceivable(TENANT_ID, PO_ID)).thenReturn(false);
+
+    assertCoded422(() -> service.confirmGoodsReceipt(UUID.randomUUID()), "GR_PO_NOT_RECEIVABLE");
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/production/execution/goodsreceipt/app/adapter/PoGoodsReceiptReadAdapterTest.java
+++ b/src/test/java/com/fabricmanagement/production/execution/goodsreceipt/app/adapter/PoGoodsReceiptReadAdapterTest.java
@@ -1,0 +1,164 @@
+package com.fabricmanagement.production.execution.goodsreceipt.app.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptSourceType;
+import com.fabricmanagement.production.execution.goodsreceipt.domain.GoodsReceiptStatus;
+import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository;
+import com.fabricmanagement.production.execution.goodsreceipt.infra.repository.GoodsReceiptItemRepository.PoReceiptMeasureBucket;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PoGoodsReceiptReadAdapterTest {
+
+  private static final UUID TENANT_ID = UUID.randomUUID();
+  private static final UUID PO_ID = UUID.randomUUID();
+  private static final UUID LINE_ID = UUID.randomUUID();
+
+  @Mock private GoodsReceiptItemRepository itemRepository;
+
+  @Test
+  void convertsWeightFromContractualKgIntoRequestedUnits() {
+    PoReceiptMeasureBucket weightBucket = bucket(LINE_ID, null, "2.500", null, 2, 2, 0);
+    when(itemRepository.sumConfirmedPoReceiptMeasures(
+            TENANT_ID, GoodsReceiptSourceType.PURCHASE_ORDER, PO_ID, GoodsReceiptStatus.CONFIRMED))
+        .thenReturn(List.of(weightBucket));
+    PoGoodsReceiptReadAdapter adapter = new PoGoodsReceiptReadAdapter(itemRepository);
+
+    var kgResult =
+        adapter
+            .sumReceivedByLine(TENANT_ID, PO_ID, Map.of(LINE_ID, "KG"))
+            .receivedByLine()
+            .get(LINE_ID);
+    assertThat(kgResult.receivedQty()).isEqualByComparingTo("2.500");
+    assertThat(kgResult.excludedItemCount()).isZero();
+    assertThat(kgResult.receiveMismatch()).isFalse();
+    assertThat(
+            adapter
+                .sumReceivedByLine(TENANT_ID, PO_ID, Map.of(LINE_ID, "G"))
+                .receivedByLine()
+                .get(LINE_ID)
+                .receivedQty())
+        .isEqualByComparingTo("2500");
+    assertThat(
+            adapter
+                .sumReceivedByLine(TENANT_ID, PO_ID, Map.of(LINE_ID, "MT"))
+                .receivedByLine()
+                .get(LINE_ID)
+                .receivedQty())
+        .isEqualByComparingTo("0.0025");
+  }
+
+  @Test
+  void convertsMixedLengthBucketsAndCountsExcludedItems() {
+    UUID meterLineId = UUID.randomUUID();
+    UUID millimeterLineId = UUID.randomUUID();
+    List<PoReceiptMeasureBucket> lengthBuckets =
+        Stream.of(
+                mixedLengthBuckets(LINE_ID),
+                mixedLengthBuckets(meterLineId),
+                mixedLengthBuckets(millimeterLineId))
+            .flatMap(List::stream)
+            .toList();
+    when(itemRepository.sumConfirmedPoReceiptMeasures(
+            TENANT_ID, GoodsReceiptSourceType.PURCHASE_ORDER, PO_ID, GoodsReceiptStatus.CONFIRMED))
+        .thenReturn(lengthBuckets);
+
+    var totals =
+        new PoGoodsReceiptReadAdapter(itemRepository)
+            .sumReceivedByLine(
+                TENANT_ID, PO_ID, Map.of(LINE_ID, "CM", meterLineId, "M", millimeterLineId, "MM"))
+            .receivedByLine();
+    var result = totals.get(LINE_ID);
+    var meters = totals.get(meterLineId);
+    var millimeters = totals.get(millimeterLineId);
+
+    assertThat(result.receivedQty()).isEqualByComparingTo("250");
+    assertThat(meters.receivedQty()).isEqualByComparingTo("2.5");
+    assertThat(millimeters.receivedQty()).isEqualByComparingTo("2500");
+    assertThat(result.excludedItemCount()).isEqualTo(2);
+    assertThat(result.receiveMismatch()).isTrue();
+    verify(itemRepository)
+        .sumConfirmedPoReceiptMeasures(
+            TENANT_ID, GoodsReceiptSourceType.PURCHASE_ORDER, PO_ID, GoodsReceiptStatus.CONFIRMED);
+  }
+
+  @Test
+  void nullWeightMeasuresAreExcludedAndFlagged() {
+    PoReceiptMeasureBucket weightBucket = bucket(LINE_ID, null, "2.500", null, 3, 2, 0);
+    when(itemRepository.sumConfirmedPoReceiptMeasures(
+            TENANT_ID, GoodsReceiptSourceType.PURCHASE_ORDER, PO_ID, GoodsReceiptStatus.CONFIRMED))
+        .thenReturn(List.of(weightBucket));
+
+    var result =
+        new PoGoodsReceiptReadAdapter(itemRepository)
+            .sumReceivedByLine(TENANT_ID, PO_ID, Map.of(LINE_ID, "KG"))
+            .receivedByLine()
+            .get(LINE_ID);
+
+    assertThat(result.receivedQty()).isEqualByComparingTo("2.500");
+    assertThat(result.excludedItemCount()).isEqualTo(1);
+    assertThat(result.receiveMismatch()).isTrue();
+  }
+
+  @Test
+  void unsupportedLineUnitReturnsZeroAndFlagsEveryItem() {
+    PoReceiptMeasureBucket unsupportedBucket = bucket(LINE_ID, null, "12", null, 3, 3, 0);
+    when(itemRepository.sumConfirmedPoReceiptMeasures(
+            TENANT_ID, GoodsReceiptSourceType.PURCHASE_ORDER, PO_ID, GoodsReceiptStatus.CONFIRMED))
+        .thenReturn(List.of(unsupportedBucket));
+
+    var totals =
+        new PoGoodsReceiptReadAdapter(itemRepository)
+            .sumReceivedByLine(TENANT_ID, PO_ID, Map.of(LINE_ID, "PCS"));
+    var result = totals.receivedByLine().get(LINE_ID);
+
+    assertThat(totals.hasConfirmedReceipts()).isTrue();
+    assertThat(result.receivedQty()).isEqualByComparingTo(BigDecimal.ZERO);
+    assertThat(result.excludedItemCount()).isEqualTo(3);
+    assertThat(result.unitSupported()).isFalse();
+    assertThat(result.receiveMismatch()).isTrue();
+  }
+
+  private List<PoReceiptMeasureBucket> mixedLengthBuckets(UUID lineId) {
+    return List.of(
+        bucket(lineId, "M", "3", "2", 1, 1, 1),
+        bucket(lineId, "CM", "4", "50", 2, 2, 1),
+        bucket(lineId, "FT", "5", "10", 1, 1, 1));
+  }
+
+  private PoReceiptMeasureBucket bucket(
+      UUID lineId,
+      String lengthUnit,
+      String netWeightTotal,
+      String lengthTotal,
+      long itemCount,
+      long netWeightItemCount,
+      long lengthItemCount) {
+    PoReceiptMeasureBucket bucket = mock(PoReceiptMeasureBucket.class);
+    lenient().when(bucket.getSourceLineId()).thenReturn(lineId);
+    lenient().when(bucket.getLengthUnit()).thenReturn(lengthUnit);
+    lenient()
+        .when(bucket.getNetWeightTotal())
+        .thenReturn(netWeightTotal != null ? new BigDecimal(netWeightTotal) : null);
+    lenient()
+        .when(bucket.getLengthTotal())
+        .thenReturn(lengthTotal != null ? new BigDecimal(lengthTotal) : null);
+    lenient().when(bucket.getItemCount()).thenReturn(itemCount);
+    lenient().when(bucket.getNetWeightItemCount()).thenReturn(netWeightItemCount);
+    lenient().when(bucket.getLengthMeasureItemCount()).thenReturn(lengthItemCount);
+    return bucket;
+  }
+}


### PR DESCRIPTION
Backend half of smoke-test remediation F-20 — receive status from real events, not manual toggles.

- GR receivability gate on both create and confirm paths: PURCHASE_ORDER receipts require the PO to be CONFIRMED/PARTIALLY_RECEIVED via the new PoReceivabilityPort, else 422 GR_PO_NOT_RECEIVABLE — the permanent-drift scenario (receipt confirmed before the PO is confirmable) is unreproducible.
- PoReceiveStatusService: full re-derivation from confirmed receipts per line (received >= ordered = complete; over-receipt allowed), transitions applied through the state machine, no-op when already at target so event redelivery publishes nothing twice. Publishes the previously never-fired PoPartiallyReceivedEvent and a new PoReceivedEvent (domain event only, no notification template by design).
- PoGoodsReceiptReadPort/adapter owns unit conversion: whitelist KG/G/MT and M/CM/MM, netWeight contract = KG, unsupported line unit yields receivedQty 0 + receiveMismatch (never a guessed sum); one grouped query per PO, explicit tenantId.
- GoodsReceiptConfirmedPoListener: PURCHASE_ORDER filter, executeOnce idempotency, tenant bound from the event, single retry on optimistic-lock conflict.
- changeStatus rejects manual PARTIALLY_RECEIVED/RECEIVED with 422 PO_RECEIVE_STATUS_DERIVED (ProcurementDomainException gains a coded constructor mirroring ProductionDomainException).
- PO response lines expose receivedQty (0-not-null) + receiveMismatch, computed on read — no stored column, no migration. OpenAPI regenerated.
- Fixed latent param mismatch in onPoPartiallyReceived (receivedItemCount/totalItemCount, pinned as completed/total active lines).

Ref: docs/procurement/tickets/F-20.md.


Claude-Session: https://claude.ai/code/session_013zSZ9fBwHSgbkxcbSEkGCQ