### PR TITLE
feat(sales): add line-level fulfilment mode (RSF-1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -45143,6 +45143,17 @@ components:
           - TO_BE_CONFIRMED
           - FROM_PRODUCTION
           - STOCK_OVERRIDE
+        fulfillmentMode:
+          type:
+          - string
+          - "null"
+          description: Manual line-level fulfilment mode; omission or null clears
+            it to pending
+          enum:
+          - STOCK
+          - MAKE_TO_ORDER
+          - PURCHASE_TO_ORDER
+          - STOCK_AND_PRODUCTION
         offeredPrice:
           type: number
           minimum: 0.0001
@@ -59380,6 +59391,33 @@ components:
           - STOCK_OVERRIDE
         discountRate:
           type: number
+        fulfillmentDeterminationMethod:
+          type:
+          - string
+          - "null"
+          description: How the current fulfilment mode was determined
+          enum:
+          - AUTOMATIC
+          - MANUAL
+          - POLICY_BASED
+        fulfillmentDeterminationStatus:
+          type: string
+          description: Current fulfilment determination status
+          enum:
+          - PENDING
+          - PROPOSED
+          - CONFIRMED
+          - OVERRIDDEN
+        fulfillmentMode:
+          type:
+          - string
+          - "null"
+          description: Line-level fulfilment mode
+          enum:
+          - STOCK
+          - MAKE_TO_ORDER
+          - PURCHASE_TO_ORDER
+          - STOCK_AND_PRODUCTION
         id:
           type: string
           format: uuid
@@ -59451,6 +59489,8 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/QuoteLineResponse"
+        mixedFulfillment:
+          type: boolean
         moduleType:
           type: string
         notes:
@@ -62996,6 +63036,17 @@ components:
           - TO_BE_CONFIRMED
           - FROM_PRODUCTION
           - STOCK_OVERRIDE
+        fulfillmentMode:
+          type:
+          - string
+          - "null"
+          description: Manual line-level fulfilment mode; omission or null clears
+            it to pending
+          enum:
+          - STOCK
+          - MAKE_TO_ORDER
+          - PURCHASE_TO_ORDER
+          - STOCK_AND_PRODUCTION
         offeredPrice:
           type: number
           minimum: 0.0001

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -90,6 +90,8 @@ tags:
   name: FlowBoard — Performance
 - description: Immutable stock quality disposition decisions
   name: Quality Decisions
+- description: Commercial ownership for sales customers
+  name: Customer Account Team
 - description: Tenant go-real transition operations
   name: Tenant Go Real
 - description: Subcontract Order operations
@@ -38991,6 +38993,230 @@ paths:
       summary: List sales-readable color cards
       tags:
       - Sales Color
+  /api/v1/sales/customers/{customerId}/account-team:
+    get:
+      operationId: getAccountTeam
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCustomerAccountTeamResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get a customer's commercial account team
+      tags:
+      - Customer Account Team
+    post:
+      operationId: addMember
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddCustomerAccountTeamMemberRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCustomerAccountTeamMemberResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Add or reactivate a customer account-team member
+      tags:
+      - Customer Account Team
+  /api/v1/sales/customers/{customerId}/account-team/{userId}:
+    delete:
+      operationId: deactivateMember
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseVoid"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Deactivate a customer account-team member
+      tags:
+      - Customer Account Team
   /api/v1/sales/lots:
     get:
       operationId: listSalesLots
@@ -45081,6 +45307,14 @@ components:
           pattern: ^\S(?:.*\S)?$
       required:
       - externalCode
+    AddCustomerAccountTeamMemberRequest:
+      type: object
+      properties:
+        userId:
+          type: string
+          format: uuid
+      required:
+      - userId
     AddOrganizationCertificationRequest:
       type: object
       properties:
@@ -45965,6 +46199,42 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/CurrentUserResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseCustomerAccountTeamMemberResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CustomerAccountTeamMemberResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseCustomerAccountTeamResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CustomerAccountTeamResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -53793,6 +54063,48 @@ components:
           format: int32
         workLocationLabel:
           type: string
+    CustomerAccountTeamMemberResponse:
+      type: object
+      properties:
+        active:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        displayName:
+          type:
+          - string
+          - "null"
+        userId:
+          type: string
+          format: uuid
+    CustomerAccountTeamResponse:
+      type: object
+      properties:
+        acquiredById:
+          type:
+          - string
+          - "null"
+          format: uuid
+        customerId:
+          type: string
+          format: uuid
+        defaultOwnerId:
+          type:
+          - string
+          - "null"
+          format: uuid
+        defaultOwnerReason:
+          type: string
+          enum:
+          - EXPLICIT_OVERRIDE
+          - ACQUIRER
+          - ACCOUNT_TEAM
+          - TRIAGE_REQUIRED
+        members:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerAccountTeamMemberResponse"
     CustomerApprovalRequest:
       type: object
       properties:
@@ -59261,7 +59573,9 @@ components:
       type: object
       properties:
         assignedToId:
-          type: string
+          type:
+          - string
+          - "null"
           format: uuid
         currency:
           type: string
@@ -59307,7 +59621,6 @@ components:
           type: string
           format: date
       required:
-      - assignedToId
       - currency
       - customerId
       - moduleType
@@ -62344,6 +62657,11 @@ components:
     TradingPartnerDto:
       type: object
       properties:
+        acquiredById:
+          type:
+          - string
+          - "null"
+          format: uuid
         country:
           type: string
         createdAt:

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/DemoTransactionSeeder.java
@@ -101,7 +101,7 @@ public class DemoTransactionSeeder {
       partnerReq.setTaxId("US-GFW-" + tenantId.toString().substring(0, 8));
       partnerReq.setPartnerType(PartnerType.CUSTOMER);
       partnerReq.setCountry("USA");
-      TradingPartnerDto customer = tradingPartnerService.createPartner(partnerReq);
+      TradingPartnerDto customer = tradingPartnerService.createPartner(partnerReq, null);
 
       // 2b. Finance dataset (DEMO-1): reporting currency (USD), FX rates, AR/AP invoices +
       // payments.

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/FinanceDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/FinanceDemoSeeder.java
@@ -152,7 +152,7 @@ public class FinanceDemoSeeder {
     req.setTaxId(taxId);
     req.setPartnerType(type);
     req.setCountry(country);
-    return tradingPartnerService.createPartner(req).getId();
+    return tradingPartnerService.createPartner(req, null).getId();
   }
 
   /** Creates a no-line invoice (subtotal == total, no tax/discount), then issues and sends it. */

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeeder.java
@@ -253,7 +253,7 @@ public class ProcurementDemoSeeder {
     req.setPartnerType(type);
     req.setRelationshipMeta(
         Map.of("payment_terms", paymentTerms, "contact_email", contactEmail(name), "notes", notes));
-    return tradingPartnerService.createPartner(req);
+    return tradingPartnerService.createPartner(req, null);
   }
 
   private WorkOrderResponse approvedWorkOrder(

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeeder.java
@@ -39,6 +39,7 @@ import com.fabricmanagement.production.masterdata.product.dto.CreateProductReque
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
+import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.domain.DiscountPolicy;
 import com.fabricmanagement.sales.quote.api.QuoteCreateRequest;
@@ -121,6 +122,7 @@ public class SalesQuoteDemoSeeder {
   private final DiscountPolicyService discountPolicyService;
   private final ExchangeRateService exchangeRateService;
   private final QuoteService quoteService;
+  private final CustomerAccountTeamService customerAccountTeamService;
   private final UserRepository userRepository;
   private final UserCreationService userCreationService;
   private final RoleService roleService;
@@ -252,9 +254,12 @@ public class SalesQuoteDemoSeeder {
       releasePieceBackedBatch(lot23050.getId());
 
       // ── Actors ──
-      TradingPartnerDto albion = createAlbionCustomer(tenantId);
       UUID emmaId = ensureMarketer(tenantId);
+      TradingPartnerDto albion = createAlbionCustomer(tenantId, emmaId);
       UUID draftOwnerId = resolveDraftOwner(tenantId, emmaId);
+      if (!draftOwnerId.equals(emmaId)) {
+        customerAccountTeamService.addMember(tenantId, albion.getId(), draftOwnerId);
+      }
 
       // ── Emma's competing open quote: soft intents shrink Navy free stock ──
       Quote emmaQuote =
@@ -490,7 +495,7 @@ public class SalesQuoteDemoSeeder {
 
   // ── Actor helpers ───────────────────────────────────────────────────────────
 
-  private TradingPartnerDto createAlbionCustomer(UUID tenantId) {
+  private TradingPartnerDto createAlbionCustomer(UUID tenantId, UUID acquiredById) {
     CreateTradingPartnerRequest req = new CreateTradingPartnerRequest();
     req.setCompanyName(CUSTOMER_ALBION);
     req.setCustomName(CUSTOMER_ALBION);
@@ -502,7 +507,7 @@ public class SalesQuoteDemoSeeder {
             "payment_terms", "NET30",
             "contact_email", "buying@albionapparel.co.uk",
             "notes", "Demo customer for sales quotes"));
-    return tradingPartnerService.createPartner(req);
+    return tradingPartnerService.createPartner(req, acquiredById);
   }
 
   private UUID ensureMarketer(UUID tenantId) {

--- a/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/TradingPartnerSeeder.java
+++ b/src/main/java/com/fabricmanagement/common/infrastructure/bootstrap/TradingPartnerSeeder.java
@@ -118,7 +118,7 @@ public class TradingPartnerSeeder implements DataSeeder {
             .country("TR")
             .build();
 
-    tradingPartnerService.createPartner(req);
+    tradingPartnerService.createPartner(req, null);
     log.info("Created Trading Partner: {} - Type: {}", name, type);
   }
 

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -137,6 +137,7 @@ public class TenantTransactionalPurgeService {
           "sales_ord.sales_order",
           "sales.sample_delivery",
           "sales.sample_request",
+          "sales.customer_account_team_member",
           "sales.quote_send_request",
           "sales.quote_approval_token",
           "sales.quote_line",

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/api/controller/TradingPartnerController.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/api/controller/TradingPartnerController.java
@@ -77,7 +77,8 @@ public class TradingPartnerController {
         request.getCompanyName(),
         request.getPartnerType());
 
-    TradingPartnerDto created = tradingPartnerService.createPartner(request);
+    TradingPartnerDto created =
+        tradingPartnerService.createPartner(request, TenantContext.getCurrentUserId());
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success(created, "Trading partner created successfully"));
@@ -88,7 +89,8 @@ public class TradingPartnerController {
   @Operation(summary = "Quick-create a customer for sales")
   public ResponseEntity<ApiResponse<TradingPartnerDto>> quickCreateCustomer(
       @Valid @RequestBody QuickCreateCustomerRequest request) {
-    TradingPartnerDto created = tradingPartnerService.quickCreateCustomer(request);
+    TradingPartnerDto created =
+        tradingPartnerService.quickCreateCustomer(request, TenantContext.getCurrentUserId());
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(ApiResponse.success(created, "Customer created successfully"));
   }
@@ -116,7 +118,8 @@ public class TradingPartnerController {
       @Parameter(description = "Partner ID") @PathVariable UUID id,
       @Valid @RequestBody UpdateTradingPartnerRequest request) {
     log.info("Updating trading partner: id={}", id);
-    TradingPartnerDto updated = tradingPartnerService.updatePartner(id, request);
+    TradingPartnerDto updated =
+        tradingPartnerService.updatePartner(id, request, TenantContext.getCurrentUserId());
     return ResponseEntity.ok(ApiResponse.success(updated, "Trading partner updated successfully"));
   }
 

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerOwnershipSnapshot.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerOwnershipSnapshot.java
@@ -1,0 +1,11 @@
+package com.fabricmanagement.platform.tradingpartner.app;
+
+import java.util.UUID;
+
+/**
+ * Sales-readable projection of the trading-partner facts used for commercial ownership.
+ *
+ * <p>This record deliberately carries no platform domain types.
+ */
+public record TradingPartnerOwnershipSnapshot(
+    UUID customerId, UUID acquiredById, boolean customer, boolean transactionAllowed) {}

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
@@ -184,6 +184,22 @@ public class TradingPartnerResolver {
     return partnerRepository.findByTenantIdAndLegacyCompanyId(tenantId, partnerId);
   }
 
+  /**
+   * Resolve the tenant-scoped ownership facts needed by sales without exposing the platform domain
+   * entity across the bounded-context boundary.
+   */
+  public Optional<TradingPartnerOwnershipSnapshot> resolveOwnershipSnapshot(
+      UUID tenantId, UUID partnerId) {
+    return resolvePartner(tenantId, partnerId)
+        .map(
+            partner ->
+                new TradingPartnerOwnershipSnapshot(
+                    partner.getId(),
+                    partner.getAcquiredById(),
+                    partner.getPartnerType().isCustomer(),
+                    partner.getStatus().isTransactionAllowed()));
+  }
+
   public Map<UUID, String> resolveDisplayNames(UUID tenantId, List<UUID> partnerIds) {
     if (partnerIds == null || partnerIds.isEmpty()) {
       return Map.of();

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerService.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerService.java
@@ -77,6 +77,17 @@ public class TradingPartnerService {
    */
   @Transactional
   public TradingPartnerDto createPartner(CreateTradingPartnerRequest request) {
+    return createPartner(request, null);
+  }
+
+  /**
+   * Internal creation gate with an explicit acquisition initiator.
+   *
+   * <p>Public controllers supply the acting user. Seeders supply an explicit demo persona or null.
+   * The service never infers the value from the security context.
+   */
+  @Transactional
+  public TradingPartnerDto createPartner(CreateTradingPartnerRequest request, UUID acquiredById) {
     UUID tenantId = TenantContext.requireTenantId();
     String country =
         request.getCountry() != null ? request.getCountry().toUpperCase() : DEFAULT_COUNTRY;
@@ -95,12 +106,16 @@ public class TradingPartnerService {
       if (partner.getPartnerType() != request.getPartnerType()
           && partner.getPartnerType() != PartnerType.BOTH) {
         partner.upgradeToMultiType(request.getPartnerType());
+        stampAcquirerIfCustomer(partner, acquiredById);
         TradingPartner updated = partnerRepository.save(partner);
         log.info(
             "Partner upgraded to BOTH: uid={}, registry={}", updated.getUid(), registry.getUid());
         return TradingPartnerDto.from(updated);
       }
       // Already exists with same or BOTH type
+      if (stampAcquirerIfCustomer(partner, acquiredById)) {
+        partner = partnerRepository.save(partner);
+      }
       log.debug(
           "Partner already exists: uid={}, type={}", partner.getUid(), partner.getPartnerType());
       return TradingPartnerDto.from(partner);
@@ -114,6 +129,7 @@ public class TradingPartnerService {
       partner.setRelationshipMeta(request.getRelationshipMeta());
     }
 
+    stampAcquirerIfCustomer(partner, acquiredById);
     TradingPartner saved = partnerRepository.save(partner);
 
     // Auto-create partner Organization for user management
@@ -146,6 +162,13 @@ public class TradingPartnerService {
 
   @Transactional
   public TradingPartnerDto quickCreateCustomer(QuickCreateCustomerRequest request) {
+    return quickCreateCustomer(request, null);
+  }
+
+  /** Internal quick-create gate; see {@link #createPartner(CreateTradingPartnerRequest, UUID)}. */
+  @Transactional
+  public TradingPartnerDto quickCreateCustomer(
+      QuickCreateCustomerRequest request, UUID acquiredById) {
     UUID tenantId = TenantContext.requireTenantId();
     TradingPartnerRegistry registry =
         registryService.findOrCreate(
@@ -167,6 +190,7 @@ public class TradingPartnerService {
     partner.setPendingAccountingReview(true);
     partner.setRelationshipMeta(
         quickCustomerRelationshipMeta(request, partner.getRelationshipMeta()));
+    stampAcquirerIfCustomer(partner, acquiredById);
     TradingPartner saved = partnerRepository.save(partner);
 
     if (saved.getOrganizationId() == null) {
@@ -193,6 +217,10 @@ public class TradingPartnerService {
     return toCustomerDto(tenantId, saved);
   }
 
+  private boolean stampAcquirerIfCustomer(TradingPartner partner, UUID acquiredById) {
+    return partner.recordAcquirer(acquiredById);
+  }
+
   // ═══════════════════════════════════════════════════════════════════════════
   // UPDATE
   // ═══════════════════════════════════════════════════════════════════════════
@@ -209,8 +237,19 @@ public class TradingPartnerService {
    */
   @Transactional
   public TradingPartnerDto updatePartner(UUID partnerId, UpdateTradingPartnerRequest request) {
+    return updatePartner(partnerId, request, null);
+  }
+
+  /**
+   * Internal update gate with an explicit initiator for a relationship that becomes
+   * customer-facing.
+   */
+  @Transactional
+  public TradingPartnerDto updatePartner(
+      UUID partnerId, UpdateTradingPartnerRequest request, UUID acquiredById) {
     UUID tenantId = TenantContext.requireTenantId();
     TradingPartner partner = getPartnerOrThrow(tenantId, partnerId);
+    boolean wasCustomer = partner.getPartnerType().isCustomer();
 
     if (request.getCustomName() != null) {
       partner.setCustomName(
@@ -225,6 +264,9 @@ public class TradingPartnerService {
       partner.setRelationshipMeta(request.getRelationshipMeta());
     }
 
+    if (!wasCustomer) {
+      stampAcquirerIfCustomer(partner, acquiredById);
+    }
     TradingPartner saved = partnerRepository.save(partner);
     log.info("Partner updated: uid={}, type={}", saved.getUid(), saved.getPartnerType());
     return TradingPartnerDto.from(saved);

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/TradingPartner.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/TradingPartner.java
@@ -152,11 +152,30 @@ public class TradingPartner extends BaseEntity {
   @Builder.Default
   private boolean pendingAccountingReview = false;
 
+  /**
+   * Immutable acquisition fact for customer relationships.
+   *
+   * <p>Null for supplier-only relationships and legacy customers whose initiator is unknown. Once
+   * populated it is never overwritten by normal create or update flows.
+   */
+  @Setter(AccessLevel.NONE)
+  @Column(name = "acquired_by_id")
+  private UUID acquiredById;
+
   @Embedded private OfflineMetadata offlineMetadata;
 
   @Override
   protected String getModuleCode() {
     return "TP";
+  }
+
+  /** Records the acquisition fact once; subsequent calls cannot overwrite it. */
+  public boolean recordAcquirer(UUID acquirerId) {
+    if (!partnerType.isCustomer() || acquiredById != null || acquirerId == null) {
+      return false;
+    }
+    acquiredById = acquirerId;
+    return true;
   }
 
   /**

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/dto/TradingPartnerDto.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/dto/TradingPartnerDto.java
@@ -50,6 +50,9 @@ public class TradingPartnerDto {
   private String preferredCurrency;
   private boolean pendingAccountingReview;
 
+  @Schema(nullable = true)
+  private UUID acquiredById;
+
   // Audit
   private Instant createdAt;
   private Boolean isActive;
@@ -83,6 +86,7 @@ public class TradingPartnerDto {
         .verifiedStatus(registry != null ? registry.getVerifiedStatus().name() : null)
         .organizationId(tp.getOrganizationId())
         .pendingAccountingReview(tp.isPendingAccountingReview())
+        .acquiredById(tp.getAcquiredById())
         .createdAt(tp.getCreatedAt())
         .isActive(tp.getIsActive())
         .legacyCompanyId(tp.getLegacyCompanyId())

--- a/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
+++ b/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
@@ -110,4 +110,25 @@ public class SalesDomainException extends DomainException {
     return new SalesDomainException(
         message, "SALES_017_LOT_INTENT_QUANTITY_MISMATCH", HttpStatus.UNPROCESSABLE_ENTITY);
   }
+
+  public static SalesDomainException ownerNotSelectable(String ownerId) {
+    return new SalesDomainException(
+        "Requested owner is not selectable for this customer: " + ownerId,
+        "SALES_018_OWNER_NOT_SELECTABLE",
+        HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  public static SalesDomainException accountTeamUserInactive(String userId) {
+    return new SalesDomainException(
+        "Inactive user cannot be added to a customer account team: " + userId,
+        "SALES_019_ACCOUNT_TEAM_USER_INACTIVE",
+        HttpStatus.UNPROCESSABLE_ENTITY);
+  }
+
+  public static SalesDomainException customerNotEligible(String customerId) {
+    return new SalesDomainException(
+        "Trading partner is not an active customer: " + customerId,
+        "SALES_020_CUSTOMER_NOT_ELIGIBLE",
+        HttpStatus.UNPROCESSABLE_ENTITY);
+  }
 }

--- a/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamController.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamController.java
@@ -1,0 +1,62 @@
+package com.fabricmanagement.sales.ownership.api.controller;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
+import com.fabricmanagement.sales.ownership.dto.AddCustomerAccountTeamMemberRequest;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/sales/customers/{customerId}/account-team")
+@RequiredArgsConstructor
+@Tag(name = "Customer Account Team", description = "Commercial ownership for sales customers")
+public class CustomerAccountTeamController {
+
+  private final CustomerAccountTeamService accountTeamService;
+
+  @GetMapping
+  @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
+  @Operation(summary = "Get a customer's commercial account team")
+  public ResponseEntity<ApiResponse<CustomerAccountTeamResponse>> getAccountTeam(
+      @PathVariable UUID customerId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            accountTeamService.getAccountTeam(TenantContext.requireTenantId(), customerId)));
+  }
+
+  @PostMapping
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(summary = "Add or reactivate a customer account-team member")
+  public ResponseEntity<ApiResponse<CustomerAccountTeamMemberResponse>> addMember(
+      @PathVariable UUID customerId,
+      @Valid @RequestBody AddCustomerAccountTeamMemberRequest request) {
+    CustomerAccountTeamMemberResponse member =
+        accountTeamService.addMember(TenantContext.requireTenantId(), customerId, request.userId());
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(member));
+  }
+
+  @DeleteMapping("/{userId}")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(summary = "Deactivate a customer account-team member")
+  public ResponseEntity<ApiResponse<Void>> deactivateMember(
+      @PathVariable UUID customerId, @PathVariable UUID userId) {
+    accountTeamService.deactivateMember(TenantContext.requireTenantId(), customerId, userId);
+    return ResponseEntity.ok(ApiResponse.success(null));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/AcquirerFirstPolicy.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/AcquirerFirstPolicy.java
@@ -1,0 +1,79 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/** V1 commercial-owner policy: explicit override, then acquirer, then stable account-team order. */
+@Component
+@RequiredArgsConstructor
+public class AcquirerFirstPolicy implements DefaultOwnerPolicy {
+
+  private final CustomerEligibilityService customerEligibilityService;
+  private final CustomerAccountTeamMemberRepository memberRepository;
+  private final UserQueryService userQueryService;
+
+  @Override
+  @Transactional(readOnly = true)
+  public OwnerResolution resolve(OwnerResolutionContext context) {
+    CustomerEligibilityService.EligibleCustomer customer =
+        customerEligibilityService.requireEligible(context.tenantId(), context.customerId());
+    List<CustomerAccountTeamMember> members =
+        memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            context.tenantId(), customer.customerId());
+    Map<UUID, Boolean> activeUsers = new HashMap<>();
+
+    List<UUID> activeTeamUserIds =
+        members.stream()
+            .filter(member -> Boolean.TRUE.equals(member.getIsActive()))
+            .map(CustomerAccountTeamMember::getUserId)
+            .filter(userId -> isActiveUser(context.tenantId(), userId, activeUsers))
+            .toList();
+    boolean acquirerActive =
+        customer.acquiredById() != null
+            && isActiveUser(context.tenantId(), customer.acquiredById(), activeUsers);
+
+    if (context.requestedOwnerId() != null) {
+      boolean selectable =
+          (acquirerActive && context.requestedOwnerId().equals(customer.acquiredById()))
+              || activeTeamUserIds.contains(context.requestedOwnerId());
+      if (!selectable) {
+        throw SalesDomainException.ownerNotSelectable(context.requestedOwnerId().toString());
+      }
+      return new OwnerResolution(
+          context.requestedOwnerId(), OwnerResolutionReason.EXPLICIT_OVERRIDE);
+    }
+
+    if (acquirerActive) {
+      return new OwnerResolution(customer.acquiredById(), OwnerResolutionReason.ACQUIRER);
+    }
+    if (!activeTeamUserIds.isEmpty()) {
+      return new OwnerResolution(activeTeamUserIds.get(0), OwnerResolutionReason.ACCOUNT_TEAM);
+    }
+    return new OwnerResolution(null, OwnerResolutionReason.TRIAGE_REQUIRED);
+  }
+
+  private boolean isActiveUser(UUID tenantId, UUID userId, Map<UUID, Boolean> activeUsers) {
+    return activeUsers.computeIfAbsent(
+        userId,
+        id ->
+            userQueryService
+                .findById(tenantId, id)
+                .map(UserDto::getIsActive)
+                .map(Boolean.TRUE::equals)
+                .orElse(false));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamService.java
@@ -1,0 +1,104 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerAccountTeamService {
+
+  private final CustomerEligibilityService customerEligibilityService;
+  private final CustomerAccountTeamMemberRepository memberRepository;
+  private final UserQueryService userQueryService;
+  private final DefaultOwnerPolicy defaultOwnerPolicy;
+
+  @Transactional(readOnly = true)
+  public CustomerAccountTeamResponse getAccountTeam(UUID tenantId, UUID customerId) {
+    CustomerEligibilityService.EligibleCustomer customer =
+        customerEligibilityService.requireEligible(tenantId, customerId);
+    List<CustomerAccountTeamMemberResponse> members =
+        memberRepository
+            .findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+                tenantId, customer.customerId())
+            .stream()
+            .map(member -> toResponse(tenantId, member))
+            .toList();
+    OwnerResolution resolution =
+        defaultOwnerPolicy.resolve(
+            new OwnerResolutionContext(tenantId, customer.customerId(), null));
+
+    return new CustomerAccountTeamResponse(
+        customer.customerId(),
+        customer.acquiredById(),
+        resolution.ownerId(),
+        resolution.reason(),
+        members);
+  }
+
+  @Transactional
+  public CustomerAccountTeamMemberResponse addMember(UUID tenantId, UUID customerId, UUID userId) {
+    CustomerEligibilityService.EligibleCustomer customer =
+        customerEligibilityService.requireEligible(tenantId, customerId);
+    UserDto user = requireUser(tenantId, userId);
+    if (!Boolean.TRUE.equals(user.getIsActive())) {
+      throw SalesDomainException.accountTeamUserInactive(userId.toString());
+    }
+
+    CustomerAccountTeamMember member =
+        memberRepository
+            .findByTenantIdAndCustomerIdAndUserId(tenantId, customer.customerId(), userId)
+            .map(
+                existing -> {
+                  existing.activate();
+                  return existing;
+                })
+            .orElseGet(() -> CustomerAccountTeamMember.create(customer.customerId(), userId));
+
+    return toResponse(tenantId, memberRepository.save(member));
+  }
+
+  @Transactional
+  public void deactivateMember(UUID tenantId, UUID customerId, UUID userId) {
+    CustomerEligibilityService.EligibleCustomer customer =
+        customerEligibilityService.requireEligible(tenantId, customerId);
+    CustomerAccountTeamMember member =
+        memberRepository
+            .findByTenantIdAndCustomerIdAndUserId(tenantId, customer.customerId(), userId)
+            .orElseThrow(
+                () -> new NotFoundException("Customer account-team member not found: " + userId));
+    member.deactivate();
+    memberRepository.save(member);
+  }
+
+  private UserDto requireUser(UUID tenantId, UUID userId) {
+    return userQueryService
+        .findById(tenantId, userId)
+        .orElseThrow(() -> new NotFoundException("User not found: " + userId));
+  }
+
+  private CustomerAccountTeamMemberResponse toResponse(
+      UUID tenantId, CustomerAccountTeamMember member) {
+    Optional<UserDto> user = userQueryService.findById(tenantId, member.getUserId());
+    String displayName = user.map(UserDto::getDisplayName).orElse(null);
+    boolean active =
+        Boolean.TRUE.equals(member.getIsActive())
+            && user.map(UserDto::getIsActive).map(Boolean.TRUE::equals).orElse(false);
+    return new CustomerAccountTeamMemberResponse(
+        member.getUserId(), displayName, active, member.getCreatedAt());
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityService.java
@@ -1,0 +1,32 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerOwnershipSnapshot;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/** Shared tenant-scoped customer soft-reference validation for commercial ownership. */
+@Service
+@RequiredArgsConstructor
+public class CustomerEligibilityService {
+
+  private final TradingPartnerResolver tradingPartnerResolver;
+
+  public EligibleCustomer requireEligible(UUID tenantId, UUID customerId) {
+    TradingPartnerOwnershipSnapshot snapshot =
+        tradingPartnerResolver
+            .resolveOwnershipSnapshot(tenantId, customerId)
+            .orElseThrow(() -> new NotFoundException("Customer not found: " + customerId));
+
+    if (!snapshot.customer() || !snapshot.transactionAllowed()) {
+      throw SalesDomainException.customerNotEligible(customerId.toString());
+    }
+
+    return new EligibleCustomer(snapshot.customerId(), snapshot.acquiredById());
+  }
+
+  public record EligibleCustomer(UUID customerId, UUID acquiredById) {}
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerAccountTeamMember.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerAccountTeamMember.java
@@ -1,0 +1,59 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseJunctionEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.util.UUID;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/** Tenant-scoped membership of an internal user in a customer's commercial account team. */
+@Entity
+@Table(
+    name = "customer_account_team_member",
+    schema = "sales",
+    indexes = {
+      @Index(
+          name = "idx_customer_account_team_lookup",
+          columnList = "tenant_id, customer_id, is_active, created_at")
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_customer_account_team_member",
+          columnNames = {"tenant_id", "customer_id", "user_id"})
+    })
+@IdClass(CustomerAccountTeamMemberId.class)
+@Getter
+@NoArgsConstructor
+public class CustomerAccountTeamMember extends BaseJunctionEntity {
+
+  @Id
+  @Column(name = "customer_id", nullable = false, updatable = false)
+  private UUID customerId;
+
+  @Id
+  @Column(name = "user_id", nullable = false, updatable = false)
+  private UUID userId;
+
+  public static CustomerAccountTeamMember create(UUID customerId, UUID userId) {
+    CustomerAccountTeamMember member = new CustomerAccountTeamMember();
+    member.customerId = customerId;
+    member.userId = userId;
+    return member;
+  }
+
+  /** Domain-language alias for the inherited soft-delete operation. */
+  public void deactivate() {
+    delete();
+  }
+
+  @Override
+  protected String getModuleCode() {
+    return "CATM";
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerAccountTeamMemberId.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerAccountTeamMemberId.java
@@ -1,0 +1,16 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import java.io.Serializable;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+
+/** Composite identity for a customer-account-team membership. */
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class CustomerAccountTeamMemberId implements Serializable {
+  private UUID customerId;
+  private UUID userId;
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/DefaultOwnerPolicy.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/DefaultOwnerPolicy.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+/** Resolves a quote's commercial owner from stable customer ownership facts. */
+public interface DefaultOwnerPolicy {
+  OwnerResolution resolve(OwnerResolutionContext context);
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolution.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolution.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import java.util.UUID;
+
+/** Commercial-owner resolution result. Owner is null only when triage is required. */
+public record OwnerResolution(UUID ownerId, OwnerResolutionReason reason) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionContext.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionContext.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import java.util.UUID;
+
+/** Stable inputs to commercial-owner resolution; deliberately excludes the requesting user. */
+public record OwnerResolutionContext(UUID tenantId, UUID customerId, UUID requestedOwnerId) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionReason.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionReason.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+public enum OwnerResolutionReason {
+  EXPLICIT_OVERRIDE,
+  ACQUIRER,
+  ACCOUNT_TEAM,
+  TRIAGE_REQUIRED
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/AddCustomerAccountTeamMemberRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/AddCustomerAccountTeamMemberRequest.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record AddCustomerAccountTeamMemberRequest(
+    @NotNull(message = "User ID is required") UUID userId) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamMemberResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamMemberResponse.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record CustomerAccountTeamMemberResponse(
+    UUID userId, @Schema(nullable = true) String displayName, boolean active, Instant createdAt) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamResponse.java
@@ -1,0 +1,13 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import java.util.UUID;
+
+public record CustomerAccountTeamResponse(
+    UUID customerId,
+    @Schema(nullable = true) UUID acquiredById,
+    @Schema(nullable = true) UUID defaultOwnerId,
+    OwnerResolutionReason defaultOwnerReason,
+    List<CustomerAccountTeamMemberResponse> members) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/CustomerAccountTeamMemberRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/CustomerAccountTeamMemberRepository.java
@@ -1,0 +1,20 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMemberId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CustomerAccountTeamMemberRepository
+    extends JpaRepository<CustomerAccountTeamMember, CustomerAccountTeamMemberId> {
+
+  Optional<CustomerAccountTeamMember> findByTenantIdAndCustomerIdAndUserId(
+      UUID tenantId, UUID customerId, UUID userId);
+
+  List<CustomerAccountTeamMember> findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+      UUID tenantId, UUID customerId);
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/api/QuoteCreateRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/api/QuoteCreateRequest.java
@@ -2,6 +2,7 @@ package com.fabricmanagement.sales.quote.api;
 
 import com.fabricmanagement.offline.domain.OfflineMetadata;
 import com.fabricmanagement.sales.quote.domain.Quote;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -29,7 +30,7 @@ public class QuoteCreateRequest {
   @NotNull(message = "Customer ID is required")
   private UUID customerId;
 
-  @NotNull(message = "Assigned salesperson ID is required")
+  @Schema(nullable = true)
   private UUID assignedToId;
 
   @NotBlank(message = "Module type is required")

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -238,6 +238,7 @@ public class QuoteService {
     applyColorSnapshot(line, colorSnapshot);
     applyLotSnapshots(line, lotSnapshots);
     line.applyDelivery(delivery.status(), delivery.date(), delivery.covered());
+    line.applyManualFulfillmentMode(req.getFulfillmentMode());
     line.setDiscountRate(pricing.getDiscountRate());
     line.setProfitMargin(pricing.getProfitMargin());
     line.setPriceZone(pricing.getPriceZone());
@@ -299,6 +300,7 @@ public class QuoteService {
     applyColorSnapshot(line, colorSnapshot);
     applyLotSnapshots(line, lotSnapshots);
     line.applyDelivery(delivery.status(), delivery.date(), delivery.covered());
+    line.applyManualFulfillmentMode(req.getFulfillmentMode());
     line.applyPricing(pricing.getDiscountRate(), pricing.getProfitMargin(), pricing.getPriceZone());
     recomputeTotals(quote);
     Quote saved = quoteRepository.save(quote);
@@ -498,6 +500,7 @@ public class QuoteService {
       newLine.applyLotSnapshot(oldLine.getLotSnapshot());
       newLine.applyDelivery(
           oldLine.getDeliveryStatus(), oldLine.getDeliveryDate(), oldLine.getDeliveryCovered());
+      newLine.copyFulfillmentDeterminationFrom(oldLine);
       newLine.setDiscountRate(oldLine.getDiscountRate());
       newLine.setProfitMargin(oldLine.getProfitMargin());
       newLine.setPriceZone(oldLine.getPriceZone());

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -19,6 +19,9 @@ import com.fabricmanagement.sales.color.app.SalesColorService;
 import com.fabricmanagement.sales.color.app.SalesColorSnapshot;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
 import com.fabricmanagement.sales.lot.app.SalesLotService;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService.PricingResult;
@@ -88,6 +91,7 @@ public class QuoteService {
   private final SalesLotService salesLotService;
   private final StockUnitSoftHoldPort stockUnitSoftHoldPort;
   private final BatchLotQuantityIntentPort batchLotQuantityIntentPort;
+  private final DefaultOwnerPolicy defaultOwnerPolicy;
 
   @Transactional(readOnly = true)
   public Page<Quote> findAll(Pageable pageable) {
@@ -170,8 +174,22 @@ public class QuoteService {
 
   @Transactional
   public Quote createQuote(QuoteCreateRequest req) {
+    UUID tenantId = TenantContext.requireTenantId();
+    OwnerResolution ownerResolution =
+        defaultOwnerPolicy.resolve(
+            new OwnerResolutionContext(tenantId, req.getCustomerId(), req.getAssignedToId()));
+    UUID ownerId = ownerResolution.ownerId();
+    if (ownerId == null) {
+      // TODO(RSF-3, ADR-0003 A3.2): replace creator fallback with sales triage + ops alert.
+      ownerId =
+          Objects.requireNonNull(
+              TenantContext.getCurrentUserId(),
+              "Current user is required while the RSF-3 creator fallback is active");
+    }
+
     Quote quote = req.toQuote();
-    quote.setTenantId(TenantContext.requireTenantId());
+    quote.setTenantId(tenantId);
+    quote.setAssignedToId(ownerId);
     quote.setStatus(QuoteStatus.DRAFT);
     quote.setRevisionNumber(1);
     return quoteRepository.save(quote);

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentDeterminationMethod.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentDeterminationMethod.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.sales.quote.domain;
+
+public enum FulfillmentDeterminationMethod {
+  AUTOMATIC,
+  MANUAL,
+  POLICY_BASED
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentDeterminationStatus.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentDeterminationStatus.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.sales.quote.domain;
+
+public enum FulfillmentDeterminationStatus {
+  PENDING,
+  PROPOSED,
+  CONFIRMED,
+  OVERRIDDEN
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentMode.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/FulfillmentMode.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.sales.quote.domain;
+
+public enum FulfillmentMode {
+  STOCK,
+  MAKE_TO_ORDER,
+  PURCHASE_TO_ORDER,
+  STOCK_AND_PRODUCTION
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/Quote.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/Quote.java
@@ -132,6 +132,16 @@ public class Quote extends BaseEntity {
     return this.lines.stream().filter(line -> Objects.equals(line.getId(), lineId)).findFirst();
   }
 
+  public boolean isMixedFulfillment() {
+    return this.lines.stream()
+            .map(QuoteLine::getFulfillmentMode)
+            .filter(Objects::nonNull)
+            .distinct()
+            .limit(2)
+            .count()
+        > 1;
+  }
+
   /**
    * @deprecated the {@code leadTimeDays} parameter is superseded by per-line {@code
    *     QuoteLine.deliveryStatus}/{@code deliveryDate} (QLINE-ATP-1); retained for historical data,

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteLine.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/QuoteLine.java
@@ -68,6 +68,19 @@ public class QuoteLine extends BaseEntity {
   @Column(name = "delivery_covered")
   private Boolean deliveryCovered;
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "fulfillment_mode", length = 32)
+  private FulfillmentMode fulfillmentMode;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "fulfillment_determination_status", nullable = false, length = 16)
+  private FulfillmentDeterminationStatus fulfillmentDeterminationStatus =
+      FulfillmentDeterminationStatus.PENDING;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "fulfillment_determination_method", length = 16)
+  private FulfillmentDeterminationMethod fulfillmentDeterminationMethod;
+
   @Column(name = "requested_qty", nullable = false, precision = 15, scale = 3)
   private BigDecimal requestedQty;
 
@@ -148,6 +161,22 @@ public class QuoteLine extends BaseEntity {
     this.deliveryStatus = deliveryStatus;
     this.deliveryDate = deliveryDate;
     this.deliveryCovered = deliveryCovered;
+  }
+
+  public void applyManualFulfillmentMode(FulfillmentMode fulfillmentMode) {
+    this.fulfillmentMode = fulfillmentMode;
+    this.fulfillmentDeterminationStatus =
+        fulfillmentMode == null
+            ? FulfillmentDeterminationStatus.PENDING
+            : FulfillmentDeterminationStatus.CONFIRMED;
+    this.fulfillmentDeterminationMethod =
+        fulfillmentMode == null ? null : FulfillmentDeterminationMethod.MANUAL;
+  }
+
+  public void copyFulfillmentDeterminationFrom(QuoteLine source) {
+    this.fulfillmentMode = source.getFulfillmentMode();
+    this.fulfillmentDeterminationStatus = source.getFulfillmentDeterminationStatus();
+    this.fulfillmentDeterminationMethod = source.getFulfillmentDeterminationMethod();
   }
 
   public void applyPricing(

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/AddQuoteLineRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/AddQuoteLineRequest.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.sales.quote.dto;
 
+import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
 import com.fabricmanagement.sales.quote.domain.QuoteLineDeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -27,6 +29,11 @@ public class AddQuoteLineRequest {
   private QuoteLineDeliveryStatus deliveryStatus;
 
   private LocalDate deliveryDate;
+
+  @Schema(
+      description = "Manual line-level fulfilment mode; omission or null clears it to pending",
+      nullable = true)
+  private FulfillmentMode fulfillmentMode;
 
   @NotNull(message = "Requested quantity is required")
   @DecimalMin(value = "0.001", message = "Requested quantity must be greater than zero")

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteLineResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteLineResponse.java
@@ -1,8 +1,12 @@
 package com.fabricmanagement.sales.quote.dto;
 
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationMethod;
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationStatus;
+import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuoteLineDeliveryStatus;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
@@ -27,6 +31,16 @@ public class QuoteLineResponse {
   private final QuoteLineDeliveryStatus deliveryStatus;
   private final LocalDate deliveryDate;
   private final Boolean deliveryCovered;
+
+  @Schema(description = "Line-level fulfilment mode", nullable = true)
+  private final FulfillmentMode fulfillmentMode;
+
+  @Schema(description = "Current fulfilment determination status")
+  private final FulfillmentDeterminationStatus fulfillmentDeterminationStatus;
+
+  @Schema(description = "How the current fulfilment mode was determined", nullable = true)
+  private final FulfillmentDeterminationMethod fulfillmentDeterminationMethod;
+
   private final BigDecimal requestedQty;
   private final String unit;
   private final BigDecimal listPrice;
@@ -53,6 +67,9 @@ public class QuoteLineResponse {
     this.deliveryStatus = line.getDeliveryStatus();
     this.deliveryDate = line.getDeliveryDate();
     this.deliveryCovered = line.getDeliveryCovered();
+    this.fulfillmentMode = line.getFulfillmentMode();
+    this.fulfillmentDeterminationStatus = line.getFulfillmentDeterminationStatus();
+    this.fulfillmentDeterminationMethod = line.getFulfillmentDeterminationMethod();
     this.requestedQty = line.getRequestedQty();
     this.unit = line.getUnit();
     this.listPrice = line.getListPrice();

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
@@ -45,6 +45,7 @@ public class QuoteResponse {
   private final UUID parentQuoteId;
   private final Instant createdAt;
   private final List<QuoteLineResponse> lines;
+  private final boolean mixedFulfillment;
 
   private QuoteResponse(Quote quote) {
     this(quote, null);
@@ -70,6 +71,7 @@ public class QuoteResponse {
     this.parentQuoteId = quote.getParentQuoteId();
     this.createdAt = quote.getCreatedAt();
     this.lines = quote.getLines().stream().map(QuoteLineResponse::from).toList();
+    this.mixedFulfillment = quote.isMixedFulfillment();
   }
 
   public static QuoteResponse from(Quote quote) {

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/UpdateQuoteLineRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/UpdateQuoteLineRequest.java
@@ -1,6 +1,8 @@
 package com.fabricmanagement.sales.quote.dto;
 
+import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
 import com.fabricmanagement.sales.quote.domain.QuoteLineDeliveryStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotBlank;
@@ -24,6 +26,11 @@ public class UpdateQuoteLineRequest {
   private QuoteLineDeliveryStatus deliveryStatus;
 
   private LocalDate deliveryDate;
+
+  @Schema(
+      description = "Manual line-level fulfilment mode; omission or null clears it to pending",
+      nullable = true)
+  private FulfillmentMode fulfillmentMode;
 
   @NotNull(message = "Requested quantity is required")
   @DecimalMin(value = "0.001", message = "Requested quantity must be greater than zero")

--- a/src/main/resources/db/migration/V20260724120000__add_fulfillment_mode_to_quote_line.sql
+++ b/src/main/resources/db/migration/V20260724120000__add_fulfillment_mode_to_quote_line.sql
@@ -1,0 +1,56 @@
+ALTER TABLE sales.quote_line
+    ADD COLUMN fulfillment_mode varchar(32),
+    ADD COLUMN fulfillment_determination_status varchar(16) NOT NULL DEFAULT 'PENDING',
+    ADD COLUMN fulfillment_determination_method varchar(16);
+
+ALTER TABLE sales.quote_line
+    ADD CONSTRAINT chk_quote_line_fulfillment_mode
+        CHECK (
+            fulfillment_mode IS NULL
+            OR fulfillment_mode IN (
+                'STOCK',
+                'MAKE_TO_ORDER',
+                'PURCHASE_TO_ORDER',
+                'STOCK_AND_PRODUCTION'
+            )
+        )
+        NOT VALID,
+    ADD CONSTRAINT chk_quote_line_fulfillment_status
+        CHECK (
+            fulfillment_determination_status IN (
+                'PENDING',
+                'PROPOSED',
+                'CONFIRMED',
+                'OVERRIDDEN'
+            )
+        )
+        NOT VALID,
+    ADD CONSTRAINT chk_quote_line_fulfillment_method
+        CHECK (
+            fulfillment_determination_method IS NULL
+            OR fulfillment_determination_method IN (
+                'AUTOMATIC',
+                'MANUAL',
+                'POLICY_BASED'
+            )
+        )
+        NOT VALID,
+    ADD CONSTRAINT chk_quote_line_fulfillment_mode_status
+        CHECK (
+            (fulfillment_mode IS NULL)
+            = (fulfillment_determination_status = 'PENDING')
+        )
+        NOT VALID,
+    ADD CONSTRAINT chk_quote_line_fulfillment_mode_method
+        CHECK (
+            (fulfillment_determination_method IS NULL)
+            = (fulfillment_mode IS NULL)
+        )
+        NOT VALID;
+
+ALTER TABLE sales.quote_line
+    VALIDATE CONSTRAINT chk_quote_line_fulfillment_mode,
+    VALIDATE CONSTRAINT chk_quote_line_fulfillment_status,
+    VALIDATE CONSTRAINT chk_quote_line_fulfillment_method,
+    VALIDATE CONSTRAINT chk_quote_line_fulfillment_mode_status,
+    VALIDATE CONSTRAINT chk_quote_line_fulfillment_mode_method;

--- a/src/main/resources/db/migration/V20260724130000__add_acquired_by_to_trading_partner.sql
+++ b/src/main/resources/db/migration/V20260724130000__add_acquired_by_to_trading_partner.sql
@@ -1,0 +1,11 @@
+ALTER TABLE common_company.common_trading_partner
+    ADD COLUMN IF NOT EXISTS acquired_by_id UUID;
+
+COMMENT ON COLUMN common_company.common_trading_partner.acquired_by_id IS
+    'Immutable user id that initiated the customer relationship; null for supplier-only or unknown legacy acquisition.';
+
+UPDATE common_company.common_trading_partner
+SET acquired_by_id = created_by
+WHERE partner_type IN ('CUSTOMER', 'BOTH')
+  AND acquired_by_id IS NULL
+  AND created_by IS NOT NULL;

--- a/src/main/resources/db/migration/V20260724131000__create_customer_account_team_member.sql
+++ b/src/main/resources/db/migration/V20260724131000__create_customer_account_team_member.sql
@@ -1,0 +1,30 @@
+CREATE TABLE IF NOT EXISTS sales.customer_account_team_member (
+    tenant_id UUID NOT NULL,
+    customer_id UUID NOT NULL,
+    user_id UUID NOT NULL,
+    uid VARCHAR(100) UNIQUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT pk_customer_account_team_member PRIMARY KEY (customer_id, user_id),
+    CONSTRAINT uk_customer_account_team_member
+        UNIQUE (tenant_id, customer_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_customer_account_team_lookup
+    ON sales.customer_account_team_member(tenant_id, customer_id, is_active, created_at);
+
+COMMENT ON TABLE sales.customer_account_team_member IS
+    'Tenant-scoped commercial account-team membership; customer_id and user_id are cross-context soft references.';
+
+ALTER TABLE sales.customer_account_team_member ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales.customer_account_team_member FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY rls_tenant_isolation ON sales.customer_account_team_member
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::uuid)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::uuid);

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/FinanceDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/FinanceDemoSeederTest.java
@@ -2,6 +2,7 @@ package com.fabricmanagement.common.infrastructure.bootstrap;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -107,7 +108,7 @@ class FinanceDemoSeederTest {
   void seedsReportingCurrencyFxInvoicesAndPayments() {
     // Idempotency anchor absent → proceed.
     when(tradingPartnerService.searchByName(eq(TENANT_ID), any())).thenReturn(List.of());
-    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class)))
+    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class), isNull()))
         .thenAnswer(i -> TradingPartnerDto.builder().id(UUID.randomUUID()).build());
 
     Organization rootOrg = org.mockito.Mockito.mock(Organization.class);

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/ProcurementDemoSeederTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -127,7 +128,7 @@ class ProcurementDemoSeederTest {
                 partners.stream()
                     .filter(p -> ProcurementDemoSeeder.SUPPLIER_ANATOLIA.equals(p.getDisplayName()))
                     .toList());
-    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class)))
+    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class), isNull()))
         .thenAnswer(
             invocation -> {
               CreateTradingPartnerRequest req = invocation.getArgument(0);
@@ -285,7 +286,7 @@ class ProcurementDemoSeederTest {
 
     ArgumentCaptor<CreateTradingPartnerRequest> partnerCaptor =
         ArgumentCaptor.forClass(CreateTradingPartnerRequest.class);
-    verify(tradingPartnerService, times(3)).createPartner(partnerCaptor.capture());
+    verify(tradingPartnerService, times(3)).createPartner(partnerCaptor.capture(), isNull());
     assertThat(partnerCaptor.getAllValues())
         .filteredOn(req -> req.getPartnerType() == PartnerType.SUPPLIER)
         .hasSizeGreaterThanOrEqualTo(1);

--- a/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
+++ b/src/test/java/com/fabricmanagement/common/infrastructure/bootstrap/SalesQuoteDemoSeederTest.java
@@ -43,6 +43,7 @@ import com.fabricmanagement.production.masterdata.product.dto.CreateProductReque
 import com.fabricmanagement.production.masterdata.product.dto.ProductDto;
 import com.fabricmanagement.production.masterdata.qualitygrade.app.QualityGradeService;
 import com.fabricmanagement.production.masterdata.qualitygrade.domain.QualityGrade;
+import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.quote.api.QuoteCreateRequest;
 import com.fabricmanagement.sales.quote.app.QuoteService;
@@ -89,6 +90,7 @@ class SalesQuoteDemoSeederTest {
   @Mock private DiscountPolicyService discountPolicyService;
   @Mock private ExchangeRateService exchangeRateService;
   @Mock private QuoteService quoteService;
+  @Mock private CustomerAccountTeamService customerAccountTeamService;
   @Mock private UserRepository userRepository;
   @Mock private UserCreationService userCreationService;
   @Mock private RoleService roleService;
@@ -115,6 +117,7 @@ class SalesQuoteDemoSeederTest {
             discountPolicyService,
             exchangeRateService,
             quoteService,
+            customerAccountTeamService,
             userRepository,
             userCreationService,
             roleService,
@@ -138,7 +141,7 @@ class SalesQuoteDemoSeederTest {
     // Idempotency: the second run must short-circuit on the demo-customer marker.
     ArgumentCaptor<CreateTradingPartnerRequest> partnerCaptor =
         ArgumentCaptor.forClass(CreateTradingPartnerRequest.class);
-    verify(tradingPartnerService, times(1)).createPartner(partnerCaptor.capture());
+    verify(tradingPartnerService, times(1)).createPartner(partnerCaptor.capture(), eq(EMMA_ID));
     assertThat(partnerCaptor.getValue().getPartnerType()).isEqualTo(PartnerType.CUSTOMER);
     assertThat(partnerCaptor.getValue().getCountry()).isEqualTo("GBR");
 
@@ -213,6 +216,7 @@ class SalesQuoteDemoSeederTest {
     assertThat(draftQuote.getQuoteNumber())
         .startsWith(SalesQuoteDemoSeeder.DRAFT_QUOTE_NUMBER_STEM);
     assertThat(draftQuote.getAssignedToId()).isEqualTo(SANDRA_ID);
+    verify(customerAccountTeamService).addMember(TENANT_ID, partners.get(0).getId(), SANDRA_ID);
 
     ArgumentCaptor<CreateInternalUserRequest> userCaptor =
         ArgumentCaptor.forClass(CreateInternalUserRequest.class);
@@ -267,7 +271,7 @@ class SalesQuoteDemoSeederTest {
     assertThatThrownBy(() -> seeder.seedFor(TENANT_ID))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("grades unavailable");
-    verify(tradingPartnerService, never()).createPartner(any());
+    verify(tradingPartnerService, never()).createPartner(any(), any());
     // The finally block must still restore the previous tenant context.
     assertThat(TenantContext.getCurrentTenantIdOrNull()).isNull();
   }
@@ -286,7 +290,7 @@ class SalesQuoteDemoSeederTest {
   private void stubHappyPath() {
     when(tradingPartnerService.searchByName(TENANT_ID, SalesQuoteDemoSeeder.CUSTOMER_ALBION))
         .thenAnswer(invocation -> List.copyOf(partners));
-    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class)))
+    when(tradingPartnerService.createPartner(any(CreateTradingPartnerRequest.class), eq(EMMA_ID)))
         .thenAnswer(
             invocation -> {
               CreateTradingPartnerRequest req = invocation.getArgument(0);

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/api/controller/TradingPartnerControllerTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/api/controller/TradingPartnerControllerTest.java
@@ -1,0 +1,79 @@
+package com.fabricmanagement.platform.tradingpartner.api.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerService;
+import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
+import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
+import com.fabricmanagement.platform.tradingpartner.dto.QuickCreateCustomerRequest;
+import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
+import com.fabricmanagement.platform.tradingpartner.dto.UpdateTradingPartnerRequest;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TradingPartnerControllerTest {
+
+  @Mock private TradingPartnerService tradingPartnerService;
+
+  private TradingPartnerController controller;
+  private UUID actingUserId;
+
+  @BeforeEach
+  void setUp() {
+    controller = new TradingPartnerController(tradingPartnerService);
+    actingUserId = UUID.randomUUID();
+    TenantContext.setCurrentUserId(actingUserId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void createPartnerPassesActingUserAsInternalAcquirer() {
+    CreateTradingPartnerRequest request =
+        CreateTradingPartnerRequest.builder()
+            .companyName("Customer Ltd")
+            .partnerType(PartnerType.CUSTOMER)
+            .build();
+    when(tradingPartnerService.createPartner(request, actingUserId))
+        .thenReturn(TradingPartnerDto.builder().id(UUID.randomUUID()).build());
+
+    controller.createPartner(request);
+
+    verify(tradingPartnerService).createPartner(request, actingUserId);
+  }
+
+  @Test
+  void quickCreatePassesActingUserAsInternalAcquirer() {
+    QuickCreateCustomerRequest request = new QuickCreateCustomerRequest();
+    when(tradingPartnerService.quickCreateCustomer(request, actingUserId))
+        .thenReturn(TradingPartnerDto.builder().id(UUID.randomUUID()).build());
+
+    controller.quickCreateCustomer(request);
+
+    verify(tradingPartnerService).quickCreateCustomer(request, actingUserId);
+  }
+
+  @Test
+  void updatePartnerPassesActingUserAsInternalAcquirer() {
+    UUID partnerId = UUID.randomUUID();
+    UpdateTradingPartnerRequest request =
+        UpdateTradingPartnerRequest.builder().partnerType(PartnerType.CUSTOMER).build();
+    when(tradingPartnerService.updatePartner(partnerId, request, actingUserId))
+        .thenReturn(TradingPartnerDto.builder().id(partnerId).build());
+
+    controller.updatePartner(partnerId, request);
+
+    verify(tradingPartnerService).updatePartner(partnerId, request, actingUserId);
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerServiceTest.java
@@ -21,6 +21,7 @@ import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequ
 import com.fabricmanagement.platform.tradingpartner.dto.QuickCreateCustomerContactRequest;
 import com.fabricmanagement.platform.tradingpartner.dto.QuickCreateCustomerRequest;
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
+import com.fabricmanagement.platform.tradingpartner.dto.UpdateTradingPartnerRequest;
 import com.fabricmanagement.platform.tradingpartner.infra.repository.TradingPartnerRepository;
 import java.util.List;
 import java.util.Optional;
@@ -172,6 +173,185 @@ class TradingPartnerServiceTest {
     }
 
     @Test
+    void stampsAcquirerWhenSupplierIsUpgradedToCustomerRelationship() {
+      UUID acquirerId = UUID.randomUUID();
+      CreateTradingPartnerRequest request =
+          CreateTradingPartnerRequest.builder()
+              .companyName("Akkaya Tekstil")
+              .taxId("1234567890")
+              .country("TUR")
+              .partnerType(PartnerType.CUSTOMER)
+              .build();
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .taxId("1234567890")
+              .officialName("Akkaya Tekstil")
+              .country("TUR")
+              .build();
+      TradingPartner existing =
+          TradingPartner.builder()
+              .registry(registry)
+              .partnerType(PartnerType.SUPPLIER)
+              .status(PartnerStatus.ACTIVE)
+              .build();
+      existing.setId(PARTNER_ID);
+      existing.setTenantId(TENANT_ID);
+
+      when(registryService.findOrCreate("1234567890", "Akkaya Tekstil", "TUR"))
+          .thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.of(existing));
+      when(partnerRepository.save(existing)).thenReturn(existing);
+
+      TradingPartnerDto result = service.createPartner(request, acquirerId);
+
+      assertThat(result.getPartnerType()).isEqualTo(PartnerType.BOTH);
+      assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+      assertThat(existing.getAcquiredById()).isEqualTo(acquirerId);
+    }
+
+    @Test
+    void stampsAcquirerWhenNewCustomerRelationshipIsCreated() {
+      UUID acquirerId = UUID.randomUUID();
+      CreateTradingPartnerRequest request =
+          CreateTradingPartnerRequest.builder()
+              .companyName("New Customer")
+              .country("GBR")
+              .partnerType(PartnerType.CUSTOMER)
+              .build();
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .officialName("New Customer")
+              .country("GBR")
+              .build();
+
+      when(registryService.findOrCreate(null, "New Customer", "GBR")).thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.empty());
+      when(partnerRepository.save(any(TradingPartner.class)))
+          .thenAnswer(
+              invocation -> {
+                TradingPartner partner = invocation.getArgument(0);
+                partner.setId(PARTNER_ID);
+                partner.setTenantId(TENANT_ID);
+                return partner;
+              });
+      when(organizationFacade.createPartnerOrganization(any(), any(), any()))
+          .thenReturn(OrganizationDto.builder().id(UUID.randomUUID()).build());
+
+      TradingPartnerDto result = service.createPartner(request, acquirerId);
+
+      assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+    }
+
+    @Test
+    void stampsUnattributedExistingCustomerWhenExplicitInitiatorIsAvailable() {
+      UUID acquirerId = UUID.randomUUID();
+      CreateTradingPartnerRequest request =
+          CreateTradingPartnerRequest.builder()
+              .companyName("Unattributed Customer")
+              .country("GBR")
+              .partnerType(PartnerType.CUSTOMER)
+              .build();
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .officialName("Unattributed Customer")
+              .country("GBR")
+              .build();
+      TradingPartner existing =
+          TradingPartner.builder()
+              .registry(registry)
+              .partnerType(PartnerType.CUSTOMER)
+              .status(PartnerStatus.ACTIVE)
+              .build();
+      existing.setId(PARTNER_ID);
+      existing.setTenantId(TENANT_ID);
+
+      when(registryService.findOrCreate(null, "Unattributed Customer", "GBR")).thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.of(existing));
+      when(partnerRepository.save(existing)).thenReturn(existing);
+
+      TradingPartnerDto result = service.createPartner(request, acquirerId);
+
+      assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+      verify(partnerRepository).save(existing);
+    }
+
+    @Test
+    void neverStampsSupplierOnlyRelationship() {
+      UUID acquirerId = UUID.randomUUID();
+      CreateTradingPartnerRequest request =
+          CreateTradingPartnerRequest.builder()
+              .companyName("Supplier Ltd")
+              .country("GBR")
+              .partnerType(PartnerType.SUPPLIER)
+              .build();
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .officialName("Supplier Ltd")
+              .country("GBR")
+              .build();
+
+      when(registryService.findOrCreate(null, "Supplier Ltd", "GBR")).thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.empty());
+      when(partnerRepository.save(any(TradingPartner.class)))
+          .thenAnswer(
+              invocation -> {
+                TradingPartner partner = invocation.getArgument(0);
+                partner.setId(PARTNER_ID);
+                partner.setTenantId(TENANT_ID);
+                return partner;
+              });
+      when(organizationFacade.createPartnerOrganization(any(), any(), any()))
+          .thenReturn(OrganizationDto.builder().id(UUID.randomUUID()).build());
+
+      TradingPartnerDto result = service.createPartner(request, acquirerId);
+
+      assertThat(result.getAcquiredById()).isNull();
+    }
+
+    @Test
+    void neverOverwritesExistingAcquirerWhenCustomerIsReadded() {
+      UUID originalAcquirerId = UUID.randomUUID();
+      CreateTradingPartnerRequest request =
+          CreateTradingPartnerRequest.builder()
+              .companyName("Existing Customer")
+              .country("GBR")
+              .partnerType(PartnerType.CUSTOMER)
+              .build();
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .officialName("Existing Customer")
+              .country("GBR")
+              .build();
+      TradingPartner existing =
+          TradingPartner.builder()
+              .registry(registry)
+              .partnerType(PartnerType.CUSTOMER)
+              .status(PartnerStatus.ACTIVE)
+              .acquiredById(originalAcquirerId)
+              .build();
+      existing.setId(PARTNER_ID);
+      existing.setTenantId(TENANT_ID);
+
+      when(registryService.findOrCreate(null, "Existing Customer", "GBR")).thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.of(existing));
+
+      TradingPartnerDto result = service.createPartner(request, UUID.randomUUID());
+
+      assertThat(result.getAcquiredById()).isEqualTo(originalAcquirerId);
+      verify(partnerRepository, never()).save(any());
+    }
+
+    @Test
     void returnsExistingWhenSameRegistryAndSameType() {
       CreateTradingPartnerRequest request =
           CreateTradingPartnerRequest.builder()
@@ -210,6 +390,55 @@ class TradingPartnerServiceTest {
       assertThat(result.getPartnerType()).isEqualTo(PartnerType.SUPPLIER);
       verify(partnerRepository, never()).save(any());
       verify(eventPublisher, never()).publish(any(TradingPartnerCreatedEvent.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("updatePartner")
+  class UpdatePartner {
+
+    @Test
+    void stampsAcquirerWhenUpdateTurnsSupplierIntoCustomer() {
+      UUID acquirerId = UUID.randomUUID();
+      TradingPartner partner =
+          TradingPartner.builder()
+              .registry(TradingPartnerRegistry.builder().id(REGISTRY_ID).build())
+              .partnerType(PartnerType.SUPPLIER)
+              .status(PartnerStatus.ACTIVE)
+              .build();
+      partner.setId(PARTNER_ID);
+      partner.setTenantId(TENANT_ID);
+      UpdateTradingPartnerRequest request =
+          UpdateTradingPartnerRequest.builder().partnerType(PartnerType.CUSTOMER).build();
+      when(partnerRepository.findByTenantIdAndId(TENANT_ID, PARTNER_ID))
+          .thenReturn(Optional.of(partner));
+      when(partnerRepository.save(partner)).thenReturn(partner);
+
+      TradingPartnerDto result = service.updatePartner(PARTNER_ID, request, acquirerId);
+
+      assertThat(result.getPartnerType()).isEqualTo(PartnerType.CUSTOMER);
+      assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+    }
+
+    @Test
+    void doesNotAttributeLegacyCustomerDuringUnrelatedUpdate() {
+      TradingPartner partner =
+          TradingPartner.builder()
+              .registry(TradingPartnerRegistry.builder().id(REGISTRY_ID).build())
+              .partnerType(PartnerType.CUSTOMER)
+              .status(PartnerStatus.ACTIVE)
+              .build();
+      partner.setId(PARTNER_ID);
+      partner.setTenantId(TENANT_ID);
+      UpdateTradingPartnerRequest request =
+          UpdateTradingPartnerRequest.builder().customName("Updated alias").build();
+      when(partnerRepository.findByTenantIdAndId(TENANT_ID, PARTNER_ID))
+          .thenReturn(Optional.of(partner));
+      when(partnerRepository.save(partner)).thenReturn(partner);
+
+      TradingPartnerDto result = service.updatePartner(PARTNER_ID, request, UUID.randomUUID());
+
+      assertThat(result.getAcquiredById()).isNull();
     }
   }
 
@@ -295,6 +524,44 @@ class TradingPartnerServiceTest {
               PartnerContactRole.FINANCE,
               false,
               false);
+    }
+
+    @Test
+    void stampsAcquirerWhenQuickCreateUpgradesSupplierToBoth() {
+      UUID acquirerId = UUID.randomUUID();
+      QuickCreateCustomerRequest request = new QuickCreateCustomerRequest();
+      request.setCompanyName("Existing Supplier Ltd");
+      request.setTaxNumber("TAX-UPGRADE");
+      request.setContacts(List.of());
+      TradingPartnerRegistry registry =
+          TradingPartnerRegistry.builder()
+              .id(REGISTRY_ID)
+              .officialName("Existing Supplier Ltd")
+              .taxId("TAX-UPGRADE")
+              .country("TUR")
+              .build();
+      TradingPartner existing =
+          TradingPartner.builder()
+              .registry(registry)
+              .partnerType(PartnerType.SUPPLIER)
+              .status(PartnerStatus.ACTIVE)
+              .organizationId(UUID.randomUUID())
+              .build();
+      existing.setId(PARTNER_ID);
+      existing.setTenantId(TENANT_ID);
+
+      when(registryService.findOrCreate("TAX-UPGRADE", "Existing Supplier Ltd", "TUR"))
+          .thenReturn(registry);
+      when(partnerRepository.findByTenantIdAndRegistryId(TENANT_ID, REGISTRY_ID))
+          .thenReturn(Optional.of(existing));
+      when(partnerRepository.save(existing)).thenReturn(existing);
+      when(organizationFacade.findById(TENANT_ID, existing.getOrganizationId()))
+          .thenReturn(Optional.empty());
+
+      TradingPartnerDto result = service.quickCreateCustomer(request, acquirerId);
+
+      assertThat(result.getPartnerType()).isEqualTo(PartnerType.BOTH);
+      assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
     }
   }
 

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/infra/TradingPartnerAcquiredByMigrationIT.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/infra/TradingPartnerAcquiredByMigrationIT.java
@@ -1,0 +1,116 @@
+package com.fabricmanagement.platform.tradingpartner.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class TradingPartnerAcquiredByMigrationIT {
+
+  private static final String CREATOR_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("trading_partner_acquirer_migration")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @BeforeAll
+  static void migrateToPreChangeAndSeedPartners() throws SQLException {
+    migrateTo("20260724120000");
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(
+          """
+          INSERT INTO common_tenant.common_tenant (id, uid, slug, name, status)
+          VALUES ('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'RSF2A-MIGRATION',
+                  'rsf2a-migration', 'RSF-2a Migration', 'ACTIVE');
+
+          INSERT INTO common_company.trading_partner_registry
+            (id, uid, official_name, country, verified_status, is_active,
+             created_at, updated_at, version)
+          VALUES
+            ('10000000-0000-4000-8000-000000000001', 'RSF2A-REG-CREATED',
+             'Created Customer', 'GBR', 'UNVERIFIED', true, now(), now(), 0),
+            ('10000000-0000-4000-8000-000000000002', 'RSF2A-REG-UNKNOWN',
+             'Unknown Customer', 'GBR', 'UNVERIFIED', true, now(), now(), 0),
+            ('10000000-0000-4000-8000-000000000003', 'RSF2A-REG-SUPPLIER',
+             'Supplier', 'GBR', 'UNVERIFIED', true, now(), now(), 0);
+
+          INSERT INTO common_company.common_trading_partner
+            (id, tenant_id, uid, registry_id, partner_type, status, created_by,
+             is_active, created_at, updated_at, version)
+          VALUES
+            ('20000000-0000-4000-8000-000000000001',
+             'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'RSF2A-CUSTOMER-CREATED',
+             '10000000-0000-4000-8000-000000000001', 'CUSTOMER', 'ACTIVE',
+             'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', true, now(), now(), 0),
+            ('20000000-0000-4000-8000-000000000002',
+             'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'RSF2A-CUSTOMER-UNKNOWN',
+             '10000000-0000-4000-8000-000000000002', 'CUSTOMER', 'ACTIVE',
+             null, true, now(), now(), 0),
+            ('20000000-0000-4000-8000-000000000003',
+             'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa', 'RSF2A-SUPPLIER-CREATED',
+             '10000000-0000-4000-8000-000000000003', 'SUPPLIER', 'ACTIVE',
+             'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb', true, now(), now(), 0);
+          """);
+    }
+  }
+
+  @Test
+  void backfillsOnlyCustomerRelationshipsWithKnownCreators() throws SQLException {
+    migrateTo("20260724130000");
+
+    Map<String, String> acquiredByUid = new HashMap<>();
+    try (Connection connection = ownerConnection();
+        Statement statement = connection.createStatement();
+        ResultSet result =
+            statement.executeQuery(
+                """
+                SELECT uid, acquired_by_id::text
+                FROM common_company.common_trading_partner
+                WHERE tenant_id = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+                ORDER BY uid
+                """)) {
+      while (result.next()) {
+        acquiredByUid.put(result.getString(1), result.getString(2));
+      }
+    }
+
+    assertThat(acquiredByUid)
+        .containsEntry("RSF2A-CUSTOMER-CREATED", CREATOR_ID)
+        .containsKeys("RSF2A-CUSTOMER-UNKNOWN", "RSF2A-SUPPLIER-CREATED");
+    assertThat(acquiredByUid.get("RSF2A-CUSTOMER-UNKNOWN")).isNull();
+    assertThat(acquiredByUid.get("RSF2A-SUPPLIER-CREATED")).isNull();
+  }
+
+  private static void migrateTo(String target) {
+    Flyway.configure()
+        .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+        .locations("classpath:db/migration")
+        .schemas("common_tenant")
+        .defaultSchema("common_tenant")
+        .target(target)
+        .load()
+        .migrate();
+  }
+
+  private static Connection ownerConnection() throws SQLException {
+    return DriverManager.getConnection(
+        POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
@@ -1,0 +1,41 @@
+package com.fabricmanagement.sales.ownership;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseJunctionEntity;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class SalesOwnershipArchTest {
+
+  private static JavaClasses productionClasses;
+
+  @BeforeAll
+  static void importClasses() {
+    productionClasses =
+        new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.fabricmanagement");
+  }
+
+  @Test
+  void ownershipModuleDoesNotImportPlatformDomainClasses() {
+    noClasses()
+        .that()
+        .resideInAPackage("com.fabricmanagement.sales.ownership..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("com.fabricmanagement.platform..domain..")
+        .check(productionClasses);
+  }
+
+  @Test
+  void accountTeamMemberReusesJunctionAuditAndSoftDeleteContract() {
+    assertThat(CustomerAccountTeamMember.class.getSuperclass()).isEqualTo(BaseJunctionEntity.class);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamControllerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamControllerTest.java
@@ -1,0 +1,95 @@
+package com.fabricmanagement.sales.ownership.api.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CustomerAccountTeamController.class)
+@EnableMethodSecurity
+class CustomerAccountTeamControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+  @MockBean private CustomerAccountTeamService accountTeamService;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  private UUID tenantId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+  }
+
+  @AfterEach
+  void tearDown() {
+    TenantContext.clear();
+  }
+
+  @Test
+  @WithMockUser
+  void getReturnsStableTriagePreviewWithNullableOwner() throws Exception {
+    UUID customerId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("read"))).thenReturn(true);
+    when(accountTeamService.getAccountTeam(tenantId, customerId))
+        .thenReturn(
+            new CustomerAccountTeamResponse(
+                customerId, null, null, OwnerResolutionReason.TRIAGE_REQUIRED, List.of()));
+
+    mockMvc
+        .perform(get("/api/v1/sales/customers/{customerId}/account-team", customerId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data.customerId").value(customerId.toString()))
+        .andExpect(jsonPath("$.data.defaultOwnerId").doesNotExist())
+        .andExpect(jsonPath("$.data.defaultOwnerReason").value("TRIAGE_REQUIRED"));
+  }
+
+  @Test
+  @WithMockUser
+  void addRejectsMissingUserIdWithValidationErrorBeforeServiceInvocation() throws Exception {
+    UUID customerId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("write"))).thenReturn(true);
+
+    mockMvc
+        .perform(
+            post("/api/v1/sales/customers/{customerId}/account-team", customerId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andExpect(status().isUnprocessableEntity())
+        .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+        .andExpect(jsonPath("$.errors.userId").value("User ID is required"));
+
+    verifyNoInteractions(accountTeamService);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/AcquirerFirstPolicyTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/AcquirerFirstPolicyTest.java
@@ -1,0 +1,189 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AcquirerFirstPolicyTest {
+
+  @Mock private CustomerEligibilityService customerEligibilityService;
+  @Mock private CustomerAccountTeamMemberRepository memberRepository;
+  @Mock private UserQueryService userQueryService;
+  @InjectMocks private AcquirerFirstPolicy policy;
+
+  private UUID tenantId;
+  private UUID customerId;
+  private UUID acquirerId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    customerId = UUID.randomUUID();
+    acquirerId = UUID.randomUUID();
+    when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, acquirerId));
+  }
+
+  @Test
+  void acceptsActiveAcquirerAsExplicitOverrideWithoutTeamMembership() {
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    active(acquirerId);
+
+    OwnerResolution result =
+        policy.resolve(new OwnerResolutionContext(tenantId, customerId, acquirerId));
+
+    assertThat(result.ownerId()).isEqualTo(acquirerId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.EXPLICIT_OVERRIDE);
+  }
+
+  @Test
+  void acceptsActiveTeamMemberAsExplicitOverride() {
+    UUID teamUserId = UUID.randomUUID();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of(member(teamUserId, Instant.parse("2026-01-01T00:00:00Z"))));
+    active(acquirerId);
+    active(teamUserId);
+
+    OwnerResolution result =
+        policy.resolve(new OwnerResolutionContext(tenantId, customerId, teamUserId));
+
+    assertThat(result.ownerId()).isEqualTo(teamUserId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.EXPLICIT_OVERRIDE);
+  }
+
+  @Test
+  void rejectsInactiveAcquirerAsExplicitOverride() {
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    inactive(acquirerId);
+
+    assertThatThrownBy(
+            () -> policy.resolve(new OwnerResolutionContext(tenantId, customerId, acquirerId)))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_018_OWNER_NOT_SELECTABLE"));
+  }
+
+  @Test
+  void rejectsRandomUserOutsideSelectableSet() {
+    UUID randomUserId = UUID.randomUUID();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    active(acquirerId);
+
+    assertThatThrownBy(
+            () -> policy.resolve(new OwnerResolutionContext(tenantId, customerId, randomUserId)))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_018_OWNER_NOT_SELECTABLE"));
+  }
+
+  @Test
+  void rejectsTeamMemberWhoseUserWasDeactivated() {
+    UUID inactiveMemberId = UUID.randomUUID();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of(member(inactiveMemberId, Instant.parse("2026-01-01T00:00:00Z"))));
+    active(acquirerId);
+    inactive(inactiveMemberId);
+
+    assertThatThrownBy(
+            () ->
+                policy.resolve(new OwnerResolutionContext(tenantId, customerId, inactiveMemberId)))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_018_OWNER_NOT_SELECTABLE"));
+  }
+
+  @Test
+  void defaultsToActiveAcquirerBeforeAccountTeam() {
+    UUID teamUserId = UUID.randomUUID();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of(member(teamUserId, Instant.parse("2026-01-01T00:00:00Z"))));
+    active(acquirerId);
+    active(teamUserId);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isEqualTo(acquirerId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.ACQUIRER);
+  }
+
+  @Test
+  void skipsMemberWhoseUserWasDeactivatedAndPicksNextStableMember() {
+    UUID inactiveMemberId = UUID.randomUUID();
+    UUID activeMemberId = UUID.randomUUID();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(
+            List.of(
+                member(inactiveMemberId, Instant.parse("2026-01-01T00:00:00Z")),
+                member(activeMemberId, Instant.parse("2026-01-02T00:00:00Z"))));
+    inactive(acquirerId);
+    inactive(inactiveMemberId);
+    active(activeMemberId);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isEqualTo(activeMemberId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.ACCOUNT_TEAM);
+  }
+
+  @Test
+  void returnsTriageRequiredWhenNoSelectableOwnerExists() {
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    inactive(acquirerId);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isNull();
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.TRIAGE_REQUIRED);
+  }
+
+  private CustomerAccountTeamMember member(UUID userId, Instant createdAt) {
+    CustomerAccountTeamMember member = CustomerAccountTeamMember.create(customerId, userId);
+    member.setTenantId(tenantId);
+    member.setCreatedAt(createdAt);
+    return member;
+  }
+
+  private void active(UUID userId) {
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(
+            Optional.of(UserDto.builder().id(userId).tenantId(tenantId).isActive(true).build()));
+  }
+
+  private void inactive(UUID userId) {
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(
+            Optional.of(UserDto.builder().id(userId).tenantId(tenantId).isActive(false).build()));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamServiceTest.java
@@ -1,0 +1,179 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerAccountTeamServiceTest {
+
+  @Mock private CustomerEligibilityService customerEligibilityService;
+  @Mock private CustomerAccountTeamMemberRepository memberRepository;
+  @Mock private UserQueryService userQueryService;
+  @Mock private DefaultOwnerPolicy defaultOwnerPolicy;
+  @InjectMocks private CustomerAccountTeamService service;
+
+  private UUID tenantId;
+  private UUID customerId;
+  private UUID acquirerId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    customerId = UUID.randomUUID();
+    acquirerId = UUID.randomUUID();
+  }
+
+  @Test
+  void addsActiveMemberAndReturnsThinResponse() {
+    UUID userId = UUID.randomUUID();
+    eligibleCustomer();
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(
+            Optional.of(
+                UserDto.builder().id(userId).displayName("Emma Clarke").isActive(true).build()));
+    when(memberRepository.findByTenantIdAndCustomerIdAndUserId(tenantId, customerId, userId))
+        .thenReturn(Optional.empty());
+    when(memberRepository.save(org.mockito.ArgumentMatchers.any()))
+        .thenAnswer(
+            invocation -> {
+              CustomerAccountTeamMember member = invocation.getArgument(0);
+              member.setTenantId(tenantId);
+              member.setCreatedAt(Instant.parse("2026-07-24T12:00:00Z"));
+              return member;
+            });
+
+    CustomerAccountTeamMemberResponse response = service.addMember(tenantId, customerId, userId);
+
+    assertThat(response.userId()).isEqualTo(userId);
+    assertThat(response.displayName()).isEqualTo("Emma Clarke");
+    assertThat(response.active()).isTrue();
+  }
+
+  @Test
+  void reactivatesExistingMembershipIdempotently() {
+    UUID userId = UUID.randomUUID();
+    CustomerAccountTeamMember existing = CustomerAccountTeamMember.create(customerId, userId);
+    existing.deactivate();
+    eligibleCustomer();
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(Optional.of(UserDto.builder().id(userId).isActive(true).build()));
+    when(memberRepository.findByTenantIdAndCustomerIdAndUserId(tenantId, customerId, userId))
+        .thenReturn(Optional.of(existing));
+    when(memberRepository.save(existing)).thenReturn(existing);
+
+    CustomerAccountTeamMemberResponse response = service.addMember(tenantId, customerId, userId);
+
+    assertThat(response.active()).isTrue();
+    assertThat(existing.getIsActive()).isTrue();
+    verify(memberRepository).save(existing);
+  }
+
+  @Test
+  void rejectsInactiveUserWithLockedCode() {
+    UUID userId = UUID.randomUUID();
+    eligibleCustomer();
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(Optional.of(UserDto.builder().id(userId).isActive(false).build()));
+
+    assertThatThrownBy(() -> service.addMember(tenantId, customerId, userId))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error ->
+                assertThat(error.getErrorCode()).isEqualTo("SALES_019_ACCOUNT_TEAM_USER_INACTIVE"));
+  }
+
+  @Test
+  void rejectsUnknownOrCrossTenantUserAsNotFound() {
+    UUID userId = UUID.randomUUID();
+    eligibleCustomer();
+    when(userQueryService.findById(tenantId, userId)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.addMember(tenantId, customerId, userId))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void deactivatesWithoutHardDelete() {
+    UUID userId = UUID.randomUUID();
+    CustomerAccountTeamMember existing = CustomerAccountTeamMember.create(customerId, userId);
+    eligibleCustomer();
+    when(memberRepository.findByTenantIdAndCustomerIdAndUserId(tenantId, customerId, userId))
+        .thenReturn(Optional.of(existing));
+    when(memberRepository.save(existing)).thenReturn(existing);
+
+    service.deactivateMember(tenantId, customerId, userId);
+
+    assertThat(existing.getIsActive()).isFalse();
+    assertThat(existing.getDeletedAt()).isNotNull();
+    verify(memberRepository).save(existing);
+  }
+
+  @Test
+  void returnsStableTriagePreviewWithoutViewerFallback() {
+    eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    when(defaultOwnerPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, null)))
+        .thenReturn(new OwnerResolution(null, OwnerResolutionReason.TRIAGE_REQUIRED));
+
+    CustomerAccountTeamResponse response = service.getAccountTeam(tenantId, customerId);
+
+    assertThat(response.defaultOwnerId()).isNull();
+    assertThat(response.defaultOwnerReason()).isEqualTo(OwnerResolutionReason.TRIAGE_REQUIRED);
+    assertThat(response.acquiredById()).isEqualTo(acquirerId);
+  }
+
+  @Test
+  void reportsMembershipInactiveWhenItsUserWasDeactivated() {
+    UUID userId = UUID.randomUUID();
+    CustomerAccountTeamMember member = CustomerAccountTeamMember.create(customerId, userId);
+    member.setCreatedAt(Instant.parse("2026-07-24T12:00:00Z"));
+    eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of(member));
+    when(userQueryService.findById(tenantId, userId))
+        .thenReturn(
+            Optional.of(
+                UserDto.builder().id(userId).displayName("Departed Rep").isActive(false).build()));
+    when(defaultOwnerPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, null)))
+        .thenReturn(new OwnerResolution(null, OwnerResolutionReason.TRIAGE_REQUIRED));
+
+    CustomerAccountTeamResponse response = service.getAccountTeam(tenantId, customerId);
+
+    assertThat(response.members())
+        .singleElement()
+        .satisfies(returnedMember -> assertThat(returnedMember.active()).isFalse());
+  }
+
+  private void eligibleCustomer() {
+    when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, acquirerId));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityServiceTest.java
@@ -1,0 +1,80 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerOwnershipSnapshot;
+import com.fabricmanagement.platform.tradingpartner.app.TradingPartnerResolver;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerEligibilityServiceTest {
+
+  @Mock private TradingPartnerResolver tradingPartnerResolver;
+  @InjectMocks private CustomerEligibilityService service;
+
+  @Test
+  void returnsCanonicalCustomerAndAcquirerForEligiblePartner() {
+    UUID tenantId = UUID.randomUUID();
+    UUID requestedId = UUID.randomUUID();
+    UUID canonicalId = UUID.randomUUID();
+    UUID acquirerId = UUID.randomUUID();
+    when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, requestedId))
+        .thenReturn(
+            Optional.of(new TradingPartnerOwnershipSnapshot(canonicalId, acquirerId, true, true)));
+
+    CustomerEligibilityService.EligibleCustomer result =
+        service.requireEligible(tenantId, requestedId);
+
+    assertThat(result.customerId()).isEqualTo(canonicalId);
+    assertThat(result.acquiredById()).isEqualTo(acquirerId);
+  }
+
+  @Test
+  void rejectsUnknownOrCrossTenantCustomerAsNotFound() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, customerId))
+        .thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.requireEligible(tenantId, customerId))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void rejectsSupplierOrInactivePartnerWithLockedCode() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, customerId))
+        .thenReturn(
+            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, false, true)));
+
+    assertThatThrownBy(() -> service.requireEligible(tenantId, customerId))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_020_CUSTOMER_NOT_ELIGIBLE"));
+  }
+
+  @Test
+  void rejectsInactiveCustomerWithLockedCode() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, customerId))
+        .thenReturn(
+            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, true, false)));
+
+    assertThatThrownBy(() -> service.requireEligible(tenantId, customerId))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_020_CUSTOMER_NOT_ELIGIBLE"));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/api/QuoteControllerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/api/QuoteControllerTest.java
@@ -1,0 +1,72 @@
+package com.fabricmanagement.sales.quote.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
+import com.fabricmanagement.sales.quote.app.QuoteApprovalService;
+import com.fabricmanagement.sales.quote.app.QuoteService;
+import com.fabricmanagement.sales.quote.dto.AddQuoteLineRequest;
+import com.fabricmanagement.sales.quote.mapper.QuoteMapper;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(QuoteController.class)
+@EnableMethodSecurity
+class QuoteControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockBean private QuoteService quoteService;
+  @MockBean private QuoteApprovalService quoteApprovalService;
+  @MockBean private QuoteMapper quoteMapper;
+  @MockBean private com.fabricmanagement.platform.auth.app.JwtService jwtService;
+
+  @MockBean
+  private com.fabricmanagement.common.infrastructure.tenant.TenantQueryPort tenantQueryPort;
+
+  @MockBean(name = "auth")
+  private SpELPermissionEvaluator authEvaluator;
+
+  @Test
+  @WithMockUser
+  void invalidFulfillmentModeReturnsBadRequestBeforeServiceInvocation() throws Exception {
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("write"))).thenReturn(true);
+    UUID quoteId = UUID.randomUUID();
+
+    mockMvc
+        .perform(
+            post("/api/v1/sales/quotes/{quoteId}/lines", quoteId)
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                    {
+                      "productId": "11111111-1111-4111-8111-111111111111",
+                      "requestedQty": 2,
+                      "unit": "M",
+                      "offeredPrice": 12.5,
+                      "fulfillmentMode": "INVALID"
+                    }
+                    """))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("BAD_REQUEST"));
+
+    verify(quoteService, never()).addQuoteLine(eq(quoteId), any(AddQuoteLineRequest.class));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -42,6 +42,9 @@ import com.fabricmanagement.sales.pricing.domain.DiscountPolicy;
 import com.fabricmanagement.sales.qualitygrade.app.SalesQualityGradeService;
 import com.fabricmanagement.sales.qualitygrade.app.SalesQualityGradeSnapshot;
 import com.fabricmanagement.sales.quote.api.QuoteCreateRequest;
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationMethod;
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationStatus;
+import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
 import com.fabricmanagement.sales.quote.domain.Quote;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalStatus;
@@ -427,7 +430,39 @@ class QuoteServiceTest {
         quoteService.addQuoteLine(
             quoteId, productId, new BigDecimal("2.000"), "KG", new BigDecimal("12.00"));
 
-    assertEquals("USD", updated.getLines().get(0).getCurrency());
+    QuoteLine line = updated.getLines().get(0);
+    assertEquals("USD", line.getCurrency());
+    assertNull(line.getFulfillmentMode());
+    assertEquals(FulfillmentDeterminationStatus.PENDING, line.getFulfillmentDeterminationStatus());
+    assertNull(line.getFulfillmentDeterminationMethod());
+  }
+
+  @Test
+  @DisplayName("Should derive confirmed manual determination from submitted fulfillment mode")
+  void shouldDeriveConfirmedManualDeterminationFromSubmittedFulfillmentMode() {
+    AddQuoteLineRequest req = new AddQuoteLineRequest();
+    req.setProductId(productId);
+    req.setRequestedQty(new BigDecimal("2.000"));
+    req.setUnit("KG");
+    req.setOfferedPrice(new BigDecimal("12.00"));
+    req.setFulfillmentMode(FulfillmentMode.STOCK);
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+    when(catalogService.getActiveByProductId(productId)).thenReturn(product("GBP", "15.00"));
+    when(policyService.getActivePolicy("FABRIC")).thenReturn(new DiscountPolicy());
+    when(pricingEngineService.evaluatePrice(any(), any(), any(), any()))
+        .thenReturn(pricingResult());
+    when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("GBP");
+
+    Quote updated = quoteService.addQuoteLine(quoteId, req);
+
+    QuoteLine line = updated.getLines().get(0);
+    assertEquals(FulfillmentMode.STOCK, line.getFulfillmentMode());
+    assertEquals(
+        FulfillmentDeterminationStatus.CONFIRMED, line.getFulfillmentDeterminationStatus());
+    assertEquals(FulfillmentDeterminationMethod.MANUAL, line.getFulfillmentDeterminationMethod());
   }
 
   @Test
@@ -711,6 +746,9 @@ class QuoteServiceTest {
     QuoteLine sourceLine = quoteLine("USD", "12.00", "2.000");
     sourceLine.applyQualityGrade(qualityGradeId, "A", "Grade A", new BigDecimal("1.125"));
     sourceLine.applyColor(colorId, "NAVY-01", "Navy", "#001F3F");
+    sourceLine.setFulfillmentMode(FulfillmentMode.MAKE_TO_ORDER);
+    sourceLine.setFulfillmentDeterminationStatus(FulfillmentDeterminationStatus.PROPOSED);
+    sourceLine.setFulfillmentDeterminationMethod(FulfillmentDeterminationMethod.AUTOMATIC);
     quote.addLine(sourceLine);
 
     when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
@@ -738,6 +776,11 @@ class QuoteServiceTest {
     assertEquals("NAVY-01", revisedLine.getColorCode());
     assertEquals("Navy", revisedLine.getColorName());
     assertEquals("#001F3F", revisedLine.getColorHex());
+    assertEquals(FulfillmentMode.MAKE_TO_ORDER, revisedLine.getFulfillmentMode());
+    assertEquals(
+        FulfillmentDeterminationStatus.PROPOSED, revisedLine.getFulfillmentDeterminationStatus());
+    assertEquals(
+        FulfillmentDeterminationMethod.AUTOMATIC, revisedLine.getFulfillmentDeterminationMethod());
     assertNotNull(savedRevision.getTotalAmount());
     assertNotNull(savedRevision.getReportingTotal());
   }
@@ -1003,6 +1046,48 @@ class QuoteServiceTest {
     assertEquals(0, updated.getTotalAmount().getAmount().compareTo(new BigDecimal("240.00")));
     assertEquals(
         0, updated.getReportingTotal().getConvertedAmount().compareTo(new BigDecimal("240.00")));
+  }
+
+  @Test
+  @DisplayName("Should echo or clear fulfillment mode on full-state line update")
+  void shouldEchoOrClearFulfillmentModeOnFullStateLineUpdate() {
+    UUID lineId = UUID.randomUUID();
+    QuoteLine line = quoteLine("GBP", "100.00", "2.000");
+    line.setId(lineId);
+    line.applyManualFulfillmentMode(FulfillmentMode.MAKE_TO_ORDER);
+    quote.addLine(line);
+
+    UpdateQuoteLineRequest req = new UpdateQuoteLineRequest();
+    req.setRequestedQty(new BigDecimal("2.000"));
+    req.setUnit("KG");
+    req.setOfferedPrice(new BigDecimal("100.00"));
+    req.setFulfillmentMode(FulfillmentMode.MAKE_TO_ORDER);
+
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(policyService.getActivePolicy("FABRIC")).thenReturn(new DiscountPolicy());
+    when(pricingEngineService.evaluatePrice(any(), any(), any(), any()))
+        .thenReturn(pricingResult());
+    when(tenantReportingCurrencyPort.getReportingCurrency(tenantId)).thenReturn("GBP");
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Quote echoed = quoteService.updateQuoteLine(quoteId, lineId, req);
+
+    QuoteLine echoedLine = echoed.getLines().get(0);
+    assertEquals(FulfillmentMode.MAKE_TO_ORDER, echoedLine.getFulfillmentMode());
+    assertEquals(
+        FulfillmentDeterminationStatus.CONFIRMED, echoedLine.getFulfillmentDeterminationStatus());
+    assertEquals(
+        FulfillmentDeterminationMethod.MANUAL, echoedLine.getFulfillmentDeterminationMethod());
+
+    req.setFulfillmentMode(null);
+    Quote cleared = quoteService.updateQuoteLine(quoteId, lineId, req);
+
+    QuoteLine updatedLine = cleared.getLines().get(0);
+    assertNull(updatedLine.getFulfillmentMode());
+    assertEquals(
+        FulfillmentDeterminationStatus.PENDING, updatedLine.getFulfillmentDeterminationStatus());
+    assertNull(updatedLine.getFulfillmentDeterminationMethod());
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -35,6 +35,10 @@ import com.fabricmanagement.sales.color.app.SalesColorService;
 import com.fabricmanagement.sales.color.app.SalesColorSnapshot;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
 import com.fabricmanagement.sales.lot.app.SalesLotService;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService.PricingResult;
@@ -110,6 +114,7 @@ class QuoteServiceTest {
   @Mock private SalesLotService salesLotService;
   @Mock private StockUnitSoftHoldPort stockUnitSoftHoldPort;
   @Mock private BatchLotQuantityIntentPort batchLotQuantityIntentPort;
+  @Mock private DefaultOwnerPolicy defaultOwnerPolicy;
 
   @InjectMocks private QuoteService quoteService;
 
@@ -144,12 +149,70 @@ class QuoteServiceTest {
     req.setCurrency("GBP");
     req.setValidUntil(LocalDate.now().plusDays(5));
 
+    when(defaultOwnerPolicy.resolve(any(OwnerResolutionContext.class)))
+        .thenReturn(
+            new OwnerResolution(req.getAssignedToId(), OwnerResolutionReason.EXPLICIT_OVERRIDE));
     when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
 
     Quote created = quoteService.createQuote(req);
 
     assertEquals("GBP", created.getCurrency());
     assertEquals(QuoteStatus.DRAFT, created.getStatus());
+  }
+
+  @Test
+  @DisplayName("Should use creator only for the temporary triage bridge")
+  void shouldUseCreatorForTemporaryTriageBridge() {
+    QuoteCreateRequest req = new QuoteCreateRequest();
+    req.setCustomerId(customerId);
+    req.setModuleType("FABRIC");
+    req.setQuoteNumber("Q-2026-TRIAGE");
+    req.setCurrency("GBP");
+    req.setValidUntil(LocalDate.now().plusDays(5));
+    when(defaultOwnerPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, null)))
+        .thenReturn(new OwnerResolution(null, OwnerResolutionReason.TRIAGE_REQUIRED));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Quote created = quoteService.createQuote(req);
+
+    assertEquals(userId, created.getAssignedToId());
+    assertNotNull(created.getAssignedToId());
+  }
+
+  @Test
+  @DisplayName("Should not create quote when customer eligibility fails")
+  void shouldNotCreateQuoteWhenCustomerEligibilityFails() {
+    QuoteCreateRequest req = new QuoteCreateRequest();
+    req.setCustomerId(customerId);
+    req.setModuleType("FABRIC");
+    req.setQuoteNumber("Q-2026-BAD-CUSTOMER");
+    req.setCurrency("GBP");
+    req.setValidUntil(LocalDate.now().plusDays(5));
+    when(defaultOwnerPolicy.resolve(any(OwnerResolutionContext.class)))
+        .thenThrow(new NotFoundException("Customer not found: " + customerId));
+
+    assertThrows(NotFoundException.class, () -> quoteService.createQuote(req));
+
+    verify(quoteRepository, never()).save(any());
+  }
+
+  @Test
+  @DisplayName("Should not create quote for a non-customer or inactive partner")
+  void shouldNotCreateQuoteWhenCustomerIsNotEligible() {
+    QuoteCreateRequest req = new QuoteCreateRequest();
+    req.setCustomerId(customerId);
+    req.setModuleType("FABRIC");
+    req.setQuoteNumber("Q-2026-INELIGIBLE-CUSTOMER");
+    req.setCurrency("GBP");
+    req.setValidUntil(LocalDate.now().plusDays(5));
+    when(defaultOwnerPolicy.resolve(any(OwnerResolutionContext.class)))
+        .thenThrow(SalesDomainException.customerNotEligible(customerId.toString()));
+
+    SalesDomainException error =
+        assertThrows(SalesDomainException.class, () -> quoteService.createQuote(req));
+
+    assertEquals("SALES_020_CUSTOMER_NOT_ELIGIBLE", error.getErrorCode());
+    verify(quoteRepository, never()).save(any());
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/sales/quote/domain/QuoteFulfillmentTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/domain/QuoteFulfillmentTest.java
@@ -1,0 +1,57 @@
+package com.fabricmanagement.sales.quote.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class QuoteFulfillmentTest {
+
+  @Test
+  void manualModeDerivesConfirmedManualAndNullClearsToPending() {
+    QuoteLine line = new QuoteLine();
+
+    assertThat(line.getFulfillmentMode()).isNull();
+    assertThat(line.getFulfillmentDeterminationStatus())
+        .isEqualTo(FulfillmentDeterminationStatus.PENDING);
+    assertThat(line.getFulfillmentDeterminationMethod()).isNull();
+
+    line.applyManualFulfillmentMode(FulfillmentMode.MAKE_TO_ORDER);
+
+    assertThat(line.getFulfillmentMode()).isEqualTo(FulfillmentMode.MAKE_TO_ORDER);
+    assertThat(line.getFulfillmentDeterminationStatus())
+        .isEqualTo(FulfillmentDeterminationStatus.CONFIRMED);
+    assertThat(line.getFulfillmentDeterminationMethod())
+        .isEqualTo(FulfillmentDeterminationMethod.MANUAL);
+
+    line.applyManualFulfillmentMode(null);
+
+    assertThat(line.getFulfillmentMode()).isNull();
+    assertThat(line.getFulfillmentDeterminationStatus())
+        .isEqualTo(FulfillmentDeterminationStatus.PENDING);
+    assertThat(line.getFulfillmentDeterminationMethod()).isNull();
+  }
+
+  @Test
+  void mixedFulfillmentIsDerivedFromDistinctNonNullLineModes() {
+    Quote quote = new Quote();
+    QuoteLine pending = new QuoteLine();
+    QuoteLine stock = new QuoteLine();
+    stock.applyManualFulfillmentMode(FulfillmentMode.STOCK);
+    QuoteLine production = new QuoteLine();
+    production.applyManualFulfillmentMode(FulfillmentMode.MAKE_TO_ORDER);
+
+    quote.addLine(pending);
+    assertThat(quote.isMixedFulfillment()).isFalse();
+
+    quote.addLine(stock);
+    assertThat(quote.isMixedFulfillment()).isFalse();
+
+    QuoteLine anotherStock = new QuoteLine();
+    anotherStock.applyManualFulfillmentMode(FulfillmentMode.STOCK);
+    quote.addLine(anotherStock);
+    assertThat(quote.isMixedFulfillment()).isFalse();
+
+    quote.addLine(production);
+    assertThat(quote.isMixedFulfillment()).isTrue();
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/dto/QuoteRequestValidationTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/dto/QuoteRequestValidationTest.java
@@ -165,6 +165,14 @@ class QuoteRequestValidationTest {
     return request;
   }
 
+  @Test
+  void assignedToIdIsAnOptionalOwnerOverride() {
+    QuoteCreateRequest request = validCreateRequest();
+    request.setAssignedToId(null);
+
+    assertThat(violatedFields(request)).doesNotContain("assignedToId");
+  }
+
   private static Set<String> violatedFields(Object request) {
     return validator.validate(request).stream()
         .map(violation -> violation.getPropertyPath().toString())

--- a/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
@@ -1,10 +1,14 @@
 package com.fabricmanagement.sales.quote.infra.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationMethod;
+import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationStatus;
+import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
 import com.fabricmanagement.sales.quote.domain.Quote;
 import com.fabricmanagement.sales.quote.domain.QuoteLine;
 import com.fabricmanagement.sales.quote.domain.QuotePriceZone;
@@ -21,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -156,6 +161,30 @@ class QuoteRepositoryIntegrationTest extends AbstractIntegrationTest {
 
     assertThat(counts).containsEntry(QuoteStatus.DRAFT, 1L).containsEntry(QuoteStatus.EXPIRED, 1L);
     assertThat(counts).hasSize(2);
+  }
+
+  @Test
+  @DisplayName("fulfillment mode and status combination is protected by a database constraint")
+  void fulfillmentModeStatusCombination_isProtectedByDatabaseConstraint() {
+    Quote invalid = quoteWithLine();
+    QuoteLine line = invalid.getLines().get(0);
+    line.setFulfillmentMode(FulfillmentMode.STOCK);
+    line.setFulfillmentDeterminationStatus(FulfillmentDeterminationStatus.PENDING);
+    line.setFulfillmentDeterminationMethod(FulfillmentDeterminationMethod.MANUAL);
+
+    assertThatThrownBy(() -> persist(invalid)).isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("fulfillment mode and method combination is protected by a database constraint")
+  void fulfillmentModeMethodCombination_isProtectedByDatabaseConstraint() {
+    Quote invalid = quoteWithLine();
+    QuoteLine line = invalid.getLines().get(0);
+    line.setFulfillmentMode(FulfillmentMode.STOCK);
+    line.setFulfillmentDeterminationStatus(FulfillmentDeterminationStatus.CONFIRMED);
+    line.setFulfillmentDeterminationMethod(null);
+
+    assertThatThrownBy(() -> persist(invalid)).isInstanceOf(DataIntegrityViolationException.class);
   }
 
   private UUID persistQuoteWithLine() {


### PR DESCRIPTION
Add FulfillmentMode / FulfillmentDeterminationStatus / FulfillmentDeterminationMethod to QuoteLine. The write request carries fulfillmentMode only; the backend derives the other two axes (null -> PENDING/null, a mode -> CONFIRMED/MANUAL). reviseQuote copies all three fields verbatim so a revised sent quote keeps its fulfilment decision. Expose a derived mixedFulfillment on QuoteResponse. Guard the mode/status and mode/method invariants with database CHECK constraints. Regenerate the OpenAPI contract.

Routing Spine Foundation slice 1 of 4.