### PR TITLE
feat(sales): add owner display names and account-team candidates (RSF…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -39140,6 +39140,77 @@ paths:
       summary: Add or reactivate a customer account-team member
       tags:
       - Customer Account Team
+  /api/v1/sales/customers/{customerId}/account-team/candidates:
+    get:
+      operationId: listCandidates
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseListCustomerAccountTeamCandidateResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List active users selectable for a customer's account team
+      tags:
+      - Customer Account Team
   /api/v1/sales/customers/{customerId}/account-team/{userId}:
     delete:
       operationId: deactivateMember
@@ -46871,6 +46942,26 @@ components:
           type: array
           items:
             type: string
+    ApiResponseListCustomerAccountTeamCandidateResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerAccountTeamCandidateResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseListDashboardWidgetDto:
       type: object
       properties:
@@ -54063,6 +54154,18 @@ components:
           format: int32
         workLocationLabel:
           type: string
+    CustomerAccountTeamCandidateResponse:
+      type: object
+      properties:
+        displayName:
+          type:
+          - string
+          - "null"
+        userId:
+          type: string
+          format: uuid
+      required:
+      - userId
     CustomerAccountTeamMemberResponse:
       type: object
       properties:
@@ -54081,6 +54184,10 @@ components:
     CustomerAccountTeamResponse:
       type: object
       properties:
+        acquiredByDisplayName:
+          type:
+          - string
+          - "null"
         acquiredById:
           type:
           - string
@@ -54089,6 +54196,10 @@ components:
         customerId:
           type: string
           format: uuid
+        defaultOwnerDisplayName:
+          type:
+          - string
+          - "null"
         defaultOwnerId:
           type:
           - string

--- a/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamController.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamController.java
@@ -4,11 +4,13 @@ import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.web.ApiResponse;
 import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
 import com.fabricmanagement.sales.ownership.dto.AddCustomerAccountTeamMemberRequest;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamCandidateResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -38,6 +40,16 @@ public class CustomerAccountTeamController {
     return ResponseEntity.ok(
         ApiResponse.success(
             accountTeamService.getAccountTeam(TenantContext.requireTenantId(), customerId)));
+  }
+
+  @GetMapping("/candidates")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'write')")
+  @Operation(summary = "List active users selectable for a customer's account team")
+  public ResponseEntity<ApiResponse<List<CustomerAccountTeamCandidateResponse>>> listCandidates(
+      @PathVariable UUID customerId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            accountTeamService.listCandidates(TenantContext.requireTenantId(), customerId)));
   }
 
   @PostMapping

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamService.java
@@ -1,6 +1,7 @@
 package com.fabricmanagement.sales.ownership.app;
 
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.user.app.UserDisplayNameResolver;
 import com.fabricmanagement.platform.user.app.UserQueryService;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
@@ -8,12 +9,16 @@ import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
 import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamCandidateResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
 import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,9 +27,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CustomerAccountTeamService {
 
+  private static final Comparator<CustomerAccountTeamCandidateResponse> CANDIDATE_ORDER =
+      Comparator.comparing(
+              CustomerAccountTeamCandidateResponse::displayName,
+              Comparator.nullsLast(String.CASE_INSENSITIVE_ORDER))
+          .thenComparing(CustomerAccountTeamCandidateResponse::userId);
+
   private final CustomerEligibilityService customerEligibilityService;
   private final CustomerAccountTeamMemberRepository memberRepository;
   private final UserQueryService userQueryService;
+  private final UserDisplayNameResolver userDisplayNameResolver;
   private final DefaultOwnerPolicy defaultOwnerPolicy;
 
   @Transactional(readOnly = true)
@@ -45,9 +57,33 @@ public class CustomerAccountTeamService {
     return new CustomerAccountTeamResponse(
         customer.customerId(),
         customer.acquiredById(),
+        resolveDisplayName(tenantId, customer.acquiredById()),
         resolution.ownerId(),
+        resolveDisplayName(tenantId, resolution.ownerId()),
         resolution.reason(),
         members);
+  }
+
+  @Transactional(readOnly = true)
+  public List<CustomerAccountTeamCandidateResponse> listCandidates(UUID tenantId, UUID customerId) {
+    CustomerEligibilityService.EligibleCustomer customer =
+        customerEligibilityService.requireEligible(tenantId, customerId);
+    Set<UUID> activeMemberIds =
+        memberRepository
+            .findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+                tenantId, customer.customerId())
+            .stream()
+            .filter(member -> Boolean.TRUE.equals(member.getIsActive()))
+            .map(CustomerAccountTeamMember::getUserId)
+            .collect(Collectors.toSet());
+
+    return userQueryService.findByTenant(tenantId).stream()
+        .filter(user -> tenantId.equals(user.getTenantId()))
+        .filter(user -> Boolean.TRUE.equals(user.getIsActive()))
+        .filter(user -> !activeMemberIds.contains(user.getId()))
+        .map(user -> new CustomerAccountTeamCandidateResponse(user.getId(), user.getDisplayName()))
+        .sorted(CANDIDATE_ORDER)
+        .toList();
   }
 
   @Transactional
@@ -89,6 +125,12 @@ public class CustomerAccountTeamService {
     return userQueryService
         .findById(tenantId, userId)
         .orElseThrow(() -> new NotFoundException("User not found: " + userId));
+  }
+
+  private String resolveDisplayName(UUID tenantId, UUID userId) {
+    return userId == null
+        ? null
+        : userDisplayNameResolver.resolveDisplayName(tenantId, userId).orElse(null);
   }
 
   private CustomerAccountTeamMemberResponse toResponse(

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamCandidateResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamCandidateResponse.java
@@ -1,0 +1,8 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.UUID;
+
+public record CustomerAccountTeamCandidateResponse(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID userId,
+    @Schema(nullable = true) String displayName) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerAccountTeamResponse.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 public record CustomerAccountTeamResponse(
     UUID customerId,
     @Schema(nullable = true) UUID acquiredById,
+    @Schema(nullable = true) String acquiredByDisplayName,
     @Schema(nullable = true) UUID defaultOwnerId,
+    @Schema(nullable = true) String defaultOwnerDisplayName,
     OwnerResolutionReason defaultOwnerReason,
     List<CustomerAccountTeamMemberResponse> members) {}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
@@ -78,7 +78,7 @@ class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
             UUID.class,
             organizationName);
     UUID ownerId = findUserIdByContact(ownerEmail);
-    UUID realUserId = insertRealUser(tenantId);
+    UUID realUserId = insertRealUser(tenantId, ownerId);
     Timestamp trialStartedAt = tenantTimestamp(tenantId, "trial_started_at");
     Timestamp trialEndsAt = tenantTimestamp(tenantId, "trial_ends_at");
     UUID mutatedSeedUserId =
@@ -118,12 +118,17 @@ class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
         contactValue);
   }
 
-  private UUID insertRealUser(UUID tenantId) {
+  private UUID insertRealUser(UUID tenantId, UUID ownerId) {
     UUID organizationId =
         jdbc.queryForObject(
-            "SELECT id FROM common_company.common_organization WHERE tenant_id = ? LIMIT 1",
+            """
+            SELECT organization_id
+            FROM common_user.common_user
+            WHERE tenant_id = ? AND id = ?
+            """,
             UUID.class,
-            tenantId);
+            tenantId,
+            ownerId);
     UUID roleId =
         jdbc.queryForObject(
             "SELECT id FROM common_user.common_role WHERE tenant_id = ? AND role_code = 'WORKER' LIMIT 1",

--- a/src/test/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamControllerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/api/controller/CustomerAccountTeamControllerTest.java
@@ -14,6 +14,7 @@ import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import com.fabricmanagement.common.infrastructure.security.SpELPermissionEvaluator;
 import com.fabricmanagement.sales.ownership.app.CustomerAccountTeamService;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamCandidateResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
 import java.util.List;
 import java.util.UUID;
@@ -64,7 +65,13 @@ class CustomerAccountTeamControllerTest {
     when(accountTeamService.getAccountTeam(tenantId, customerId))
         .thenReturn(
             new CustomerAccountTeamResponse(
-                customerId, null, null, OwnerResolutionReason.TRIAGE_REQUIRED, List.of()));
+                customerId,
+                null,
+                null,
+                null,
+                null,
+                OwnerResolutionReason.TRIAGE_REQUIRED,
+                List.of()));
 
     mockMvc
         .perform(get("/api/v1/sales/customers/{customerId}/account-team", customerId))
@@ -91,5 +98,35 @@ class CustomerAccountTeamControllerTest {
         .andExpect(jsonPath("$.errors.userId").value("User ID is required"));
 
     verifyNoInteractions(accountTeamService);
+  }
+
+  @Test
+  @WithMockUser
+  void candidatesRejectsSalesReadWithoutSalesWrite() throws Exception {
+    UUID customerId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("read"))).thenReturn(true);
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("write"))).thenReturn(false);
+
+    mockMvc
+        .perform(get("/api/v1/sales/customers/{customerId}/account-team/candidates", customerId))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(accountTeamService);
+  }
+
+  @Test
+  @WithMockUser
+  void candidatesReturnsThinProjectionWithSalesWrite() throws Exception {
+    UUID customerId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    when(authEvaluator.can(any(Authentication.class), eq("sales"), eq("write"))).thenReturn(true);
+    when(accountTeamService.listCandidates(tenantId, customerId))
+        .thenReturn(List.of(new CustomerAccountTeamCandidateResponse(userId, "Emma Clarke")));
+
+    mockMvc
+        .perform(get("/api/v1/sales/customers/{customerId}/account-team/candidates", customerId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.data[0].userId").value(userId.toString()))
+        .andExpect(jsonPath("$.data[0].displayName").value("Emma Clarke"));
   }
 }

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerAccountTeamServiceTest.java
@@ -3,9 +3,11 @@ package com.fabricmanagement.sales.ownership.app;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.user.app.UserDisplayNameResolver;
 import com.fabricmanagement.platform.user.app.UserQueryService;
 import com.fabricmanagement.platform.user.dto.UserDto;
 import com.fabricmanagement.sales.common.exception.SalesDomainException;
@@ -14,6 +16,7 @@ import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamCandidateResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamMemberResponse;
 import com.fabricmanagement.sales.ownership.dto.CustomerAccountTeamResponse;
 import com.fabricmanagement.sales.ownership.infra.repository.CustomerAccountTeamMemberRepository;
@@ -34,6 +37,7 @@ class CustomerAccountTeamServiceTest {
   @Mock private CustomerEligibilityService customerEligibilityService;
   @Mock private CustomerAccountTeamMemberRepository memberRepository;
   @Mock private UserQueryService userQueryService;
+  @Mock private UserDisplayNameResolver userDisplayNameResolver;
   @Mock private DefaultOwnerPolicy defaultOwnerPolicy;
   @InjectMocks private CustomerAccountTeamService service;
 
@@ -134,8 +138,28 @@ class CustomerAccountTeamServiceTest {
   }
 
   @Test
-  void returnsStableTriagePreviewWithoutViewerFallback() {
+  void resolvesAcquirerAndDefaultOwnerNamesWhenAcquirerIsNotATeamMember() {
     eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    when(defaultOwnerPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, null)))
+        .thenReturn(new OwnerResolution(acquirerId, OwnerResolutionReason.ACQUIRER));
+    when(userDisplayNameResolver.resolveDisplayName(tenantId, acquirerId))
+        .thenReturn(Optional.of("Emma Clarke"));
+
+    CustomerAccountTeamResponse response = service.getAccountTeam(tenantId, customerId);
+
+    assertThat(response.acquiredById()).isEqualTo(acquirerId);
+    assertThat(response.acquiredByDisplayName()).isEqualTo("Emma Clarke");
+    assertThat(response.defaultOwnerId()).isEqualTo(acquirerId);
+    assertThat(response.defaultOwnerDisplayName()).isEqualTo("Emma Clarke");
+    assertThat(response.defaultOwnerReason()).isEqualTo(OwnerResolutionReason.ACQUIRER);
+  }
+
+  @Test
+  void returnsNullDisplayNamesWhenOwnerAndAcquirerIdsAreNull() {
+    eligibleCustomer(null);
     when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
             tenantId, customerId))
         .thenReturn(List.of());
@@ -144,9 +168,12 @@ class CustomerAccountTeamServiceTest {
 
     CustomerAccountTeamResponse response = service.getAccountTeam(tenantId, customerId);
 
+    assertThat(response.acquiredById()).isNull();
+    assertThat(response.acquiredByDisplayName()).isNull();
     assertThat(response.defaultOwnerId()).isNull();
+    assertThat(response.defaultOwnerDisplayName()).isNull();
     assertThat(response.defaultOwnerReason()).isEqualTo(OwnerResolutionReason.TRIAGE_REQUIRED);
-    assertThat(response.acquiredById()).isEqualTo(acquirerId);
+    verifyNoInteractions(userDisplayNameResolver);
   }
 
   @Test
@@ -172,8 +199,123 @@ class CustomerAccountTeamServiceTest {
         .satisfies(returnedMember -> assertThat(returnedMember.active()).isFalse());
   }
 
-  private void eligibleCustomer() {
+  @Test
+  void returnsOnlyActiveUsersFromTheRequestedTenantAsCandidates() {
+    UUID activeUserId = UUID.randomUUID();
+    UUID inactiveUserId = UUID.randomUUID();
+    UUID otherTenantId = UUID.randomUUID();
+    eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    when(userQueryService.findByTenant(tenantId))
+        .thenReturn(
+            List.of(
+                user(activeUserId, tenantId, "Active Rep", true),
+                user(inactiveUserId, tenantId, "Inactive Rep", false),
+                user(UUID.randomUUID(), otherTenantId, "Other Tenant Rep", true)));
+
+    List<CustomerAccountTeamCandidateResponse> candidates =
+        service.listCandidates(tenantId, customerId);
+
+    assertThat(candidates)
+        .extracting(CustomerAccountTeamCandidateResponse::userId)
+        .containsExactly(activeUserId);
+  }
+
+  @Test
+  void excludesActiveMembersAndKeepsDeactivatedMembersReAddable() {
+    UUID activeMemberId = UUID.randomUUID();
+    UUID formerMemberId = UUID.randomUUID();
+    CustomerAccountTeamMember activeMember =
+        CustomerAccountTeamMember.create(customerId, activeMemberId);
+    CustomerAccountTeamMember formerMember =
+        CustomerAccountTeamMember.create(customerId, formerMemberId);
+    formerMember.deactivate();
+    eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of(activeMember, formerMember));
+    when(userQueryService.findByTenant(tenantId))
+        .thenReturn(
+            List.of(
+                user(activeMemberId, tenantId, "Active Member", true),
+                user(formerMemberId, tenantId, "Former Member", true)));
+
+    List<CustomerAccountTeamCandidateResponse> candidates =
+        service.listCandidates(tenantId, customerId);
+
+    assertThat(candidates)
+        .extracting(CustomerAccountTeamCandidateResponse::userId)
+        .containsExactly(formerMemberId);
+  }
+
+  @Test
+  void ordersCandidatesDeterministicallyByDisplayNameThenUserIdWithNullsLast() {
+    UUID firstAlexId = UUID.fromString("10000000-0000-4000-8000-000000000001");
+    UUID secondAlexId = UUID.fromString("20000000-0000-4000-8000-000000000002");
+    UUID nullNameId = UUID.fromString("30000000-0000-4000-8000-000000000003");
+    eligibleCustomer();
+    when(memberRepository.findAllByTenantIdAndCustomerIdOrderByCreatedAtAscUserIdAsc(
+            tenantId, customerId))
+        .thenReturn(List.of());
+    when(userQueryService.findByTenant(tenantId))
+        .thenReturn(
+            List.of(
+                user(nullNameId, tenantId, null, true),
+                user(secondAlexId, tenantId, "alex", true),
+                user(firstAlexId, tenantId, "Alex", true)));
+
+    List<CustomerAccountTeamCandidateResponse> firstCall =
+        service.listCandidates(tenantId, customerId);
+    List<CustomerAccountTeamCandidateResponse> secondCall =
+        service.listCandidates(tenantId, customerId);
+
+    assertThat(firstCall).isEqualTo(secondCall);
+    assertThat(firstCall)
+        .extracting(CustomerAccountTeamCandidateResponse::userId)
+        .containsExactly(firstAlexId, secondAlexId, nullNameId);
+  }
+
+  @Test
+  void rejectsIneligibleCustomerBeforeReadingCandidates() {
     when(customerEligibilityService.requireEligible(tenantId, customerId))
-        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, acquirerId));
+        .thenThrow(SalesDomainException.customerNotEligible(customerId.toString()));
+
+    assertThatThrownBy(() -> service.listCandidates(tenantId, customerId))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> assertThat(error.getErrorCode()).isEqualTo("SALES_020_CUSTOMER_NOT_ELIGIBLE"));
+
+    verifyNoInteractions(memberRepository, userQueryService);
+  }
+
+  @Test
+  void rejectsUnknownCustomerBeforeReadingCandidates() {
+    when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenThrow(new NotFoundException("Customer not found: " + customerId));
+
+    assertThatThrownBy(() -> service.listCandidates(tenantId, customerId))
+        .isInstanceOf(NotFoundException.class);
+
+    verifyNoInteractions(memberRepository, userQueryService);
+  }
+
+  private void eligibleCustomer() {
+    eligibleCustomer(acquirerId);
+  }
+
+  private void eligibleCustomer(UUID acquiredById) {
+    when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, acquiredById));
+  }
+
+  private UserDto user(UUID userId, UUID userTenantId, String displayName, boolean active) {
+    return UserDto.builder()
+        .id(userId)
+        .tenantId(userTenantId)
+        .displayName(displayName)
+        .isActive(active)
+        .build();
   }
 }


### PR DESCRIPTION
…-2a)

Resolve acquiredByDisplayName and defaultOwnerDisplayName server-side so the ownership summary needs no second directory call, and add a sales-gated GET /account-team/candidates for the add-member picker.

The picker cannot reuse GET /api/v1/common/users: that endpoint enforces members:read in its method body and narrows results by the requester's data scope, so a sales:write user would get 403 inside the modal, and a DEPARTMENT -scoped user would get a silently truncated candidate list. Sales exposes its own thin two-field projection instead, gated on sales:write so visibility never exceeds the ability to act.

Candidates are active tenant users minus currently active members; deactivated memberships stay listed, since addMember reactivates them and that is the only route back for a former member. SALES_019 remains for races and direct API callers.