### PR TITLE
feat(sales): add effective-dated commercial assignment and relationsh…

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -120,6 +120,8 @@ tags:
   name: Role
 - description: User operations
   name: User
+- description: Derived queue of customers requiring a commercial representative
+  name: Sales Ownership Triage
 - description: Supplier Quote Management API
   name: Supplier Quote
 - description: FX Exposure summary operations
@@ -195,6 +197,8 @@ tags:
   name: Batch
 - description: Hr Policy Pack operations
   name: Hr Policy Pack
+- description: Effective-dated primary commercial representative history
+  name: Customer Commercial Assignments
 - description: Whisper operations
   name: Whisper
 - description: Endpoints for PLG Simulation Playground
@@ -5302,7 +5306,7 @@ paths:
       - Department
   /api/v1/common/notifications:
     get:
-      operationId: list_6
+      operationId: list_7
       parameters:
       - in: query
         name: pageRequest
@@ -24270,7 +24274,7 @@ paths:
       - Notifications
   /api/v1/platform/fiber-requests:
     get:
-      operationId: list_5
+      operationId: list_6
       parameters:
       - in: query
         name: status
@@ -24560,7 +24564,7 @@ paths:
       - Fiber Request Platform
   /api/v1/platform/notifications:
     get:
-      operationId: list_4
+      operationId: list_5
       parameters:
       - in: query
         name: pageRequest
@@ -39288,6 +39292,225 @@ paths:
       summary: Deactivate a customer account-team member
       tags:
       - Customer Account Team
+  /api/v1/sales/customers/{customerId}/commercial-assignments:
+    post:
+      operationId: assignPrimary
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignPrimaryRepresentativeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCustomerCommercialAssignmentResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Assign the primary commercial representative
+      tags:
+      - Customer Commercial Assignments
+  /api/v1/sales/customers/{customerId}/commercial-assignments/current:
+    get:
+      operationId: getCurrent
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCustomerCommercialAssignmentResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get the current commercial assignment
+      tags:
+      - Customer Commercial Assignments
+  /api/v1/sales/customers/{customerId}/commercial-assignments/history:
+    get:
+      operationId: getHistory
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseListCustomerCommercialAssignmentResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Get effective-dated commercial assignment history
+      tags:
+      - Customer Commercial Assignments
   /api/v1/sales/lots:
     get:
       operationId: listSalesLots
@@ -40645,6 +40868,173 @@ paths:
       summary: Ship an order
       tags:
       - Sales Orders
+  /api/v1/sales/ownership/triage:
+    get:
+      operationId: list_4
+      parameters:
+      - description: Zero-based page index (0..N)
+        in: query
+        name: page
+        required: false
+        schema:
+          type: integer
+          default: 0
+          minimum: 0
+      - description: The size of the page to be returned
+        in: query
+        name: size
+        required: false
+        schema:
+          type: integer
+          default: 20
+          minimum: 1
+      - description: "Sorting criteria in the format: property,(asc|desc). Default\
+          \ sort order is ascending. Multiple sort criteria are supported."
+        in: query
+        name: sort
+        required: false
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponsePagedResponseOwnershipTriageCaseResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: List current sales ownership triage cases
+      tags:
+      - Sales Ownership Triage
+  /api/v1/sales/ownership/triage/{customerId}/resolve:
+    post:
+      operationId: resolve
+      parameters:
+      - in: path
+        name: customerId
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignPrimaryRepresentativeRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/ApiResponseCustomerCommercialAssignmentResponse"
+          description: OK
+        "400":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Bad Request
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unauthorized
+        "403":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Forbidden
+        "404":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Not Found
+        "409":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Conflict
+        "422":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Unprocessable Entity
+        "429":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Too Many Requests
+        "500":
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ApiProblemDetail"
+          description: Internal Server Error
+      summary: Resolve a triage case by assigning its primary representative
+      tags:
+      - Sales Ownership Triage
   /api/v1/sales/products:
     get:
       operationId: listCatalog
@@ -46319,6 +46709,24 @@ components:
           type: array
           items:
             type: string
+    ApiResponseCustomerCommercialAssignmentResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/CustomerCommercialAssignmentResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
     ApiResponseDashboardConfigDto:
       type: object
       properties:
@@ -46949,6 +47357,26 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/CustomerAccountTeamCandidateResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponseListCustomerCommercialAssignmentResponse:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomerCommercialAssignmentResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -48591,6 +49019,24 @@ components:
       properties:
         data:
           $ref: "#/components/schemas/PagedResponseNotificationLogResponse"
+        error:
+          $ref: "#/components/schemas/ErrorDetail"
+        message:
+          type: string
+        success:
+          type: boolean
+        timestamp:
+          type: string
+          format: date-time
+        warnings:
+          type: array
+          items:
+            type: string
+    ApiResponsePagedResponseOwnershipTriageCaseResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/PagedResponseOwnershipTriageCaseResponse"
         error:
           $ref: "#/components/schemas/ErrorDetail"
         message:
@@ -50382,6 +50828,14 @@ components:
           type: boolean
       required:
       - departmentId
+    AssignPrimaryRepresentativeRequest:
+      type: object
+      properties:
+        representativeId:
+          type: string
+          format: uuid
+      required:
+      - representativeId
     AssignWorkLocationRequest:
       type: object
       properties:
@@ -54209,6 +54663,11 @@ components:
           type: string
           enum:
           - EXPLICIT_OVERRIDE
+          - PRIMARY_ASSIGNMENT
+          - CREATOR_FALLBACK
+          - OPTIONAL_UNASSIGNED
+          - OWNERSHIP_EXEMPT
+          - LEGACY_UNKNOWN
           - ACQUIRER
           - ACCOUNT_TEAM
           - TRIAGE_REQUIRED
@@ -54236,6 +54695,79 @@ components:
           minLength: 0
       required:
       - token
+    CustomerCommercialAssignmentResponse:
+      type: object
+      properties:
+        closedBySystemCode:
+          type:
+          - string
+          - "null"
+        closedByType:
+          type:
+          - string
+          - "null"
+          enum:
+          - USER
+          - SYSTEM
+        closedByUserId:
+          type:
+          - string
+          - "null"
+          format: uuid
+        closureReason:
+          type:
+          - string
+          - "null"
+          enum:
+          - SUPERSEDED
+          - REPRESENTATIVE_DEACTIVATED
+        customerId:
+          type: string
+          format: uuid
+        decidedBySystemCode:
+          type:
+          - string
+          - "null"
+        decidedByType:
+          type: string
+          enum:
+          - USER
+          - SYSTEM
+        decidedByUserId:
+          type:
+          - string
+          - "null"
+          format: uuid
+        id:
+          type: string
+          format: uuid
+        policyVersion:
+          type: string
+        representativeId:
+          type: string
+          format: uuid
+        source:
+          type: string
+          enum:
+          - ACQUISITION
+          - MANUAL
+          - TRIAGE_RESOLUTION
+          - BACKFILL_ACQUIRER
+          - BACKFILL_SOLE_TEAM_MEMBER
+          - SYSTEM_POLICY
+        supersedesAssignmentId:
+          type:
+          - string
+          - "null"
+          format: uuid
+        validFrom:
+          type: string
+          format: date-time
+        validTo:
+          type:
+          - string
+          - "null"
+          format: date-time
     CustomerMarginDto:
       type: object
       properties:
@@ -56823,6 +57355,40 @@ components:
           minLength: 10
       required:
       - reason
+    OwnershipTriageCaseResponse:
+      type: object
+      description: A customer currently requiring a commercial ownership assignment
+      properties:
+        ageHours:
+          type: integer
+          format: int64
+        customerId:
+          type: string
+          format: uuid
+        customerName:
+          type: string
+        gapStartedAt:
+          type: string
+          format: date-time
+        oldestUnassignedQuoteAt:
+          type:
+          - string
+          - "null"
+          format: date-time
+        unassignedOpenQuoteCount:
+          type: integer
+          format: int64
+        workAgeHours:
+          type:
+          - integer
+          - "null"
+          format: int64
+      required:
+      - ageHours
+      - customerId
+      - customerName
+      - gapStartedAt
+      - unassignedOpenQuoteCount
     PagePaymentDto:
       type: object
       properties:
@@ -57119,6 +57685,29 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/NotificationLogResponse"
+        first:
+          type: boolean
+        last:
+          type: boolean
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+    PagedResponseOwnershipTriageCaseResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/OwnershipTriageCaseResponse"
         first:
           type: boolean
         last:
@@ -59885,7 +60474,9 @@ components:
       type: object
       properties:
         assignedToId:
-          type: string
+          type:
+          - string
+          - "null"
           format: uuid
         createdAt:
           type: string
@@ -59919,6 +60510,18 @@ components:
           type: string
         notes:
           type: string
+        ownerResolutionReason:
+          type: string
+          enum:
+          - EXPLICIT_OVERRIDE
+          - PRIMARY_ASSIGNMENT
+          - CREATOR_FALLBACK
+          - OPTIONAL_UNASSIGNED
+          - OWNERSHIP_EXEMPT
+          - LEGACY_UNKNOWN
+          - ACQUIRER
+          - ACCOUNT_TEAM
+          - TRIAGE_REQUIRED
         parentQuoteId:
           type: string
           format: uuid
@@ -62780,6 +63383,11 @@ components:
           format: date-time
         customName:
           type: string
+        customerRelationshipEstablishedAt:
+          type:
+          - string
+          - "null"
+          format: date-time
         displayName:
           type: string
         id:

--- a/src/main/java/com/fabricmanagement/notification/hub/app/listener/SalesNotificationListener.java
+++ b/src/main/java/com/fabricmanagement/notification/hub/app/listener/SalesNotificationListener.java
@@ -1,0 +1,53 @@
+package com.fabricmanagement.notification.hub.app.listener;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.notification.hub.app.NotificationHubService;
+import com.fabricmanagement.notification.hub.domain.NotificationEventType;
+import com.fabricmanagement.notification.hub.domain.port.DepartmentRecipientPort;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipTriageOpenedEvent;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SalesNotificationListener {
+
+  private final NotificationHubService notificationHubService;
+  private final DepartmentRecipientPort departmentRecipientPort;
+  private final IdempotentEventHandler idempotentEventHandler;
+
+  @ApplicationModuleListener
+  public void onCustomerOwnershipTriageOpened(CustomerOwnershipTriageOpenedEvent event) {
+    TenantContext.executeInTenantContext(
+        event.getTenantId(),
+        () ->
+            idempotentEventHandler.executeOnce(
+                event.getEventId(),
+                this.getClass(),
+                "onCustomerOwnershipTriageOpened",
+                () -> notifySalesManagers(event)));
+  }
+
+  private void notifySalesManagers(CustomerOwnershipTriageOpenedEvent event) {
+    List<UUID> recipients =
+        departmentRecipientPort.findManagersByDepartmentKeyword(event.getTenantId(), "SALES");
+    if (recipients.isEmpty()) {
+      return;
+    }
+    notificationHubService.notifyAll(
+        recipients,
+        event.getTenantId(),
+        NotificationEventType.CUSTOMER_OWNERSHIP_TRIAGE_OPENED,
+        Map.of(
+            "customerName", event.getCustomerName(),
+            "gapStartedAt", event.getGapStartedAt().toString(),
+            "unassignedQuoteCount", String.valueOf(event.getUnassignedOpenQuoteCount())),
+        event.getCustomerId(),
+        "CUSTOMER");
+  }
+}

--- a/src/main/java/com/fabricmanagement/notification/hub/domain/NotificationEventType.java
+++ b/src/main/java/com/fabricmanagement/notification/hub/domain/NotificationEventType.java
@@ -30,6 +30,7 @@ public final class NotificationEventType {
   public static final String INVOICE_OVERDUE = "INVOICE_OVERDUE";
   public static final String INVOICE_DISPUTED = "INVOICE_DISPUTED";
   public static final String COST_VARIANCE_DETECTED = "COST_VARIANCE_DETECTED";
+  public static final String CUSTOMER_OWNERSHIP_TRIAGE_OPENED = "CUSTOMER_OWNERSHIP_TRIAGE_OPENED";
 
   // ---- NORMAL ----
   public static final String WORK_ORDER_APPROVED = "WORK_ORDER_APPROVED";

--- a/src/main/java/com/fabricmanagement/platform/communication/api/facade/CustomerEmailFacade.java
+++ b/src/main/java/com/fabricmanagement/platform/communication/api/facade/CustomerEmailFacade.java
@@ -1,0 +1,30 @@
+package com.fabricmanagement.platform.communication.api.facade;
+
+import com.fabricmanagement.platform.communication.app.EmailTemplateRenderer;
+import com.fabricmanagement.platform.communication.app.NotificationService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Public cross-module API for sending customer-facing transactional email. */
+@Component
+@RequiredArgsConstructor
+public class CustomerEmailFacade {
+
+  private final NotificationService notificationService;
+  private final EmailTemplateRenderer emailTemplateRenderer;
+
+  public void sendQuoteApprovalEmail(
+      UUID tenantId,
+      String recipient,
+      String subject,
+      String heading,
+      String body,
+      String cta,
+      String expires,
+      String approvalUrl) {
+    String message =
+        emailTemplateRenderer.renderQuoteApproval(heading, body, cta, expires, approvalUrl);
+    notificationService.sendNotificationSync(tenantId, recipient, subject, message);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/communication/api/facade/SystemEmailFacade.java
+++ b/src/main/java/com/fabricmanagement/platform/communication/api/facade/SystemEmailFacade.java
@@ -1,0 +1,18 @@
+package com.fabricmanagement.platform.communication.api.facade;
+
+import com.fabricmanagement.platform.communication.app.EmailOutboxService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/** Public cross-module API for queueing tenant-owned operational email. */
+@Component
+@RequiredArgsConstructor
+public class SystemEmailFacade {
+
+  private final EmailOutboxService emailOutboxService;
+
+  public void queueSystemEmail(UUID tenantId, String recipient, String subject, String htmlBody) {
+    emailOutboxService.queueSystemEmail(tenantId, recipient, subject, htmlBody);
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantClonerService.java
@@ -223,6 +223,7 @@ public class TenantClonerService {
                   "uid, certification_code, certification_name, certifying_body, description, is_active",
                   goldenTemplateId,
                   targetTenantId);
+          tablesCloned += cloneOwnershipPolicyIfMissing(jdbc, goldenTemplateId, targetTenantId);
 
           return tablesCloned;
         });
@@ -361,6 +362,7 @@ public class TenantClonerService {
               UUID goldenTemplateId = findTemplateTenantId(jdbc);
               if (goldenTemplateId != null) {
                 doClonePermissionTemplates(jdbc, goldenTemplateId, newTenantId);
+                cloneOwnershipPolicyIfMissing(jdbc, goldenTemplateId, newTenantId);
               }
 
               // 3.4 User
@@ -550,6 +552,39 @@ public class TenantClonerService {
                 + "SELECT gen_random_uuid(), ?, %s, now(), now(), 0 FROM %s WHERE tenant_id = ?",
             tableName, columns, columns, tableName);
     jdbc.update(sql, newTenantId, templateId);
+  }
+
+  private int cloneOwnershipPolicyIfMissing(
+      org.springframework.jdbc.core.JdbcTemplate jdbc, UUID sourceTenantId, UUID targetTenantId) {
+    Integer existing =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM sales.ownership_policy WHERE tenant_id = ?",
+            Integer.class,
+            targetTenantId);
+    if (existing != null && existing > 0) {
+      return 0;
+    }
+    int inserted =
+        jdbc.update(
+            """
+            INSERT INTO sales.ownership_policy (
+                id, tenant_id, uid, default_mode, mode_effective_at,
+                assignment_ladder_enabled, triage_age_threshold_hours,
+                is_active, created_at, updated_at, version
+            )
+            SELECT
+                gen_random_uuid(), ?, gen_random_uuid()::VARCHAR, default_mode, now(),
+                FALSE, triage_age_threshold_hours, TRUE, now(), now(), 0
+            FROM sales.ownership_policy
+            WHERE tenant_id = ?
+            """,
+            targetTenantId,
+            sourceTenantId);
+    if (inserted == 0) {
+      throw new IllegalStateException(
+          "Template tenant has no sales ownership policy: " + sourceTenantId);
+    }
+    return 1;
   }
 
   private void cloneHrPolicyPacks(

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -26,6 +26,8 @@ public class TenantTransactionalPurgeService {
   private static final String TENANT_DEMOMODE_CACHE = "tenant-demomode";
   private static final String TENANT_EMAIL_SANDBOX_CACHE = "tenant-emailsandbox";
   private static final String QUALITY_DECISION_PURGE_SETTING = "app.quality_decision_purge_tenant";
+  private static final String COMMERCIAL_ASSIGNMENT_PURGE_SETTING =
+      "app.customer_commercial_assignment_purge_tenant";
 
   private static final List<String> TRANSACTIONAL_TABLES =
       List.of(
@@ -138,6 +140,7 @@ public class TenantTransactionalPurgeService {
           "sales.sample_delivery",
           "sales.sample_request",
           "sales.customer_account_team_member",
+          "sales.customer_commercial_assignment",
           "sales.quote_send_request",
           "sales.quote_approval_token",
           "sales.quote_line",
@@ -243,6 +246,7 @@ public class TenantTransactionalPurgeService {
   private void deleteTransactionalRows(
       JdbcTemplate jdbc, UUID tenantId, Map<String, Integer> rows) {
     authorizeQualityDecisionPurge(jdbc, tenantId);
+    authorizeCommercialAssignmentPurge(jdbc, tenantId);
     deleteChildRowsWithoutTenantId(jdbc, tenantId, rows);
     for (String table : TRANSACTIONAL_TABLES) {
       delete(jdbc, rows, table, "DELETE FROM " + table + " WHERE tenant_id = ?", tenantId);
@@ -258,6 +262,14 @@ public class TenantTransactionalPurgeService {
         "SELECT set_config(?, ?, true)",
         String.class,
         QUALITY_DECISION_PURGE_SETTING,
+        tenantId.toString());
+  }
+
+  private void authorizeCommercialAssignmentPurge(JdbcTemplate jdbc, UUID tenantId) {
+    jdbc.queryForObject(
+        "SELECT set_config(?, ?, true)",
+        String.class,
+        COMMERCIAL_ASSIGNMENT_PURGE_SETTING,
         tenantId.toString());
   }
 

--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -139,6 +139,7 @@ public class TenantTransactionalPurgeService {
           "sales_ord.sales_order",
           "sales.sample_delivery",
           "sales.sample_request",
+          "sales.ownership_triage_case_log",
           "sales.customer_account_team_member",
           "sales.customer_commercial_assignment",
           "sales.quote_send_request",

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerOwnershipSnapshot.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerOwnershipSnapshot.java
@@ -1,5 +1,6 @@
 package com.fabricmanagement.platform.tradingpartner.app;
 
+import java.time.Instant;
 import java.util.UUID;
 
 /**
@@ -8,4 +9,8 @@ import java.util.UUID;
  * <p>This record deliberately carries no platform domain types.
  */
 public record TradingPartnerOwnershipSnapshot(
-    UUID customerId, UUID acquiredById, boolean customer, boolean transactionAllowed) {}
+    UUID customerId,
+    UUID acquiredById,
+    Instant customerRelationshipEstablishedAt,
+    boolean customer,
+    boolean transactionAllowed) {}

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerResolver.java
@@ -196,6 +196,7 @@ public class TradingPartnerResolver {
                 new TradingPartnerOwnershipSnapshot(
                     partner.getId(),
                     partner.getAcquiredById(),
+                    partner.getCustomerRelationshipEstablishedAt(),
                     partner.getPartnerType().isCustomer(),
                     partner.getStatus().isTransactionAllowed()));
   }

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerService.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerService.java
@@ -8,6 +8,8 @@ import com.fabricmanagement.platform.tradingpartner.domain.PartnerContactRole;
 import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartnerRegistry;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipEstablishedEvent;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipSourceGate;
 import com.fabricmanagement.platform.tradingpartner.domain.event.TradingPartnerCreatedEvent;
 import com.fabricmanagement.platform.tradingpartner.domain.event.TradingPartnerStatusChangedEvent;
 import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
@@ -16,6 +18,7 @@ import com.fabricmanagement.platform.tradingpartner.dto.QuickCreateCustomerReque
 import com.fabricmanagement.platform.tradingpartner.dto.TradingPartnerDto;
 import com.fabricmanagement.platform.tradingpartner.dto.UpdateTradingPartnerRequest;
 import com.fabricmanagement.platform.tradingpartner.infra.repository.TradingPartnerRepository;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,12 +105,17 @@ public class TradingPartnerService {
 
     if (existing.isPresent()) {
       TradingPartner partner = existing.get();
+      boolean wasCustomer = partner.getPartnerType().isCustomer();
       // Upgrade to BOTH if adding different type
       if (partner.getPartnerType() != request.getPartnerType()
           && partner.getPartnerType() != PartnerType.BOTH) {
         partner.upgradeToMultiType(request.getPartnerType());
         stampAcquirerIfCustomer(partner, acquiredById);
+        boolean relationshipEstablished =
+            recordRelationshipEstablishmentIfNewCustomer(partner, wasCustomer);
         TradingPartner updated = partnerRepository.save(partner);
+        publishRelationshipEstablishedIfNeeded(
+            tenantId, updated, relationshipEstablished, CustomerRelationshipSourceGate.CREATE);
         log.info(
             "Partner upgraded to BOTH: uid={}, registry={}", updated.getUid(), registry.getUid());
         return TradingPartnerDto.from(updated);
@@ -130,6 +138,7 @@ public class TradingPartnerService {
     }
 
     stampAcquirerIfCustomer(partner, acquiredById);
+    boolean relationshipEstablished = recordRelationshipEstablishmentIfNewCustomer(partner, false);
     TradingPartner saved = partnerRepository.save(partner);
 
     // Auto-create partner Organization for user management
@@ -138,6 +147,8 @@ public class TradingPartnerService {
             saved.getDisplayName(), registry.getTaxId(), saved.getUid());
     saved.setOrganizationId(partnerOrg.getId());
     saved = partnerRepository.save(saved);
+    publishRelationshipEstablishedIfNeeded(
+        tenantId, saved, relationshipEstablished, CustomerRelationshipSourceGate.CREATE);
 
     // Publish event
     eventPublisher.publish(
@@ -178,19 +189,24 @@ public class TradingPartnerService {
         partnerRepository.findByTenantIdAndRegistryId(tenantId, registry.getId());
     TradingPartner partner;
     boolean created = false;
+    boolean wasCustomer;
 
     if (existing.isPresent()) {
       partner = existing.get();
+      wasCustomer = partner.getPartnerType().isCustomer();
       partner.upgradeToMultiType(PartnerType.CUSTOMER);
     } else {
       partner = TradingPartner.create(registry, PartnerType.CUSTOMER, request.getCompanyName());
       created = true;
+      wasCustomer = false;
     }
 
     partner.setPendingAccountingReview(true);
     partner.setRelationshipMeta(
         quickCustomerRelationshipMeta(request, partner.getRelationshipMeta()));
     stampAcquirerIfCustomer(partner, acquiredById);
+    boolean relationshipEstablished =
+        recordRelationshipEstablishmentIfNewCustomer(partner, wasCustomer);
     TradingPartner saved = partnerRepository.save(partner);
 
     if (saved.getOrganizationId() == null) {
@@ -202,6 +218,8 @@ public class TradingPartnerService {
     }
 
     createQuickCustomerContacts(tenantId, saved, request.getContacts());
+    publishRelationshipEstablishedIfNeeded(
+        tenantId, saved, relationshipEstablished, CustomerRelationshipSourceGate.QUICK_CREATE);
 
     if (created) {
       eventPublisher.publish(
@@ -219,6 +237,28 @@ public class TradingPartnerService {
 
   private boolean stampAcquirerIfCustomer(TradingPartner partner, UUID acquiredById) {
     return partner.recordAcquirer(acquiredById);
+  }
+
+  private boolean recordRelationshipEstablishmentIfNewCustomer(
+      TradingPartner partner, boolean wasCustomer) {
+    return !wasCustomer && partner.recordCustomerRelationshipEstablishedAt(Instant.now());
+  }
+
+  private void publishRelationshipEstablishedIfNeeded(
+      UUID tenantId,
+      TradingPartner partner,
+      boolean relationshipEstablished,
+      CustomerRelationshipSourceGate sourceGate) {
+    if (!relationshipEstablished) {
+      return;
+    }
+    eventPublisher.publish(
+        new CustomerRelationshipEstablishedEvent(
+            tenantId,
+            partner.getId(),
+            partner.getAcquiredById(),
+            partner.getCustomerRelationshipEstablishedAt(),
+            sourceGate));
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
@@ -267,7 +307,14 @@ public class TradingPartnerService {
     if (!wasCustomer) {
       stampAcquirerIfCustomer(partner, acquiredById);
     }
+    boolean relationshipEstablished =
+        recordRelationshipEstablishmentIfNewCustomer(partner, wasCustomer);
     TradingPartner saved = partnerRepository.save(partner);
+    publishRelationshipEstablishedIfNeeded(
+        tenantId,
+        saved,
+        relationshipEstablished,
+        CustomerRelationshipSourceGate.SUPPLIER_CONVERSION);
     log.info("Partner updated: uid={}, type={}", saved.getUid(), saved.getPartnerType());
     return TradingPartnerDto.from(saved);
   }

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/TradingPartner.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/TradingPartner.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.offline.domain.OfflineMetadata;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.*;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -162,6 +163,16 @@ public class TradingPartner extends BaseEntity {
   @Column(name = "acquired_by_id")
   private UUID acquiredById;
 
+  /**
+   * Immutable timestamp at which this tenant first gained a customer relationship.
+   *
+   * <p>Legacy customer rows deliberately remain null because their historical establishment time is
+   * unknown.
+   */
+  @Setter(AccessLevel.NONE)
+  @Column(name = "customer_relationship_established_at")
+  private Instant customerRelationshipEstablishedAt;
+
   @Embedded private OfflineMetadata offlineMetadata;
 
   @Override
@@ -175,6 +186,16 @@ public class TradingPartner extends BaseEntity {
       return false;
     }
     acquiredById = acquirerId;
+    return true;
+  }
+
+  /** Records the customer relationship establishment fact exactly once. */
+  public boolean recordCustomerRelationshipEstablishedAt(Instant establishedAt) {
+    if (!partnerType.isCustomer() || customerRelationshipEstablishedAt != null) {
+      return false;
+    }
+    customerRelationshipEstablishedAt =
+        java.util.Objects.requireNonNull(establishedAt, "establishedAt must not be null");
     return true;
   }
 

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/CustomerRelationshipEstablishedEvent.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/CustomerRelationshipEstablishedEvent.java
@@ -1,0 +1,55 @@
+package com.fabricmanagement.platform.tradingpartner.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.Getter;
+
+/** Published when a tenant first establishes a customer relationship. */
+@Getter
+public class CustomerRelationshipEstablishedEvent extends DomainEvent {
+
+  private final UUID customerId;
+  private final UUID acquiredById;
+  private final Instant establishedAt;
+  private final CustomerRelationshipSourceGate sourceGate;
+
+  public CustomerRelationshipEstablishedEvent(
+      UUID tenantId,
+      UUID customerId,
+      UUID acquiredById,
+      Instant establishedAt,
+      CustomerRelationshipSourceGate sourceGate) {
+    super(tenantId, "CUSTOMER_RELATIONSHIP_ESTABLISHED");
+    this.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
+    this.acquiredById = acquiredById;
+    this.establishedAt = Objects.requireNonNull(establishedAt, "establishedAt must not be null");
+    this.sourceGate = Objects.requireNonNull(sourceGate, "sourceGate must not be null");
+  }
+
+  @JsonCreator
+  public CustomerRelationshipEstablishedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("customerId") UUID customerId,
+      @JsonProperty("acquiredById") UUID acquiredById,
+      @JsonProperty("establishedAt") Instant establishedAt,
+      @JsonProperty("sourceGate") CustomerRelationshipSourceGate sourceGate) {
+    super(
+        eventId,
+        tenantId,
+        eventType != null ? eventType : "CUSTOMER_RELATIONSHIP_ESTABLISHED",
+        occurredAt,
+        correlationId);
+    this.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
+    this.acquiredById = acquiredById;
+    this.establishedAt = Objects.requireNonNull(establishedAt, "establishedAt must not be null");
+    this.sourceGate = Objects.requireNonNull(sourceGate, "sourceGate must not be null");
+  }
+}

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/CustomerRelationshipSourceGate.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/domain/event/CustomerRelationshipSourceGate.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.platform.tradingpartner.domain.event;
+
+public enum CustomerRelationshipSourceGate {
+  CREATE,
+  QUICK_CREATE,
+  SUPPLIER_CONVERSION
+}

--- a/src/main/java/com/fabricmanagement/platform/tradingpartner/dto/TradingPartnerDto.java
+++ b/src/main/java/com/fabricmanagement/platform/tradingpartner/dto/TradingPartnerDto.java
@@ -53,6 +53,9 @@ public class TradingPartnerDto {
   @Schema(nullable = true)
   private UUID acquiredById;
 
+  @Schema(nullable = true)
+  private Instant customerRelationshipEstablishedAt;
+
   // Audit
   private Instant createdAt;
   private Boolean isActive;
@@ -87,6 +90,7 @@ public class TradingPartnerDto {
         .organizationId(tp.getOrganizationId())
         .pendingAccountingReview(tp.isPendingAccountingReview())
         .acquiredById(tp.getAcquiredById())
+        .customerRelationshipEstablishedAt(tp.getCustomerRelationshipEstablishedAt())
         .createdAt(tp.getCreatedAt())
         .isActive(tp.getIsActive())
         .legacyCompanyId(tp.getLegacyCompanyId())

--- a/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
+++ b/src/main/java/com/fabricmanagement/sales/common/exception/SalesDomainException.java
@@ -131,4 +131,11 @@ public class SalesDomainException extends DomainException {
         "SALES_020_CUSTOMER_NOT_ELIGIBLE",
         HttpStatus.UNPROCESSABLE_ENTITY);
   }
+
+  public static SalesDomainException commercialAssignmentUserInactive(String userId) {
+    return new SalesDomainException(
+        "Inactive user cannot be assigned as a primary commercial representative: " + userId,
+        "SALES_021_COMMERCIAL_ASSIGNMENT_USER_INACTIVE",
+        HttpStatus.UNPROCESSABLE_ENTITY);
+  }
 }

--- a/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerCommercialAssignmentController.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/api/controller/CustomerCommercialAssignmentController.java
@@ -1,0 +1,79 @@
+package com.fabricmanagement.sales.ownership.api.controller;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.sales.ownership.app.CustomerCommercialAssignmentService;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.dto.AssignPrimaryRepresentativeRequest;
+import com.fabricmanagement.sales.ownership.dto.CustomerCommercialAssignmentResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/sales/customers/{customerId}/commercial-assignments")
+@RequiredArgsConstructor
+@Tag(
+    name = "Customer Commercial Assignments",
+    description = "Effective-dated primary commercial representative history")
+public class CustomerCommercialAssignmentController {
+
+  private final CustomerCommercialAssignmentService assignmentService;
+
+  @GetMapping("/current")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
+  @Operation(summary = "Get the current commercial assignment")
+  public ResponseEntity<ApiResponse<CustomerCommercialAssignmentResponse>> getCurrent(
+      @PathVariable UUID customerId) {
+    CustomerCommercialAssignmentResponse response =
+        assignmentService
+            .getCurrentAssignment(TenantContext.requireTenantId(), customerId)
+            .orElse(null);
+    return ResponseEntity.ok(ApiResponse.success(response));
+  }
+
+  @GetMapping("/history")
+  @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
+  @Operation(summary = "Get effective-dated commercial assignment history")
+  public ResponseEntity<ApiResponse<List<CustomerCommercialAssignmentResponse>>> getHistory(
+      @PathVariable UUID customerId) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            assignmentService.getAssignmentHistory(TenantContext.requireTenantId(), customerId)));
+  }
+
+  @PostMapping
+  @PreAuthorize(
+      "@auth.can(authentication, 'sales', 'write')" + " and hasAnyRole('ADMIN', 'MANAGER')")
+  @Operation(summary = "Assign the primary commercial representative")
+  public ResponseEntity<ApiResponse<CustomerCommercialAssignmentResponse>> assignPrimary(
+      @PathVariable UUID customerId,
+      @Valid @RequestBody AssignPrimaryRepresentativeRequest request) {
+    UUID actorId =
+        Objects.requireNonNull(
+            TenantContext.getCurrentUserId(), "Current user is required for manual assignment");
+    CustomerCommercialAssignmentResponse response =
+        CustomerCommercialAssignmentResponse.from(
+            assignmentService.assignPrimary(
+                TenantContext.requireTenantId(),
+                customerId,
+                request.representativeId(),
+                AssignmentSource.MANUAL,
+                ActorRef.user(actorId)));
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/api/controller/OwnershipTriageController.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/api/controller/OwnershipTriageController.java
@@ -1,0 +1,73 @@
+package com.fabricmanagement.sales.ownership.api.controller;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.common.infrastructure.web.ApiResponse;
+import com.fabricmanagement.common.infrastructure.web.PagedResponse;
+import com.fabricmanagement.sales.ownership.app.CustomerCommercialAssignmentService;
+import com.fabricmanagement.sales.ownership.app.OwnershipTriageService;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.dto.AssignPrimaryRepresentativeRequest;
+import com.fabricmanagement.sales.ownership.dto.CustomerCommercialAssignmentResponse;
+import com.fabricmanagement.sales.ownership.dto.OwnershipTriageCaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/sales/ownership/triage")
+@RequiredArgsConstructor
+@Tag(
+    name = "Sales Ownership Triage",
+    description = "Derived queue of customers requiring a commercial representative")
+public class OwnershipTriageController {
+
+  private final OwnershipTriageService triageService;
+  private final CustomerCommercialAssignmentService assignmentService;
+
+  @GetMapping
+  @PreAuthorize("@auth.can(authentication, 'sales', 'read')")
+  @Operation(summary = "List current sales ownership triage cases")
+  public ResponseEntity<ApiResponse<PagedResponse<OwnershipTriageCaseResponse>>> list(
+      @ParameterObject @PageableDefault(size = 20) Pageable pageable) {
+    return ResponseEntity.ok(
+        ApiResponse.success(
+            PagedResponse.from(triageService.list(TenantContext.requireTenantId(), pageable))));
+  }
+
+  @PostMapping("/{customerId}/resolve")
+  @PreAuthorize(
+      "@auth.can(authentication, 'sales', 'write')" + " and hasAnyRole('ADMIN', 'MANAGER')")
+  @Operation(summary = "Resolve a triage case by assigning its primary representative")
+  public ResponseEntity<ApiResponse<CustomerCommercialAssignmentResponse>> resolve(
+      @PathVariable UUID customerId,
+      @Valid @RequestBody AssignPrimaryRepresentativeRequest request) {
+    UUID actorId =
+        Objects.requireNonNull(
+            TenantContext.getCurrentUserId(), "Current user is required for triage resolution");
+    CustomerCommercialAssignmentResponse response =
+        CustomerCommercialAssignmentResponse.from(
+            assignmentService.assignPrimary(
+                TenantContext.requireTenantId(),
+                customerId,
+                request.representativeId(),
+                AssignmentSource.TRIAGE_RESOLUTION,
+                ActorRef.user(actorId)));
+    return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(response));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/AssignmentFirstPolicy.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/AssignmentFirstPolicy.java
@@ -1,0 +1,69 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.domain.OwnershipMode;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class AssignmentFirstPolicy implements DefaultOwnerPolicy {
+
+  private final CustomerEligibilityService customerEligibilityService;
+  private final CustomerCommercialAssignmentService assignmentService;
+  private final OwnershipPolicyService ownershipPolicyService;
+  private final UserQueryService userQueryService;
+  private final AcquirerFirstPolicy acquirerFirstPolicy;
+
+  @Override
+  @Transactional(readOnly = true)
+  public OwnerResolution resolve(OwnerResolutionContext context) {
+    customerEligibilityService.requireEligible(context.tenantId(), context.customerId());
+    Optional<CustomerCommercialAssignment> eligibleAssignment =
+        assignmentService
+            .findCurrent(context.tenantId(), context.customerId())
+            .filter(
+                assignment -> isActiveUser(context.tenantId(), assignment.getRepresentativeId()));
+
+    if (context.requestedOwnerId() != null) {
+      if (eligibleAssignment
+          .map(CustomerCommercialAssignment::getRepresentativeId)
+          .filter(context.requestedOwnerId()::equals)
+          .isEmpty()) {
+        acquirerFirstPolicy.resolve(context);
+      }
+      return new OwnerResolution(
+          context.requestedOwnerId(), OwnerResolutionReason.EXPLICIT_OVERRIDE);
+    }
+
+    if (eligibleAssignment.isPresent()) {
+      return new OwnerResolution(
+          eligibleAssignment.orElseThrow().getRepresentativeId(),
+          OwnerResolutionReason.PRIMARY_ASSIGNMENT);
+    }
+
+    OwnershipMode mode = ownershipPolicyService.requirePolicy(context.tenantId()).getDefaultMode();
+    return switch (mode) {
+      case REQUIRED -> new OwnerResolution(null, OwnerResolutionReason.TRIAGE_REQUIRED);
+      case OPTIONAL -> new OwnerResolution(null, OwnerResolutionReason.OPTIONAL_UNASSIGNED);
+      case EXEMPT -> new OwnerResolution(null, OwnerResolutionReason.OWNERSHIP_EXEMPT);
+    };
+  }
+
+  private boolean isActiveUser(UUID tenantId, UUID userId) {
+    return userQueryService
+        .findById(tenantId, userId)
+        .map(UserDto::getIsActive)
+        .map(Boolean.TRUE::equals)
+        .orElse(false);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentService.java
@@ -1,0 +1,164 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.web.exception.NotFoundException;
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentClosureReason;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.dto.CustomerCommercialAssignmentResponse;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialAssignmentRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerCommercialAssignmentService {
+
+  static final String POLICY_VERSION_V1 = "OWNERSHIP_POLICY_V1";
+
+  private final CustomerCommercialAssignmentRepository repository;
+  private final CustomerEligibilityService customerEligibilityService;
+  private final UserQueryService userQueryService;
+
+  @Transactional(readOnly = true)
+  public Optional<CustomerCommercialAssignment> findCurrent(UUID tenantId, UUID customerId) {
+    return repository.findByTenantIdAndCustomerIdAndValidToIsNull(tenantId, customerId);
+  }
+
+  @Transactional(readOnly = true)
+  public Optional<CustomerCommercialAssignmentResponse> getCurrentAssignment(
+      UUID tenantId, UUID customerId) {
+    customerEligibilityService.requireEligible(tenantId, customerId);
+    return findCurrent(tenantId, customerId).map(CustomerCommercialAssignmentResponse::from);
+  }
+
+  @Transactional(readOnly = true)
+  public List<CustomerCommercialAssignmentResponse> getAssignmentHistory(
+      UUID tenantId, UUID customerId) {
+    customerEligibilityService.requireEligible(tenantId, customerId);
+    return repository
+        .findAllByTenantIdAndCustomerIdOrderByValidFromDescIdDesc(tenantId, customerId)
+        .stream()
+        .map(CustomerCommercialAssignmentResponse::from)
+        .toList();
+  }
+
+  @Transactional
+  public CustomerCommercialAssignment assignPrimary(
+      UUID tenantId,
+      UUID customerId,
+      UUID representativeId,
+      AssignmentSource source,
+      ActorRef actor) {
+    customerEligibilityService.requireEligible(tenantId, customerId);
+    requireActiveRepresentative(tenantId, representativeId);
+
+    Instant effectiveAt = Instant.now();
+    Optional<CustomerCommercialAssignment> current =
+        repository.findByTenantIdAndCustomerIdAndValidToIsNull(tenantId, customerId);
+    if (current.filter(row -> row.getRepresentativeId().equals(representativeId)).isPresent()) {
+      return current.orElseThrow();
+    }
+
+    UUID supersedesId = null;
+    if (current.isPresent()) {
+      CustomerCommercialAssignment previous = current.orElseThrow();
+      previous.close(effectiveAt, AssignmentClosureReason.SUPERSEDED, actor);
+      repository.save(previous);
+      repository.flush();
+      supersedesId = previous.getId();
+    }
+
+    CustomerCommercialAssignment assignment =
+        CustomerCommercialAssignment.open(
+            customerId,
+            representativeId,
+            effectiveAt,
+            source,
+            actor,
+            POLICY_VERSION_V1,
+            supersedesId);
+    assignment.setTenantId(tenantId);
+    return repository.save(assignment);
+  }
+
+  @Transactional
+  public Optional<CustomerCommercialAssignment> createAcquisitionIfAbsent(
+      UUID tenantId, UUID customerId, UUID representativeId, Instant establishedAt) {
+    if (representativeId == null
+        || repository.existsByTenantIdAndCustomerId(tenantId, customerId)
+        || !isActiveRepresentative(tenantId, representativeId)) {
+      return Optional.empty();
+    }
+    customerEligibilityService.requireEligible(tenantId, customerId);
+    CustomerCommercialAssignment assignment =
+        CustomerCommercialAssignment.open(
+            customerId,
+            representativeId,
+            establishedAt,
+            AssignmentSource.ACQUISITION,
+            ActorRef.system("OWNERSHIP_POLICY"),
+            POLICY_VERSION_V1,
+            null);
+    assignment.setTenantId(tenantId);
+    return Optional.of(repository.save(assignment));
+  }
+
+  @Transactional
+  public boolean closeCurrent(
+      UUID tenantId,
+      UUID customerId,
+      Instant closedAt,
+      AssignmentClosureReason reason,
+      ActorRef actor) {
+    Optional<CustomerCommercialAssignment> current =
+        repository.findByTenantIdAndCustomerIdAndValidToIsNull(tenantId, customerId);
+    if (current.isEmpty()) {
+      return false;
+    }
+    current.orElseThrow().close(closedAt, reason, actor);
+    repository.save(current.orElseThrow());
+    return true;
+  }
+
+  @Transactional
+  public int closeAllForDeactivatedRepresentative(
+      UUID tenantId, UUID representativeId, Instant occurredAt) {
+    List<CustomerCommercialAssignment> assignments =
+        repository.findAllByTenantIdAndRepresentativeIdAndValidToIsNullOrderByCustomerId(
+            tenantId, representativeId);
+    ActorRef actor = ActorRef.system("OWNERSHIP_POLICY");
+    assignments.forEach(
+        assignment ->
+            assignment.close(
+                occurredAt, AssignmentClosureReason.REPRESENTATIVE_DEACTIVATED, actor));
+    assignments.forEach(repository::save);
+    return assignments.size();
+  }
+
+  private void requireActiveRepresentative(UUID tenantId, UUID representativeId) {
+    UserDto representative =
+        userQueryService
+            .findById(tenantId, representativeId)
+            .orElseThrow(() -> new NotFoundException("User not found: " + representativeId));
+    if (!Boolean.TRUE.equals(representative.getIsActive())) {
+      throw SalesDomainException.commercialAssignmentUserInactive(representativeId.toString());
+    }
+  }
+
+  private boolean isActiveRepresentative(UUID tenantId, UUID representativeId) {
+    return userQueryService
+        .findById(tenantId, representativeId)
+        .map(UserDto::getIsActive)
+        .map(Boolean.TRUE::equals)
+        .orElse(false);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentService.java
@@ -8,6 +8,7 @@ import com.fabricmanagement.sales.ownership.domain.ActorRef;
 import com.fabricmanagement.sales.ownership.domain.AssignmentClosureReason;
 import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
 import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipResolvedEvent;
 import com.fabricmanagement.sales.ownership.dto.CustomerCommercialAssignmentResponse;
 import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialAssignmentRepository;
 import java.time.Instant;
@@ -15,6 +16,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +29,7 @@ public class CustomerCommercialAssignmentService {
   private final CustomerCommercialAssignmentRepository repository;
   private final CustomerEligibilityService customerEligibilityService;
   private final UserQueryService userQueryService;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Transactional(readOnly = true)
   public Optional<CustomerCommercialAssignment> findCurrent(UUID tenantId, UUID customerId) {
@@ -87,7 +90,12 @@ public class CustomerCommercialAssignmentService {
             POLICY_VERSION_V1,
             supersedesId);
     assignment.setTenantId(tenantId);
-    return repository.save(assignment);
+    CustomerCommercialAssignment saved = repository.save(assignment);
+    if (source == AssignmentSource.TRIAGE_RESOLUTION) {
+      eventPublisher.publishEvent(
+          new CustomerOwnershipResolvedEvent(tenantId, customerId, representativeId, effectiveAt));
+    }
+    return saved;
   }
 
   @Transactional

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerOwnershipResolvedListener.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerOwnershipResolvedListener.java
@@ -1,0 +1,49 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipResolvedEvent;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageCaseLogRepository;
+import com.fabricmanagement.sales.quote.app.QuoteService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerOwnershipResolvedListener {
+
+  private final IdempotentEventHandler idempotentEventHandler;
+  private final QuoteService quoteService;
+  private final OwnershipTriageCaseLogRepository caseLogRepository;
+
+  @ApplicationModuleListener
+  public void onCustomerOwnershipResolved(CustomerOwnershipResolvedEvent event) {
+    TenantContext.executeInTenantContext(
+        event.getTenantId(),
+        () ->
+            idempotentEventHandler.executeOnce(
+                event.getEventId(),
+                this.getClass(),
+                "onCustomerOwnershipResolved",
+                () -> resolve(event)));
+  }
+
+  private void resolve(CustomerOwnershipResolvedEvent event) {
+    int quotesBackfilled =
+        quoteService.backfillUnassignedActionableQuotes(
+            event.getTenantId(), event.getCustomerId(), event.getRepresentativeId());
+    int casesResolved =
+        caseLogRepository.resolveOpenCases(
+            event.getTenantId(), event.getCustomerId(), event.getResolvedAt());
+    log.info(
+        "Customer ownership triage resolved: tenantId={}, customerId={}, quotesBackfilled={}, "
+            + "casesResolved={}",
+        event.getTenantId(),
+        event.getCustomerId(),
+        quotesBackfilled,
+        casesResolved);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerRelationshipEstablishedListener.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/CustomerRelationshipEstablishedListener.java
@@ -1,0 +1,44 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipEstablishedEvent;
+import com.fabricmanagement.sales.ownership.domain.OwnershipMode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CustomerRelationshipEstablishedListener {
+
+  private final IdempotentEventHandler idempotentEventHandler;
+  private final OwnershipPolicyService ownershipPolicyService;
+  private final CustomerCommercialAssignmentService assignmentService;
+
+  @ApplicationModuleListener
+  public void onCustomerRelationshipEstablished(CustomerRelationshipEstablishedEvent event) {
+    idempotentEventHandler.executeOnce(
+        event.getEventId(),
+        this.getClass(),
+        "onCustomerRelationshipEstablished",
+        () -> {
+          OwnershipMode mode =
+              ownershipPolicyService.requirePolicy(event.getTenantId()).getDefaultMode();
+          if (mode == OwnershipMode.EXEMPT || event.getAcquiredById() == null) {
+            return;
+          }
+          assignmentService.createAcquisitionIfAbsent(
+              event.getTenantId(),
+              event.getCustomerId(),
+              event.getAcquiredById(),
+              event.getEstablishedAt());
+          log.debug(
+              "Handled customer relationship establishment: tenantId={}, customerId={}, gate={}",
+              event.getTenantId(),
+              event.getCustomerId(),
+              event.getSourceGate());
+        });
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/FeatureFlaggedOwnerPolicy.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/FeatureFlaggedOwnerPolicy.java
@@ -1,0 +1,34 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+@Component
+@Primary
+@RequiredArgsConstructor
+public class FeatureFlaggedOwnerPolicy implements DefaultOwnerPolicy {
+
+  private final AcquirerFirstPolicy acquirerFirstPolicy;
+  private final AssignmentFirstPolicy assignmentFirstPolicy;
+  private final OwnershipPolicyService ownershipPolicyService;
+
+  @Value("${feature.sales.assignment-ladder-enabled:false}")
+  private boolean globalAssignmentLadderEnabled;
+
+  @Override
+  public OwnerResolution resolve(OwnerResolutionContext context) {
+    if (!globalAssignmentLadderEnabled) {
+      return acquirerFirstPolicy.resolve(context);
+    }
+    boolean tenantEnabled =
+        ownershipPolicyService.requirePolicy(context.tenantId()).isAssignmentLadderEnabled();
+    return tenantEnabled
+        ? assignmentFirstPolicy.resolve(context)
+        : acquirerFirstPolicy.resolve(context);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipAssignmentReconciliationMonitor.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipAssignmentReconciliationMonitor.java
@@ -1,0 +1,62 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OwnershipAssignmentReconciliationMonitor {
+
+  private final SystemTransactionExecutor systemTransactionExecutor;
+  private final MeterRegistry meterRegistry;
+  private final AtomicLong missingAssignmentCount = new AtomicLong();
+
+  @PostConstruct
+  void registerGauge() {
+    Gauge.builder(
+            "sales.ownership.assignment.missing", missingAssignmentCount, AtomicLong::doubleValue)
+        .description("Customers with an acquirer but no commercial assignment outside exempt mode")
+        .register(meterRegistry);
+  }
+
+  @Scheduled(fixedDelayString = "${sales.ownership.reconciliation.interval-ms:300000}")
+  public void reconcile() {
+    Long count =
+        systemTransactionExecutor.executeInTransaction(
+            jdbc ->
+                jdbc.queryForObject(
+                    """
+                    SELECT COUNT(*)
+                    FROM common_company.common_trading_partner partner
+                    JOIN sales.ownership_policy policy
+                      ON policy.tenant_id = partner.tenant_id
+                    WHERE partner.partner_type IN ('CUSTOMER', 'BOTH')
+                      AND partner.is_active = TRUE
+                      AND partner.acquired_by_id IS NOT NULL
+                      AND policy.default_mode <> 'EXEMPT'
+                      AND NOT EXISTS (
+                          SELECT 1
+                          FROM sales.customer_commercial_assignment assignment
+                          WHERE assignment.tenant_id = partner.tenant_id
+                            AND assignment.customer_id = partner.id
+                      )
+                    """,
+                    Long.class));
+    long safeCount = count != null ? count : 0L;
+    missingAssignmentCount.set(safeCount);
+    if (safeCount > 0) {
+      log.warn(
+          "Commercial assignment reconciliation detected customers with missing truth rows: "
+              + "count={}",
+          safeCount);
+    }
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipAssignmentReconciliationMonitor.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipAssignmentReconciliationMonitor.java
@@ -1,9 +1,12 @@
 package com.fabricmanagement.sales.ownership.app;
 
 import com.fabricmanagement.common.infrastructure.persistence.SystemTransactionExecutor;
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,13 +20,41 @@ public class OwnershipAssignmentReconciliationMonitor {
 
   private final SystemTransactionExecutor systemTransactionExecutor;
   private final MeterRegistry meterRegistry;
+  private final OwnershipTriageProcessor triageProcessor;
   private final AtomicLong missingAssignmentCount = new AtomicLong();
+  private final AtomicLong openTriageCount = new AtomicLong();
+  private final AtomicLong oldestTriageAgeHours = new AtomicLong();
+  private final AtomicLong triageCaseLogConflictCount = new AtomicLong();
+
+  private static final String ACTIVE_TENANTS_SQL =
+      """
+      SELECT id
+      FROM common_tenant.common_tenant
+      WHERE is_active = TRUE
+        AND type NOT IN ('SYSTEM', 'TEMPLATE')
+      ORDER BY id
+      """;
 
   @PostConstruct
   void registerGauge() {
     Gauge.builder(
             "sales.ownership.assignment.missing", missingAssignmentCount, AtomicLong::doubleValue)
         .description("Customers with an acquirer but no commercial assignment outside exempt mode")
+        .register(meterRegistry);
+    Gauge.builder("sales.ownership.triage.open", openTriageCount, AtomicLong::doubleValue)
+        .description("Current customers requiring a commercial ownership assignment")
+        .register(meterRegistry);
+    Gauge.builder(
+            "sales.ownership.triage.oldest_age_hours",
+            oldestTriageAgeHours,
+            AtomicLong::doubleValue)
+        .description("Age in hours of the oldest current ownership triage case")
+        .register(meterRegistry);
+    Gauge.builder(
+            "sales.ownership.triage.case_log_conflicts",
+            triageCaseLogConflictCount,
+            AtomicLong::doubleValue)
+        .description("Unresolved case-log rows that disagree with the derived triage query")
         .register(meterRegistry);
   }
 
@@ -58,5 +89,27 @@ public class OwnershipAssignmentReconciliationMonitor {
               + "count={}",
           safeCount);
     }
+
+    List<UUID> tenantIds =
+        systemTransactionExecutor.executeQuery(
+            ACTIVE_TENANTS_SQL, (rs, rowNumber) -> rs.getObject("id", UUID.class));
+    long openCases = 0;
+    long oldestAge = 0;
+    long conflicts = 0;
+    for (UUID tenantId : tenantIds) {
+      try {
+        OwnershipTriageProcessor.ProcessingSummary summary =
+            TenantContext.executeInTenantContext(
+                tenantId, () -> triageProcessor.processTenant(tenantId));
+        openCases += summary.openCases();
+        oldestAge = Math.max(oldestAge, summary.oldestAgeHours());
+        conflicts += summary.caseLogConflicts();
+      } catch (RuntimeException exception) {
+        log.error("Ownership triage processing failed for tenantId={}", tenantId, exception);
+      }
+    }
+    openTriageCount.set(openCases);
+    oldestTriageAgeHours.set(oldestAge);
+    triageCaseLogConflictCount.set(conflicts);
   }
 }

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipPolicyService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipPolicyService.java
@@ -1,0 +1,25 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipPolicy;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipPolicyRepository;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnershipPolicyService {
+
+  private final OwnershipPolicyRepository repository;
+
+  @Transactional(readOnly = true)
+  public OwnershipPolicy requirePolicy(UUID tenantId) {
+    return repository
+        .findByTenantId(tenantId)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "Sales ownership policy is missing for tenant " + tenantId));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageAgingEmailAdapter.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageAgingEmailAdapter.java
@@ -1,0 +1,45 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.platform.communication.api.facade.SystemEmailFacade;
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
+
+@Component
+@RequiredArgsConstructor
+public class OwnershipTriageAgingEmailAdapter {
+
+  private final SystemEmailFacade systemEmailFacade;
+
+  @Value("${application.sales.triage.ops-email:}")
+  private String opsEmail;
+
+  public void queue(UUID tenantId, OwnershipTriageCase triageCase) {
+    if (opsEmail == null || opsEmail.isBlank()) {
+      throw new IllegalStateException(
+          "application.sales.triage.ops-email is required before ownership aging alerts can run");
+    }
+
+    String customerName = HtmlUtils.htmlEscape(triageCase.customerName(), "UTF-8");
+    String subject =
+        "Sales ownership overdue — "
+            + triageCase.customerName().replace('\r', ' ').replace('\n', ' ');
+    String html =
+        """
+        <h2>Sales ownership requires attention</h2>
+        <p><strong>Customer:</strong> %s</p>
+        <p><strong>Customer ID:</strong> %s</p>
+        <p><strong>Gap started:</strong> %s</p>
+        <p><strong>Unassigned open quotes:</strong> %d</p>
+        """
+            .formatted(
+                customerName,
+                triageCase.customerId(),
+                triageCase.gapStartedAt(),
+                triageCase.unassignedOpenQuoteCount());
+    systemEmailFacade.queueSystemEmail(tenantId, opsEmail.trim(), subject, html);
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageProcessor.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageProcessor.java
@@ -1,0 +1,83 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipTriageOpenedEvent;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageCaseLogRepository;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageQueryRepository;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class OwnershipTriageProcessor {
+
+  private final OwnershipTriageQueryRepository queryRepository;
+  private final OwnershipTriageCaseLogRepository caseLogRepository;
+  private final OwnershipTriageAgingEmailAdapter agingEmailAdapter;
+  private final ApplicationEventPublisher eventPublisher;
+  private final Clock clock;
+
+  @Transactional
+  public ProcessingSummary processTenant(UUID tenantId) {
+    Instant now = Instant.now(clock);
+    List<OwnershipTriageCase> cases = queryRepository.findAll(tenantId);
+    int notificationsRequested = 0;
+    int agingAlertsQueued = 0;
+
+    for (OwnershipTriageCase triageCase : cases) {
+      if (caseLogRepository.tryRecordNotificationRequested(
+          tenantId, triageCase.customerId(), triageCase.gapStartedAt(), now)) {
+        notificationsRequested++;
+        eventPublisher.publishEvent(
+            new CustomerOwnershipTriageOpenedEvent(
+                tenantId,
+                triageCase.customerId(),
+                triageCase.customerName(),
+                triageCase.gapStartedAt(),
+                triageCase.unassignedOpenQuoteCount()));
+      }
+
+      long ageHours = Math.max(0, Duration.between(triageCase.gapStartedAt(), now).toHours());
+      if (ageHours >= triageCase.agingThresholdHours()
+          && caseLogRepository.tryMarkAgingAlertQueued(
+              tenantId, triageCase.customerId(), triageCase.gapStartedAt(), now)) {
+        agingEmailAdapter.queue(tenantId, triageCase);
+        agingAlertsQueued++;
+      }
+    }
+
+    long conflicts = caseLogRepository.countUnresolvedConflicts(tenantId);
+    if (conflicts > 0) {
+      log.warn(
+          "Ownership triage derived query disagrees with unresolved case log: tenantId={}, count={}",
+          tenantId,
+          conflicts);
+    }
+
+    long oldestAgeHours =
+        cases.stream()
+            .mapToLong(
+                triageCase ->
+                    Math.max(0, Duration.between(triageCase.gapStartedAt(), now).toHours()))
+            .max()
+            .orElse(0);
+    return new ProcessingSummary(
+        cases.size(), oldestAgeHours, conflicts, notificationsRequested, agingAlertsQueued);
+  }
+
+  public record ProcessingSummary(
+      long openCases,
+      long oldestAgeHours,
+      long caseLogConflicts,
+      int notificationsRequested,
+      int agingAlertsQueued) {}
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageService.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageService.java
@@ -1,0 +1,28 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.sales.ownership.dto.OwnershipTriageCaseResponse;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageQueryRepository;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OwnershipTriageService {
+
+  private final OwnershipTriageQueryRepository queryRepository;
+  private final Clock clock;
+
+  @Transactional(readOnly = true)
+  public Page<OwnershipTriageCaseResponse> list(UUID tenantId, Pageable pageable) {
+    Instant now = Instant.now(clock);
+    return queryRepository
+        .findPage(tenantId, pageable)
+        .map(triageCase -> OwnershipTriageCaseResponse.from(triageCase, now));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/app/UserDeactivatedAssignmentListener.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/app/UserDeactivatedAssignmentListener.java
@@ -1,0 +1,36 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.platform.user.domain.event.UserDeactivatedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.modulith.events.ApplicationModuleListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UserDeactivatedAssignmentListener {
+
+  private final IdempotentEventHandler idempotentEventHandler;
+  private final CustomerCommercialAssignmentService assignmentService;
+
+  @ApplicationModuleListener
+  public void onUserDeactivated(UserDeactivatedEvent event) {
+    idempotentEventHandler.executeOnce(
+        event.getEventId(),
+        this.getClass(),
+        "onUserDeactivated",
+        () -> {
+          int closed =
+              assignmentService.closeAllForDeactivatedRepresentative(
+                  event.getTenantId(), event.getUserId(), event.getOccurredAt());
+          log.info(
+              "Closed commercial assignments for deactivated representative: "
+                  + "tenantId={}, representativeId={}, closed={}",
+              event.getTenantId(),
+              event.getUserId(),
+              closed);
+        });
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/ActorRef.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/ActorRef.java
@@ -1,0 +1,33 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import java.util.Objects;
+import java.util.UUID;
+
+public record ActorRef(AssignmentActorType type, UUID userId, String systemCode) {
+
+  public ActorRef {
+    Objects.requireNonNull(type, "type must not be null");
+    boolean userActor = type == AssignmentActorType.USER && userId != null && systemCode == null;
+    boolean systemActor =
+        type == AssignmentActorType.SYSTEM
+            && userId == null
+            && systemCode != null
+            && !systemCode.isBlank();
+    if (!userActor && !systemActor) {
+      throw new IllegalArgumentException(
+          "ActorRef must contain exactly the identifier required by its actor type");
+    }
+  }
+
+  public static ActorRef user(UUID userId) {
+    return new ActorRef(
+        AssignmentActorType.USER, Objects.requireNonNull(userId, "userId must not be null"), null);
+  }
+
+  public static ActorRef system(String systemCode) {
+    return new ActorRef(
+        AssignmentActorType.SYSTEM,
+        null,
+        Objects.requireNonNull(systemCode, "systemCode must not be null"));
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentActorType.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentActorType.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+public enum AssignmentActorType {
+  USER,
+  SYSTEM
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentClosureReason.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentClosureReason.java
@@ -1,0 +1,6 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+public enum AssignmentClosureReason {
+  SUPERSEDED,
+  REPRESENTATIVE_DEACTIVATED
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentSource.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/AssignmentSource.java
@@ -1,0 +1,10 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+public enum AssignmentSource {
+  ACQUISITION,
+  MANUAL,
+  TRIAGE_RESOLUTION,
+  BACKFILL_ACQUIRER,
+  BACKFILL_SOLE_TEAM_MEMBER,
+  SYSTEM_POLICY
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerCommercialAssignment.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/CustomerCommercialAssignment.java
@@ -1,0 +1,129 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "customer_commercial_assignment", schema = "sales")
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerCommercialAssignment extends BaseEntity {
+
+  @Column(name = "customer_id", nullable = false, updatable = false)
+  private UUID customerId;
+
+  @Column(name = "representative_id", nullable = false, updatable = false)
+  private UUID representativeId;
+
+  @Column(name = "valid_from", nullable = false, updatable = false)
+  private Instant validFrom;
+
+  @Column(name = "valid_to")
+  private Instant validTo;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "source", nullable = false, updatable = false, length = 40)
+  private AssignmentSource source;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "decided_by_type", nullable = false, updatable = false, length = 10)
+  private AssignmentActorType decidedByType;
+
+  @Column(name = "decided_by_user_id", updatable = false)
+  private UUID decidedByUserId;
+
+  @Column(name = "decided_by_system_code", updatable = false, length = 60)
+  private String decidedBySystemCode;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "closed_by_type", length = 10)
+  private AssignmentActorType closedByType;
+
+  @Column(name = "closed_by_user_id")
+  private UUID closedByUserId;
+
+  @Column(name = "closed_by_system_code", length = 60)
+  private String closedBySystemCode;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "closure_reason", length = 40)
+  private AssignmentClosureReason closureReason;
+
+  @Column(name = "policy_version", nullable = false, updatable = false, length = 60)
+  private String policyVersion;
+
+  @Column(name = "supersedes_assignment_id", updatable = false)
+  private UUID supersedesAssignmentId;
+
+  public static CustomerCommercialAssignment open(
+      UUID customerId,
+      UUID representativeId,
+      Instant validFrom,
+      AssignmentSource source,
+      ActorRef actor,
+      String policyVersion,
+      UUID supersedesAssignmentId) {
+    CustomerCommercialAssignment assignment = new CustomerCommercialAssignment();
+    assignment.customerId = Objects.requireNonNull(customerId, "customerId must not be null");
+    assignment.representativeId =
+        Objects.requireNonNull(representativeId, "representativeId must not be null");
+    assignment.validFrom = Objects.requireNonNull(validFrom, "validFrom must not be null");
+    assignment.source = Objects.requireNonNull(source, "source must not be null");
+    assignment.policyVersion =
+        Objects.requireNonNull(policyVersion, "policyVersion must not be null");
+    assignment.supersedesAssignmentId = supersedesAssignmentId;
+    assignment.decidedByType = actor.type();
+    assignment.decidedByUserId = actor.userId();
+    assignment.decidedBySystemCode = actor.systemCode();
+    return assignment;
+  }
+
+  public void close(Instant closedAt, AssignmentClosureReason reason, ActorRef actor) {
+    if (validTo != null) {
+      throw new IllegalStateException(
+          "A closed commercial assignment cannot be changed or reopened");
+    }
+    Instant effectiveClosedAt = Objects.requireNonNull(closedAt, "closedAt must not be null");
+    if (effectiveClosedAt.isBefore(validFrom)) {
+      throw new IllegalArgumentException("closedAt must not be before validFrom");
+    }
+    validTo = effectiveClosedAt;
+    closureReason = Objects.requireNonNull(reason, "reason must not be null");
+    closedByType = actor.type();
+    closedByUserId = actor.userId();
+    closedBySystemCode = actor.systemCode();
+  }
+
+  public boolean isOpen() {
+    return validTo == null;
+  }
+
+  @Override
+  public final void delete() {
+    throw new UnsupportedOperationException(
+        "Commercial assignments are retained and cannot be deleted");
+  }
+
+  @Override
+  public final void activate() {
+    throw new UnsupportedOperationException(
+        "Commercial assignments are immutable after closure and cannot be reopened");
+  }
+
+  @Override
+  protected String getModuleCode() {
+    return "CASS";
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionReason.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnerResolutionReason.java
@@ -2,6 +2,11 @@ package com.fabricmanagement.sales.ownership.domain;
 
 public enum OwnerResolutionReason {
   EXPLICIT_OVERRIDE,
+  PRIMARY_ASSIGNMENT,
+  CREATOR_FALLBACK,
+  OPTIONAL_UNASSIGNED,
+  OWNERSHIP_EXEMPT,
+  LEGACY_UNKNOWN,
   ACQUIRER,
   ACCOUNT_TEAM,
   TRIAGE_REQUIRED

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipMode.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipMode.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+public enum OwnershipMode {
+  REQUIRED,
+  OPTIONAL,
+  EXEMPT
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipPolicy.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipPolicy.java
@@ -1,0 +1,39 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "ownership_policy", schema = "sales")
+@Getter
+@Setter(AccessLevel.NONE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OwnershipPolicy extends BaseEntity {
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "default_mode", nullable = false, length = 20)
+  private OwnershipMode defaultMode;
+
+  @Column(name = "mode_effective_at", nullable = false)
+  private Instant modeEffectiveAt;
+
+  @Column(name = "assignment_ladder_enabled", nullable = false)
+  private boolean assignmentLadderEnabled;
+
+  @Column(name = "triage_age_threshold_hours", nullable = false)
+  private int triageAgeThresholdHours;
+
+  @Override
+  protected String getModuleCode() {
+    return "OWNP";
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipTriageCase.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/OwnershipTriageCase.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import java.time.Instant;
+import java.util.UUID;
+
+public record OwnershipTriageCase(
+    UUID customerId,
+    String customerName,
+    long unassignedOpenQuoteCount,
+    Instant oldestUnassignedQuoteAt,
+    Instant gapStartedAt,
+    int agingThresholdHours) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/event/CustomerOwnershipResolvedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/event/CustomerOwnershipResolvedEvent.java
@@ -1,0 +1,42 @@
+package com.fabricmanagement.sales.ownership.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CustomerOwnershipResolvedEvent extends DomainEvent {
+
+  private static final String TYPE = "CUSTOMER_OWNERSHIP_RESOLVED";
+
+  private final UUID customerId;
+  private final UUID representativeId;
+  private final Instant resolvedAt;
+
+  public CustomerOwnershipResolvedEvent(
+      UUID tenantId, UUID customerId, UUID representativeId, Instant resolvedAt) {
+    super(tenantId, TYPE);
+    this.customerId = customerId;
+    this.representativeId = representativeId;
+    this.resolvedAt = resolvedAt;
+  }
+
+  @JsonCreator
+  public CustomerOwnershipResolvedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("customerId") UUID customerId,
+      @JsonProperty("representativeId") UUID representativeId,
+      @JsonProperty("resolvedAt") Instant resolvedAt) {
+    super(eventId, tenantId, eventType != null ? eventType : TYPE, occurredAt, correlationId);
+    this.customerId = customerId;
+    this.representativeId = representativeId;
+    this.resolvedAt = resolvedAt;
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/domain/event/CustomerOwnershipTriageOpenedEvent.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/domain/event/CustomerOwnershipTriageOpenedEvent.java
@@ -1,0 +1,50 @@
+package com.fabricmanagement.sales.ownership.domain.event;
+
+import com.fabricmanagement.common.infrastructure.events.DomainEvent;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public class CustomerOwnershipTriageOpenedEvent extends DomainEvent {
+
+  private static final String TYPE = "CUSTOMER_OWNERSHIP_TRIAGE_OPENED";
+
+  private final UUID customerId;
+  private final String customerName;
+  private final Instant gapStartedAt;
+  private final long unassignedOpenQuoteCount;
+
+  public CustomerOwnershipTriageOpenedEvent(
+      UUID tenantId,
+      UUID customerId,
+      String customerName,
+      Instant gapStartedAt,
+      long unassignedOpenQuoteCount) {
+    super(tenantId, TYPE);
+    this.customerId = customerId;
+    this.customerName = customerName;
+    this.gapStartedAt = gapStartedAt;
+    this.unassignedOpenQuoteCount = unassignedOpenQuoteCount;
+  }
+
+  @JsonCreator
+  public CustomerOwnershipTriageOpenedEvent(
+      @JsonProperty("eventId") UUID eventId,
+      @JsonProperty("tenantId") UUID tenantId,
+      @JsonProperty("eventType") String eventType,
+      @JsonProperty("occurredAt") Instant occurredAt,
+      @JsonProperty("correlationId") String correlationId,
+      @JsonProperty("customerId") UUID customerId,
+      @JsonProperty("customerName") String customerName,
+      @JsonProperty("gapStartedAt") Instant gapStartedAt,
+      @JsonProperty("unassignedOpenQuoteCount") long unassignedOpenQuoteCount) {
+    super(eventId, tenantId, eventType != null ? eventType : TYPE, occurredAt, correlationId);
+    this.customerId = customerId;
+    this.customerName = customerName;
+    this.gapStartedAt = gapStartedAt;
+    this.unassignedOpenQuoteCount = unassignedOpenQuoteCount;
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/AssignPrimaryRepresentativeRequest.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/AssignPrimaryRepresentativeRequest.java
@@ -1,0 +1,7 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
+
+public record AssignPrimaryRepresentativeRequest(
+    @NotNull(message = "Representative ID is required") UUID representativeId) {}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerCommercialAssignmentResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/CustomerCommercialAssignmentResponse.java
@@ -1,0 +1,46 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import com.fabricmanagement.sales.ownership.domain.AssignmentActorType;
+import com.fabricmanagement.sales.ownership.domain.AssignmentClosureReason;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Instant;
+import java.util.UUID;
+
+public record CustomerCommercialAssignmentResponse(
+    UUID id,
+    UUID customerId,
+    UUID representativeId,
+    Instant validFrom,
+    @Schema(nullable = true) Instant validTo,
+    AssignmentSource source,
+    AssignmentActorType decidedByType,
+    @Schema(nullable = true) UUID decidedByUserId,
+    @Schema(nullable = true) String decidedBySystemCode,
+    @Schema(nullable = true) AssignmentActorType closedByType,
+    @Schema(nullable = true) UUID closedByUserId,
+    @Schema(nullable = true) String closedBySystemCode,
+    @Schema(nullable = true) AssignmentClosureReason closureReason,
+    String policyVersion,
+    @Schema(nullable = true) UUID supersedesAssignmentId) {
+
+  public static CustomerCommercialAssignmentResponse from(CustomerCommercialAssignment assignment) {
+    return new CustomerCommercialAssignmentResponse(
+        assignment.getId(),
+        assignment.getCustomerId(),
+        assignment.getRepresentativeId(),
+        assignment.getValidFrom(),
+        assignment.getValidTo(),
+        assignment.getSource(),
+        assignment.getDecidedByType(),
+        assignment.getDecidedByUserId(),
+        assignment.getDecidedBySystemCode(),
+        assignment.getClosedByType(),
+        assignment.getClosedByUserId(),
+        assignment.getClosedBySystemCode(),
+        assignment.getClosureReason(),
+        assignment.getPolicyVersion(),
+        assignment.getSupersedesAssignmentId());
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/dto/OwnershipTriageCaseResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/dto/OwnershipTriageCaseResponse.java
@@ -1,0 +1,37 @@
+package com.fabricmanagement.sales.ownership.dto;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+@Schema(
+    name = "OwnershipTriageCaseResponse",
+    description = "A customer currently requiring a commercial ownership assignment")
+public record OwnershipTriageCaseResponse(
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) UUID customerId,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) String customerName,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) long unassignedOpenQuoteCount,
+    @Schema(nullable = true) Instant oldestUnassignedQuoteAt,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) Instant gapStartedAt,
+    @Schema(requiredMode = Schema.RequiredMode.REQUIRED) long ageHours,
+    @Schema(nullable = true) Long workAgeHours) {
+
+  public static OwnershipTriageCaseResponse from(OwnershipTriageCase triageCase, Instant now) {
+    return new OwnershipTriageCaseResponse(
+        triageCase.customerId(),
+        triageCase.customerName(),
+        triageCase.unassignedOpenQuoteCount(),
+        triageCase.oldestUnassignedQuoteAt(),
+        triageCase.gapStartedAt(),
+        elapsedHours(triageCase.gapStartedAt(), now),
+        triageCase.oldestUnassignedQuoteAt() == null
+            ? null
+            : elapsedHours(triageCase.oldestUnassignedQuoteAt(), now));
+  }
+
+  private static long elapsedHours(Instant startedAt, Instant now) {
+    return Math.max(0, Duration.between(startedAt, now).toHours());
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/CustomerCommercialAssignmentRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/CustomerCommercialAssignmentRepository.java
@@ -1,0 +1,33 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+/**
+ * Retention-safe assignment persistence surface.
+ *
+ * <p>Deliberately does not extend CrudRepository/JpaRepository and exposes no delete operation.
+ */
+@org.springframework.stereotype.Repository
+public interface CustomerCommercialAssignmentRepository
+    extends Repository<CustomerCommercialAssignment, UUID> {
+
+  CustomerCommercialAssignment save(CustomerCommercialAssignment assignment);
+
+  void flush();
+
+  Optional<CustomerCommercialAssignment> findByTenantIdAndCustomerIdAndValidToIsNull(
+      UUID tenantId, UUID customerId);
+
+  List<CustomerCommercialAssignment> findAllByTenantIdAndCustomerIdOrderByValidFromDescIdDesc(
+      UUID tenantId, UUID customerId);
+
+  List<CustomerCommercialAssignment>
+      findAllByTenantIdAndRepresentativeIdAndValidToIsNullOrderByCustomerId(
+          UUID tenantId, UUID representativeId);
+
+  boolean existsByTenantIdAndCustomerId(UUID tenantId, UUID customerId);
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipPolicyRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipPolicyRepository.java
@@ -1,0 +1,12 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipPolicy;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.repository.Repository;
+
+@org.springframework.stereotype.Repository
+public interface OwnershipPolicyRepository extends Repository<OwnershipPolicy, UUID> {
+
+  Optional<OwnershipPolicy> findByTenantId(UUID tenantId);
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageCaseLogRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageCaseLogRepository.java
@@ -1,0 +1,127 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.UUID;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@Transactional(propagation = Propagation.MANDATORY)
+public class OwnershipTriageCaseLogRepository {
+
+  private static final String INSERT_NOTIFICATION_REQUEST_SQL =
+      """
+      INSERT INTO sales.ownership_triage_case_log (
+          id, tenant_id, uid, customer_id, gap_started_at,
+          notification_requested_at, created_at, updated_at, is_active, version
+      )
+      VALUES (
+          gen_random_uuid(), :tenantId, CAST(gen_random_uuid() AS VARCHAR),
+          :customerId, :gapStartedAt,
+          :requestedAt, :requestedAt, :requestedAt, TRUE, 0
+      )
+      ON CONFLICT (tenant_id, customer_id, gap_started_at) DO NOTHING
+      RETURNING id
+      """;
+
+  private static final String MARK_AGING_ALERT_QUEUED_SQL =
+      """
+      UPDATE sales.ownership_triage_case_log
+      SET aging_alert_queued_at = :queuedAt,
+          updated_at = :queuedAt,
+          version = version + 1
+      WHERE tenant_id = :tenantId
+        AND customer_id = :customerId
+        AND gap_started_at = :gapStartedAt
+        AND aging_alert_queued_at IS NULL
+        AND resolved_at IS NULL
+      RETURNING id
+      """;
+
+  private static final String RESOLVE_OPEN_CASES_SQL =
+      """
+      UPDATE sales.ownership_triage_case_log
+      SET resolved_at = :resolvedAt,
+          updated_at = :resolvedAt,
+          version = version + 1
+      WHERE tenant_id = :tenantId
+        AND customer_id = :customerId
+        AND resolved_at IS NULL
+      """;
+
+  private static final String COUNT_CONFLICTS_SQL =
+      OwnershipTriageQueryRepository.DERIVED_TRIAGE_CTE
+          + """
+          SELECT COUNT(*)
+          FROM sales.ownership_triage_case_log case_log
+          WHERE case_log.tenant_id = :tenantId
+            AND case_log.resolved_at IS NULL
+            AND case_log.is_active = TRUE
+            AND case_log.deleted_at IS NULL
+            AND NOT EXISTS (
+                SELECT 1
+                FROM ownership_triage derived_case
+                WHERE derived_case.customer_id = case_log.customer_id
+                  AND derived_case.gap_started_at = case_log.gap_started_at
+            )
+          """;
+
+  @PersistenceContext private EntityManager entityManager;
+
+  public boolean tryRecordNotificationRequested(
+      UUID tenantId, UUID customerId, Instant gapStartedAt, Instant requestedAt) {
+    bindTenant(tenantId);
+    return !entityManager
+        .createNativeQuery(INSERT_NOTIFICATION_REQUEST_SQL)
+        .setParameter("tenantId", tenantId)
+        .setParameter("customerId", customerId)
+        .setParameter("gapStartedAt", Timestamp.from(gapStartedAt))
+        .setParameter("requestedAt", Timestamp.from(requestedAt))
+        .getResultList()
+        .isEmpty();
+  }
+
+  public boolean tryMarkAgingAlertQueued(
+      UUID tenantId, UUID customerId, Instant gapStartedAt, Instant queuedAt) {
+    bindTenant(tenantId);
+    return !entityManager
+        .createNativeQuery(MARK_AGING_ALERT_QUEUED_SQL)
+        .setParameter("tenantId", tenantId)
+        .setParameter("customerId", customerId)
+        .setParameter("gapStartedAt", Timestamp.from(gapStartedAt))
+        .setParameter("queuedAt", Timestamp.from(queuedAt))
+        .getResultList()
+        .isEmpty();
+  }
+
+  public int resolveOpenCases(UUID tenantId, UUID customerId, Instant resolvedAt) {
+    bindTenant(tenantId);
+    return entityManager
+        .createNativeQuery(RESOLVE_OPEN_CASES_SQL)
+        .setParameter("tenantId", tenantId)
+        .setParameter("customerId", customerId)
+        .setParameter("resolvedAt", Timestamp.from(resolvedAt))
+        .executeUpdate();
+  }
+
+  public long countUnresolvedConflicts(UUID tenantId) {
+    bindTenant(tenantId);
+    Object result =
+        entityManager
+            .createNativeQuery(COUNT_CONFLICTS_SQL)
+            .setParameter("tenantId", tenantId)
+            .getSingleResult();
+    return result == null ? 0 : ((Number) result).longValue();
+  }
+
+  private void bindTenant(UUID tenantId) {
+    entityManager
+        .createNativeQuery("SELECT set_config('app.current_tenant', :tenantId, true)")
+        .setParameter("tenantId", tenantId.toString())
+        .getSingleResult();
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageQueryRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageQueryRepository.java
@@ -1,0 +1,169 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.MANDATORY, readOnly = true)
+public class OwnershipTriageQueryRepository {
+
+  static final String DERIVED_TRIAGE_CTE =
+      """
+      WITH latest_assignment_closure AS (
+          SELECT assignment.tenant_id,
+                 assignment.customer_id,
+                 MAX(assignment.valid_to) AS latest_valid_to
+          FROM sales.customer_commercial_assignment assignment
+          WHERE assignment.tenant_id = :tenantId
+            AND assignment.is_active = TRUE
+            AND assignment.deleted_at IS NULL
+          GROUP BY assignment.tenant_id, assignment.customer_id
+      ),
+      ownership_triage AS (
+          SELECT partner.id AS customer_id,
+                 CASE
+                   WHEN NULLIF(BTRIM(partner.custom_name), '') IS NOT NULL
+                     THEN partner.custom_name
+                   ELSE registry.official_name
+                 END AS customer_name,
+                 COUNT(quote.id) AS unassigned_open_quote_count,
+                 MIN(quote.created_at) AS oldest_unassigned_quote_at,
+                 GREATEST(
+                     partner.customer_relationship_established_at,
+                     policy.mode_effective_at,
+                     latest_assignment_closure.latest_valid_to
+                 ) AS gap_started_at,
+                 policy.triage_age_threshold_hours
+          FROM common_company.common_trading_partner partner
+          JOIN common_company.trading_partner_registry registry
+            ON registry.id = partner.registry_id
+          JOIN sales.ownership_policy policy
+            ON policy.tenant_id = partner.tenant_id
+           AND policy.is_active = TRUE
+           AND policy.deleted_at IS NULL
+          LEFT JOIN latest_assignment_closure
+            ON latest_assignment_closure.tenant_id = partner.tenant_id
+           AND latest_assignment_closure.customer_id = partner.id
+          LEFT JOIN sales.quote quote
+            ON quote.tenant_id = partner.tenant_id
+           AND quote.customer_id = partner.id
+           AND quote.assigned_to_id IS NULL
+           AND quote.status IN ('DRAFT', 'EVALUATION', 'PENDING_APPROVAL', 'APPROVED')
+           AND quote.is_active = TRUE
+           AND quote.deleted_at IS NULL
+          WHERE partner.tenant_id = :tenantId
+            AND partner.partner_type IN ('CUSTOMER', 'BOTH')
+            AND partner.status = 'ACTIVE'
+            AND partner.is_active = TRUE
+            AND partner.deleted_at IS NULL
+            AND policy.default_mode = 'REQUIRED'
+            AND NOT EXISTS (
+                SELECT 1
+                FROM sales.customer_commercial_assignment active_assignment
+                JOIN common_user.common_user representative
+                  ON representative.tenant_id = active_assignment.tenant_id
+                 AND representative.id = active_assignment.representative_id
+                 AND representative.is_active = TRUE
+                 AND representative.deleted_at IS NULL
+                WHERE active_assignment.tenant_id = partner.tenant_id
+                  AND active_assignment.customer_id = partner.id
+                  AND active_assignment.valid_to IS NULL
+                  AND active_assignment.is_active = TRUE
+                  AND active_assignment.deleted_at IS NULL
+            )
+          GROUP BY partner.id,
+                   partner.custom_name,
+                   registry.official_name,
+                   partner.customer_relationship_established_at,
+                   policy.mode_effective_at,
+                   latest_assignment_closure.latest_valid_to,
+                   policy.triage_age_threshold_hours
+      )
+      """;
+
+  private static final String SELECT_PAGE_SQL =
+      DERIVED_TRIAGE_CTE
+          + """
+          SELECT customer_id,
+                 customer_name,
+                 unassigned_open_quote_count,
+                 oldest_unassigned_quote_at,
+                 gap_started_at,
+                 triage_age_threshold_hours
+          FROM ownership_triage
+          ORDER BY gap_started_at ASC, customer_id ASC
+          LIMIT :limit OFFSET :offset
+          """;
+
+  private static final String SELECT_ALL_SQL =
+      DERIVED_TRIAGE_CTE
+          + """
+          SELECT customer_id,
+                 customer_name,
+                 unassigned_open_quote_count,
+                 oldest_unassigned_quote_at,
+                 gap_started_at,
+                 triage_age_threshold_hours
+          FROM ownership_triage
+          ORDER BY gap_started_at ASC, customer_id ASC
+          """;
+
+  private static final String COUNT_SQL =
+      DERIVED_TRIAGE_CTE + "SELECT COUNT(*) FROM ownership_triage";
+
+  private final NamedParameterJdbcTemplate jdbc;
+
+  public Page<OwnershipTriageCase> findPage(UUID tenantId, Pageable pageable) {
+    bindTenant(tenantId);
+    Map<String, Object> params =
+        Map.of(
+            "tenantId", tenantId,
+            "limit", pageable.getPageSize(),
+            "offset", pageable.getOffset());
+    List<OwnershipTriageCase> cases = jdbc.query(SELECT_PAGE_SQL, params, this::mapCase);
+    Long count = jdbc.queryForObject(COUNT_SQL, Map.of("tenantId", tenantId), Long.class);
+    return new PageImpl<>(cases, pageable, count == null ? 0 : count);
+  }
+
+  public List<OwnershipTriageCase> findAll(UUID tenantId) {
+    bindTenant(tenantId);
+    return jdbc.query(SELECT_ALL_SQL, Map.of("tenantId", tenantId), this::mapCase);
+  }
+
+  private void bindTenant(UUID tenantId) {
+    jdbc.queryForObject(
+        "SELECT set_config('app.current_tenant', :tenantId, true)",
+        Map.of("tenantId", tenantId.toString()),
+        String.class);
+  }
+
+  private OwnershipTriageCase mapCase(ResultSet rs, int rowNumber) throws SQLException {
+    Timestamp oldestQuote = rs.getTimestamp("oldest_unassigned_quote_at");
+    return new OwnershipTriageCase(
+        rs.getObject("customer_id", UUID.class),
+        rs.getString("customer_name"),
+        rs.getLong("unassigned_open_quote_count"),
+        oldestQuote == null ? null : oldestQuote.toInstant(),
+        requiredInstant(rs, "gap_started_at"),
+        rs.getInt("triage_age_threshold_hours"));
+  }
+
+  private Instant requiredInstant(ResultSet rs, String column) throws SQLException {
+    return rs.getTimestamp(column).toInstant();
+  }
+}

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteApprovalEmailListener.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteApprovalEmailListener.java
@@ -2,8 +2,7 @@ package com.fabricmanagement.sales.quote.app;
 
 import com.fabricmanagement.common.infrastructure.config.FrontendUrlProvider;
 import com.fabricmanagement.common.infrastructure.web.LocalizationService;
-import com.fabricmanagement.platform.communication.app.EmailTemplateRenderer;
-import com.fabricmanagement.platform.communication.app.NotificationService;
+import com.fabricmanagement.platform.communication.api.facade.CustomerEmailFacade;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
 import com.fabricmanagement.sales.quote.domain.event.QuoteApprovalTokenGeneratedEvent;
 import java.util.Locale;
@@ -20,8 +19,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Slf4j
 public class QuoteApprovalEmailListener {
 
-  private final NotificationService notificationService;
-  private final EmailTemplateRenderer emailTemplateRenderer;
+  private final CustomerEmailFacade customerEmailFacade;
   private final LocalizationService localizationService;
   private final FrontendUrlProvider frontendUrlProvider;
 
@@ -44,10 +42,15 @@ public class QuoteApprovalEmailListener {
     String cta = localizationService.getMessage("email.quote.approval.cta", null, locale);
     String expires = localizationService.getMessage("email.quote.approval.expires", null, locale);
 
-    String message =
-        emailTemplateRenderer.renderQuoteApproval(heading, body, cta, expires, approvalUrl);
-    notificationService.sendNotificationSync(
-        event.getTenantId(), event.getCustomerEmail(), subject, message);
+    customerEmailFacade.sendQuoteApprovalEmail(
+        event.getTenantId(),
+        event.getCustomerEmail(),
+        subject,
+        heading,
+        body,
+        cta,
+        expires,
+        approvalUrl);
 
     log.info(
         "Quote approval email sent: quoteId={}, quoteNumber={}",

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -900,4 +900,11 @@ public class QuoteService {
     Instant dateSource = quote.getCreatedAt();
     return dateSource != null ? dateSource.atZone(ZoneOffset.UTC).toLocalDate() : LocalDate.now();
   }
+
+  @Transactional
+  public int backfillUnassignedActionableQuotes(
+      UUID tenantId, UUID customerId, UUID representativeId) {
+    return quoteRepository.backfillUnassignedActionableQuotes(
+        tenantId, customerId, representativeId);
+  }
 }

--- a/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/app/QuoteService.java
@@ -22,6 +22,7 @@ import com.fabricmanagement.sales.lot.app.SalesLotService;
 import com.fabricmanagement.sales.ownership.domain.DefaultOwnerPolicy;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
 import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
 import com.fabricmanagement.sales.pricing.app.DiscountPolicyService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService;
 import com.fabricmanagement.sales.pricing.app.PricingEngineService.PricingResult;
@@ -179,17 +180,20 @@ public class QuoteService {
         defaultOwnerPolicy.resolve(
             new OwnerResolutionContext(tenantId, req.getCustomerId(), req.getAssignedToId()));
     UUID ownerId = ownerResolution.ownerId();
+    OwnerResolutionReason persistedReason = ownerResolution.reason();
     if (ownerId == null) {
       // TODO(RSF-3, ADR-0003 A3.2): replace creator fallback with sales triage + ops alert.
       ownerId =
           Objects.requireNonNull(
               TenantContext.getCurrentUserId(),
               "Current user is required while the RSF-3 creator fallback is active");
+      persistedReason = OwnerResolutionReason.CREATOR_FALLBACK;
     }
 
     Quote quote = req.toQuote();
     quote.setTenantId(tenantId);
     quote.setAssignedToId(ownerId);
+    quote.setOwnerResolutionReason(persistedReason);
     quote.setStatus(QuoteStatus.DRAFT);
     quote.setRevisionNumber(1);
     return quoteRepository.save(quote);
@@ -483,6 +487,7 @@ public class QuoteService {
 
     newQuote.setCustomerId(oldQuote.getCustomerId());
     newQuote.setAssignedToId(oldQuote.getAssignedToId());
+    newQuote.setOwnerResolutionReason(oldQuote.getOwnerResolutionReason());
     newQuote.setModuleType(oldQuote.getModuleType());
     newQuote.setEstimatedUnitCost(oldQuote.getEstimatedUnitCost());
     newQuote.setCurrency(oldQuote.getCurrency());

--- a/src/main/java/com/fabricmanagement/sales/quote/domain/Quote.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/domain/Quote.java
@@ -4,6 +4,7 @@ import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.infrastructure.persistence.BaseEntity;
 import com.fabricmanagement.common.util.Money;
 import com.fabricmanagement.offline.domain.OfflineMetadata;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
 import io.hypersistence.utils.hibernate.type.json.JsonType;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
@@ -41,8 +42,12 @@ public class Quote extends BaseEntity {
   @Column(name = "customer_id", nullable = false)
   private UUID customerId;
 
-  @Column(name = "assigned_to_id", nullable = false)
+  @Column(name = "assigned_to_id")
   private UUID assignedToId;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "owner_resolution_reason", nullable = false, length = 30)
+  private OwnerResolutionReason ownerResolutionReason = OwnerResolutionReason.LEGACY_UNKNOWN;
 
   @Column(name = "module_type", nullable = false, length = 50)
   private String moduleType;

--- a/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/dto/QuoteResponse.java
@@ -3,6 +3,7 @@ package com.fabricmanagement.sales.quote.dto;
 import com.fabricmanagement.common.domain.vo.ConvertedMoney;
 import com.fabricmanagement.common.dto.ConvertedMoneyDto;
 import com.fabricmanagement.common.dto.MoneyDto;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
 import com.fabricmanagement.sales.quote.domain.Quote;
 import com.fabricmanagement.sales.quote.domain.QuoteStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -23,7 +24,10 @@ public class QuoteResponse {
   @Schema(description = "Customer display name resolved from trading partner data", nullable = true)
   private final String customerName;
 
+  @Schema(nullable = true)
   private final UUID assignedToId;
+
+  private final OwnerResolutionReason ownerResolutionReason;
   private final String moduleType;
   private final QuoteStatus status;
   private final BigDecimal estimatedUnitCost;
@@ -57,6 +61,7 @@ public class QuoteResponse {
     this.customerId = quote.getCustomerId();
     this.customerName = customerName;
     this.assignedToId = quote.getAssignedToId();
+    this.ownerResolutionReason = quote.getOwnerResolutionReason();
     this.moduleType = quote.getModuleType();
     this.status = quote.getStatus();
     this.estimatedUnitCost = quote.getEstimatedUnitCost();

--- a/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepository.java
+++ b/src/main/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -80,6 +81,32 @@ public interface QuoteRepository extends JpaRepository<Quote, UUID> {
   }
 
   List<Quote> findAllByTenantIdAndCustomerIdAndIsActiveTrue(UUID tenantId, UUID customerId);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      """
+      UPDATE Quote q
+      SET q.assignedToId = :representativeId,
+          q.ownerResolutionReason =
+              com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason.PRIMARY_ASSIGNMENT,
+          q.updatedAt = CURRENT_TIMESTAMP,
+          q.version = q.version + 1
+      WHERE q.tenantId = :tenantId
+        AND q.customerId = :customerId
+        AND q.assignedToId IS NULL
+        AND q.status IN (
+            com.fabricmanagement.sales.quote.domain.QuoteStatus.DRAFT,
+            com.fabricmanagement.sales.quote.domain.QuoteStatus.EVALUATION,
+            com.fabricmanagement.sales.quote.domain.QuoteStatus.PENDING_APPROVAL,
+            com.fabricmanagement.sales.quote.domain.QuoteStatus.APPROVED
+        )
+        AND q.isActive = TRUE
+        AND q.deletedAt IS NULL
+      """)
+  int backfillUnassignedActionableQuotes(
+      @Param("tenantId") UUID tenantId,
+      @Param("customerId") UUID customerId,
+      @Param("representativeId") UUID representativeId);
 
   @Query(
       """

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -276,6 +276,9 @@ feature:
     # Legacy Company fallback - disabled after Faz 3 migration
     # All partner data now in TradingPartner table
     legacy-fallback: ${FEATURE_TRADING_PARTNER_LEGACY_FALLBACK:false}
+  sales:
+    # Global kill-switch: a tenant flag must also be enabled before the assignment ladder is used.
+    assignment-ladder-enabled: ${FEATURE_SALES_ASSIGNMENT_LADDER_ENABLED:false}
 
 # OpenAPI / Swagger
 springdoc:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -174,6 +174,10 @@ application:
   event-visibility:
     ops-email: ${EVENT_VISIBILITY_OPS_EMAIL:akkaya064@gmail.com}
 
+  sales:
+    triage:
+      ops-email: ${SALES_TRIAGE_OPS_EMAIL:}
+
   # Email Template Configuration
   # Note: Frontend pi email render endpoint removed - backend uses its own HTML templates
   email:

--- a/src/main/resources/db/migration/V20260728120000__add_customer_relationship_established_at_to_trading_partner.sql
+++ b/src/main/resources/db/migration/V20260728120000__add_customer_relationship_established_at_to_trading_partner.sql
@@ -1,0 +1,27 @@
+ALTER TABLE common_company.common_trading_partner
+    ADD COLUMN IF NOT EXISTS customer_relationship_established_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN
+    common_company.common_trading_partner.customer_relationship_established_at IS
+    'Immutable known customer-relationship establishment timestamp; null for legacy rows with unknown history.';
+
+CREATE OR REPLACE FUNCTION common_company.guard_customer_relationship_established_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    IF OLD.customer_relationship_established_at IS NOT NULL
+       AND NEW.customer_relationship_established_at
+           IS DISTINCT FROM OLD.customer_relationship_established_at THEN
+        RAISE EXCEPTION
+            'customer_relationship_established_at is immutable once recorded'
+            USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_customer_relationship_established_at_immutable
+    BEFORE UPDATE ON common_company.common_trading_partner
+    FOR EACH ROW
+    EXECUTE FUNCTION common_company.guard_customer_relationship_established_at();

--- a/src/main/resources/db/migration/V20260728121000__create_sales_ownership_policy.sql
+++ b/src/main/resources/db/migration/V20260728121000__create_sales_ownership_policy.sql
@@ -1,0 +1,60 @@
+CREATE TABLE IF NOT EXISTS sales.ownership_policy (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    uid VARCHAR(100) UNIQUE,
+    default_mode VARCHAR(20) NOT NULL DEFAULT 'REQUIRED',
+    mode_effective_at TIMESTAMPTZ NOT NULL,
+    assignment_ladder_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    triage_age_threshold_hours INTEGER NOT NULL DEFAULT 24,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT uk_ownership_policy_tenant UNIQUE (tenant_id),
+    CONSTRAINT chk_ownership_policy_mode
+        CHECK (default_mode IN ('REQUIRED', 'OPTIONAL', 'EXEMPT')),
+    CONSTRAINT chk_ownership_policy_triage_threshold
+        CHECK (triage_age_threshold_hours > 0)
+);
+
+INSERT INTO sales.ownership_policy (
+    id,
+    tenant_id,
+    uid,
+    default_mode,
+    mode_effective_at,
+    assignment_ladder_enabled,
+    triage_age_threshold_hours,
+    created_at,
+    updated_at,
+    is_active,
+    version
+)
+SELECT
+    gen_random_uuid(),
+    tenant.id,
+    'OWNERSHIP-POLICY-' || tenant.id,
+    'REQUIRED',
+    clock_timestamp(),
+    FALSE,
+    24,
+    clock_timestamp(),
+    clock_timestamp(),
+    TRUE,
+    0
+FROM common_tenant.common_tenant tenant
+ON CONFLICT (tenant_id) DO NOTHING;
+
+COMMENT ON TABLE sales.ownership_policy IS
+    'Sales-owned tenant policy for commercial assignment and triage behaviour.';
+
+ALTER TABLE sales.ownership_policy ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales.ownership_policy FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY rls_tenant_isolation ON sales.ownership_policy
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::UUID);

--- a/src/main/resources/db/migration/V20260728122000__create_customer_commercial_assignment.sql
+++ b/src/main/resources/db/migration/V20260728122000__create_customer_commercial_assignment.sql
@@ -1,0 +1,163 @@
+CREATE TABLE IF NOT EXISTS sales.customer_commercial_assignment (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    uid VARCHAR(100) UNIQUE,
+    customer_id UUID NOT NULL,
+    representative_id UUID NOT NULL,
+    valid_from TIMESTAMPTZ NOT NULL,
+    valid_to TIMESTAMPTZ,
+    source VARCHAR(40) NOT NULL,
+    decided_by_type VARCHAR(10) NOT NULL,
+    decided_by_user_id UUID,
+    decided_by_system_code VARCHAR(60),
+    closed_by_type VARCHAR(10),
+    closed_by_user_id UUID,
+    closed_by_system_code VARCHAR(60),
+    closure_reason VARCHAR(40),
+    policy_version VARCHAR(60) NOT NULL,
+    supersedes_assignment_id UUID,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT chk_commercial_assignment_source
+        CHECK (source IN (
+            'ACQUISITION',
+            'MANUAL',
+            'TRIAGE_RESOLUTION',
+            'BACKFILL_ACQUIRER',
+            'BACKFILL_SOLE_TEAM_MEMBER',
+            'SYSTEM_POLICY'
+        )),
+    CONSTRAINT chk_commercial_assignment_decided_actor
+        CHECK (
+            (decided_by_type = 'USER'
+                AND decided_by_user_id IS NOT NULL
+                AND decided_by_system_code IS NULL)
+            OR
+            (decided_by_type = 'SYSTEM'
+                AND decided_by_user_id IS NULL
+                AND NULLIF(BTRIM(decided_by_system_code), '') IS NOT NULL)
+        ),
+    CONSTRAINT chk_commercial_assignment_closed_actor
+        CHECK (
+            (closed_by_type IS NULL
+                AND closed_by_user_id IS NULL
+                AND closed_by_system_code IS NULL)
+            OR
+            (closed_by_type = 'USER'
+                AND closed_by_user_id IS NOT NULL
+                AND closed_by_system_code IS NULL)
+            OR
+            (closed_by_type = 'SYSTEM'
+                AND closed_by_user_id IS NULL
+                AND NULLIF(BTRIM(closed_by_system_code), '') IS NOT NULL)
+        ),
+    CONSTRAINT chk_commercial_assignment_state
+        CHECK (
+            (valid_to IS NULL
+                AND closure_reason IS NULL
+                AND closed_by_type IS NULL
+                AND closed_by_user_id IS NULL
+                AND closed_by_system_code IS NULL)
+            OR
+            (valid_to IS NOT NULL
+                AND valid_to >= valid_from
+                AND closure_reason IS NOT NULL
+                AND closure_reason IN ('SUPERSEDED', 'REPRESENTATIVE_DEACTIVATED')
+                AND closed_by_type IS NOT NULL)
+        )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_customer_commercial_assignment_open
+    ON sales.customer_commercial_assignment (tenant_id, customer_id)
+    WHERE valid_to IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_customer_commercial_assignment_history
+    ON sales.customer_commercial_assignment
+        (tenant_id, customer_id, valid_from DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS idx_customer_commercial_assignment_representative
+    ON sales.customer_commercial_assignment
+        (tenant_id, representative_id, valid_to);
+
+COMMENT ON TABLE sales.customer_commercial_assignment IS
+    'Retention-stable effective-dated commercial ownership; all cross-context ids are soft references.';
+
+CREATE OR REPLACE FUNCTION sales.guard_customer_commercial_assignment_mutation()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    purge_tenant TEXT :=
+        current_setting('app.customer_commercial_assignment_purge_tenant', true);
+    trusted_purge_role BOOLEAN;
+BEGIN
+    IF TG_OP = 'DELETE' THEN
+        SELECT
+            EXISTS (
+                SELECT 1
+                FROM pg_roles active_role
+                WHERE active_role.rolname = current_user
+                  AND active_role.rolsuper
+            )
+            OR current_user = 'fabric_system'
+            OR EXISTS (
+                SELECT 1
+                FROM pg_roles system_role
+                WHERE system_role.rolname = 'fabric_system'
+                  AND pg_has_role(current_user, system_role.oid, 'MEMBER')
+            )
+        INTO trusted_purge_role;
+
+        IF trusted_purge_role
+           AND purge_tenant = OLD.tenant_id::TEXT THEN
+            RETURN OLD;
+        END IF;
+
+        RAISE EXCEPTION
+            'customer_commercial_assignment is retention-stable; row delete is forbidden'
+            USING ERRCODE = '55000';
+    END IF;
+
+    IF OLD.valid_to IS NOT NULL
+       OR NEW.valid_to IS NULL
+       OR NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+       OR NEW.uid IS DISTINCT FROM OLD.uid
+       OR NEW.customer_id IS DISTINCT FROM OLD.customer_id
+       OR NEW.representative_id IS DISTINCT FROM OLD.representative_id
+       OR NEW.valid_from IS DISTINCT FROM OLD.valid_from
+       OR NEW.source IS DISTINCT FROM OLD.source
+       OR NEW.decided_by_type IS DISTINCT FROM OLD.decided_by_type
+       OR NEW.decided_by_user_id IS DISTINCT FROM OLD.decided_by_user_id
+       OR NEW.decided_by_system_code IS DISTINCT FROM OLD.decided_by_system_code
+       OR NEW.policy_version IS DISTINCT FROM OLD.policy_version
+       OR NEW.supersedes_assignment_id IS DISTINCT FROM OLD.supersedes_assignment_id
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR NEW.created_by IS DISTINCT FROM OLD.created_by
+       OR NEW.is_active IS DISTINCT FROM OLD.is_active
+       OR NEW.deleted_at IS DISTINCT FROM OLD.deleted_at THEN
+        RAISE EXCEPTION
+            'customer_commercial_assignment only permits one-time closure'
+            USING ERRCODE = '55000';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER trg_customer_commercial_assignment_mutation
+    BEFORE UPDATE OR DELETE ON sales.customer_commercial_assignment
+    FOR EACH ROW EXECUTE FUNCTION sales.guard_customer_commercial_assignment_mutation();
+
+ALTER TABLE sales.customer_commercial_assignment ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales.customer_commercial_assignment FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY rls_tenant_isolation ON sales.customer_commercial_assignment
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::UUID);

--- a/src/main/resources/db/migration/V20260728123000__add_owner_resolution_reason_and_nullable_owner_to_quote.sql
+++ b/src/main/resources/db/migration/V20260728123000__add_owner_resolution_reason_and_nullable_owner_to_quote.sql
@@ -1,0 +1,25 @@
+ALTER TABLE sales.quote
+    ADD COLUMN IF NOT EXISTS owner_resolution_reason VARCHAR(30);
+
+UPDATE sales.quote
+SET owner_resolution_reason = 'LEGACY_UNKNOWN'
+WHERE owner_resolution_reason IS NULL;
+
+ALTER TABLE sales.quote
+    ALTER COLUMN owner_resolution_reason SET DEFAULT 'LEGACY_UNKNOWN',
+    ALTER COLUMN owner_resolution_reason SET NOT NULL,
+    ALTER COLUMN assigned_to_id DROP NOT NULL;
+
+ALTER TABLE sales.quote
+    ADD CONSTRAINT chk_quote_owner_resolution_reason
+        CHECK (owner_resolution_reason IN (
+            'EXPLICIT_OVERRIDE',
+            'PRIMARY_ASSIGNMENT',
+            'CREATOR_FALLBACK',
+            'TRIAGE_REQUIRED',
+            'OPTIONAL_UNASSIGNED',
+            'OWNERSHIP_EXEMPT',
+            'LEGACY_UNKNOWN',
+            'ACQUIRER',
+            'ACCOUNT_TEAM'
+        ));

--- a/src/main/resources/db/migration/V20260728124000__backfill_customer_commercial_assignment.sql
+++ b/src/main/resources/db/migration/V20260728124000__backfill_customer_commercial_assignment.sql
@@ -1,0 +1,88 @@
+WITH eligible_customer AS (
+    SELECT
+        partner.tenant_id,
+        partner.id AS customer_id,
+        partner.acquired_by_id,
+        partner.customer_relationship_established_at,
+        policy.mode_effective_at
+    FROM common_company.common_trading_partner partner
+    JOIN sales.ownership_policy policy
+      ON policy.tenant_id = partner.tenant_id
+    WHERE partner.partner_type IN ('CUSTOMER', 'BOTH')
+      AND partner.is_active = TRUE
+      AND policy.default_mode IN ('REQUIRED', 'OPTIONAL')
+),
+candidate AS (
+    SELECT
+        customer.*,
+        CASE
+            WHEN acquirer.id IS NOT NULL THEN acquirer.id
+            WHEN team.member_count = 1 THEN team.sole_user_id
+        END AS representative_id,
+        CASE
+            WHEN acquirer.id IS NOT NULL THEN 'BACKFILL_ACQUIRER'
+            WHEN team.member_count = 1 THEN 'BACKFILL_SOLE_TEAM_MEMBER'
+        END AS assignment_source
+    FROM eligible_customer customer
+    LEFT JOIN common_user.common_user acquirer
+      ON acquirer.tenant_id = customer.tenant_id
+     AND acquirer.id = customer.acquired_by_id
+     AND acquirer.is_active = TRUE
+     AND acquirer.user_type = 'INTERNAL'
+    LEFT JOIN LATERAL (
+        SELECT
+            COUNT(DISTINCT member.user_id) AS member_count,
+            (ARRAY_AGG(DISTINCT member.user_id ORDER BY member.user_id))[1] AS sole_user_id
+        FROM sales.customer_account_team_member member
+        JOIN common_user.common_user team_user
+          ON team_user.tenant_id = member.tenant_id
+         AND team_user.id = member.user_id
+         AND team_user.is_active = TRUE
+         AND team_user.user_type = 'INTERNAL'
+        WHERE member.tenant_id = customer.tenant_id
+          AND member.customer_id = customer.customer_id
+          AND member.is_active = TRUE
+    ) team ON TRUE
+)
+INSERT INTO sales.customer_commercial_assignment (
+    id,
+    tenant_id,
+    uid,
+    customer_id,
+    representative_id,
+    valid_from,
+    source,
+    decided_by_type,
+    decided_by_system_code,
+    policy_version,
+    created_at,
+    updated_at,
+    is_active,
+    version
+)
+SELECT
+    gen_random_uuid(),
+    candidate.tenant_id,
+    'OWNERSHIP-BACKFILL-' || candidate.customer_id,
+    candidate.customer_id,
+    candidate.representative_id,
+    GREATEST(
+        candidate.customer_relationship_established_at,
+        candidate.mode_effective_at
+    ),
+    candidate.assignment_source,
+    'SYSTEM',
+    'OWNERSHIP_POLICY',
+    'OWNERSHIP_BACKFILL_V1',
+    clock_timestamp(),
+    clock_timestamp(),
+    TRUE,
+    0
+FROM candidate
+WHERE candidate.representative_id IS NOT NULL
+  AND NOT EXISTS (
+      SELECT 1
+      FROM sales.customer_commercial_assignment existing
+      WHERE existing.tenant_id = candidate.tenant_id
+        AND existing.customer_id = candidate.customer_id
+  );

--- a/src/main/resources/db/migration/V20260728130000__create_ownership_triage_case_log.sql
+++ b/src/main/resources/db/migration/V20260728130000__create_ownership_triage_case_log.sql
@@ -1,0 +1,50 @@
+CREATE TABLE IF NOT EXISTS sales.ownership_triage_case_log (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id UUID NOT NULL,
+    uid VARCHAR(100) UNIQUE,
+    customer_id UUID NOT NULL,
+    gap_started_at TIMESTAMPTZ NOT NULL,
+    notification_requested_at TIMESTAMPTZ NOT NULL,
+    aging_alert_queued_at TIMESTAMPTZ,
+    resolved_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_by UUID,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_by UUID,
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    deleted_at TIMESTAMPTZ,
+    version BIGINT NOT NULL DEFAULT 0,
+    CONSTRAINT uq_ownership_triage_case
+        UNIQUE (tenant_id, customer_id, gap_started_at),
+    CONSTRAINT chk_ownership_triage_case_timestamps
+        CHECK (
+            aging_alert_queued_at IS NULL
+            OR aging_alert_queued_at >= notification_requested_at
+        )
+);
+
+CREATE INDEX IF NOT EXISTS idx_ownership_triage_case_open
+    ON sales.ownership_triage_case_log (tenant_id, gap_started_at)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_commercial_assignment_latest_closure
+    ON sales.customer_commercial_assignment (tenant_id, customer_id, valid_to DESC)
+    WHERE valid_to IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_quote_unassigned_actionable_by_customer
+    ON sales.quote (tenant_id, customer_id, created_at)
+    WHERE assigned_to_id IS NULL
+      AND status IN ('DRAFT', 'EVALUATION', 'PENDING_APPROVAL', 'APPROVED')
+      AND is_active = TRUE
+      AND deleted_at IS NULL;
+
+COMMENT ON TABLE sales.ownership_triage_case_log IS
+    'Notification bookkeeping only; the ownership triage truth is always derived from policy and assignments.';
+
+ALTER TABLE sales.ownership_triage_case_log ENABLE ROW LEVEL SECURITY;
+ALTER TABLE sales.ownership_triage_case_log FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY rls_tenant_isolation ON sales.ownership_triage_case_log
+    FOR ALL
+    USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    WITH CHECK (tenant_id = current_setting('app.current_tenant', true)::UUID);

--- a/src/main/resources/db/migration/V20260728131000__seed_sales_ownership_triage_notification.sql
+++ b/src/main/resources/db/migration/V20260728131000__seed_sales_ownership_triage_notification.sql
@@ -1,0 +1,146 @@
+-- Seed future tenants through the golden TEMPLATE tenant.
+INSERT INTO i18n.translation_key
+    (id, tenant_id, key_code, module, default_value, description)
+VALUES
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'notification.customer_ownership_triage_opened.title', 'NOTIFICATION',
+     'Sales ownership needed — {customerName}',
+     'New customer ownership triage case notification title'),
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'notification.customer_ownership_triage_opened.body', 'NOTIFICATION',
+     '{customerName} has no eligible commercial representative. '
+       || '{unassignedQuoteCount} open quote(s) are unassigned.',
+     'New customer ownership triage case notification body')
+ON CONFLICT (tenant_id, key_code) DO NOTHING;
+
+INSERT INTO i18n.translation_value
+    (id, tenant_id, translation_key_id, locale, value, is_override)
+SELECT gen_random_uuid(),
+       '00000000-0000-0000-ffff-000000000001',
+       translation_key.id,
+       'TR',
+       CASE translation_key.key_code
+         WHEN 'notification.customer_ownership_triage_opened.title'
+           THEN 'Satış sahipliği gerekli — {customerName}'
+         WHEN 'notification.customer_ownership_triage_opened.body'
+           THEN '{customerName} için uygun ticari temsilci yok. '
+             || '{unassignedQuoteCount} açık teklif sahipsiz.'
+       END,
+       FALSE
+FROM i18n.translation_key translation_key
+WHERE translation_key.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND translation_key.key_code IN (
+    'notification.customer_ownership_triage_opened.title',
+    'notification.customer_ownership_triage_opened.body'
+  )
+ON CONFLICT (translation_key_id, locale, tenant_id) DO NOTHING;
+
+INSERT INTO notification.notification_template
+    (id, tenant_id, event_type, channel, title_key, body_key, importance, delivery_type)
+VALUES
+    (gen_random_uuid(), '00000000-0000-0000-ffff-000000000001',
+     'CUSTOMER_OWNERSHIP_TRIAGE_OPENED', 'IN_APP',
+     'notification.customer_ownership_triage_opened.title',
+     'notification.customer_ownership_triage_opened.body',
+     'HIGH', 'INSTANT')
+ON CONFLICT (tenant_id, event_type, channel) DO NOTHING;
+
+-- Backfill keys into every existing operational tenant.
+INSERT INTO i18n.translation_key
+    (id, tenant_id, uid, key_code, module, default_value, description,
+     is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::VARCHAR,
+       source_key.key_code,
+       source_key.module,
+       source_key.default_value,
+       source_key.description,
+       source_key.is_active,
+       NOW(),
+       NOW(),
+       0
+FROM common_tenant.common_tenant tenant
+CROSS JOIN i18n.translation_key source_key
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND source_key.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND source_key.key_code IN (
+    'notification.customer_ownership_triage_opened.title',
+    'notification.customer_ownership_triage_opened.body'
+  )
+  AND NOT EXISTS (
+    SELECT 1
+    FROM i18n.translation_key destination_key
+    WHERE destination_key.tenant_id = tenant.id
+      AND destination_key.key_code = source_key.key_code
+  );
+
+-- Backfill the notification template into every existing operational tenant.
+INSERT INTO notification.notification_template
+    (id, tenant_id, uid, event_type, channel, title_key, body_key, importance,
+     delivery_type, grouping_window_minutes, is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::VARCHAR,
+       source_template.event_type,
+       source_template.channel,
+       source_template.title_key,
+       source_template.body_key,
+       source_template.importance,
+       source_template.delivery_type,
+       source_template.grouping_window_minutes,
+       source_template.is_active,
+       NOW(),
+       NOW(),
+       0
+FROM common_tenant.common_tenant tenant
+CROSS JOIN notification.notification_template source_template
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND source_template.tenant_id = '00000000-0000-0000-ffff-000000000001'
+  AND source_template.event_type = 'CUSTOMER_OWNERSHIP_TRIAGE_OPENED'
+  AND source_template.channel = 'IN_APP'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM notification.notification_template destination_template
+    WHERE destination_template.tenant_id = tenant.id
+      AND destination_template.event_type = source_template.event_type
+      AND destination_template.channel = source_template.channel
+  );
+
+-- Backfill translations while remapping to each tenant's key IDs.
+INSERT INTO i18n.translation_value
+    (id, tenant_id, uid, translation_key_id, locale, value, is_override,
+     is_active, created_at, updated_at, version)
+SELECT gen_random_uuid(),
+       tenant.id,
+       gen_random_uuid()::VARCHAR,
+       destination_key.id,
+       source_value.locale,
+       source_value.value,
+       source_value.is_override,
+       source_value.is_active,
+       NOW(),
+       NOW(),
+       0
+FROM common_tenant.common_tenant tenant
+JOIN i18n.translation_key source_key
+  ON source_key.tenant_id = '00000000-0000-0000-ffff-000000000001'
+ AND source_key.key_code IN (
+   'notification.customer_ownership_triage_opened.title',
+   'notification.customer_ownership_triage_opened.body'
+ )
+JOIN i18n.translation_value source_value
+  ON source_value.tenant_id = '00000000-0000-0000-ffff-000000000001'
+ AND source_value.translation_key_id = source_key.id
+JOIN i18n.translation_key destination_key
+  ON destination_key.tenant_id = tenant.id
+ AND destination_key.key_code = source_key.key_code
+WHERE tenant.type NOT IN ('TEMPLATE', 'SYSTEM')
+  AND NOT EXISTS (
+    SELECT 1
+    FROM i18n.translation_value destination_value
+    WHERE destination_value.tenant_id = tenant.id
+      AND destination_value.translation_key_id = destination_key.id
+      AND destination_value.locale = source_value.locale
+  );
+

--- a/src/main/resources/db/rollback/V20260728130000_ROLLBACK__create_ownership_triage_case_log.sql
+++ b/src/main/resources/db/rollback/V20260728130000_ROLLBACK__create_ownership_triage_case_log.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS sales.idx_quote_unassigned_actionable_by_customer;
+DROP INDEX IF EXISTS sales.idx_commercial_assignment_latest_closure;
+DROP TABLE IF EXISTS sales.ownership_triage_case_log;
+

--- a/src/main/resources/db/rollback/V20260728131000_ROLLBACK__seed_sales_ownership_triage_notification.sql
+++ b/src/main/resources/db/rollback/V20260728131000_ROLLBACK__seed_sales_ownership_triage_notification.sql
@@ -1,0 +1,18 @@
+DELETE FROM notification.notification_template
+WHERE event_type = 'CUSTOMER_OWNERSHIP_TRIAGE_OPENED';
+
+DELETE FROM i18n.translation_value
+WHERE translation_key_id IN (
+    SELECT id
+    FROM i18n.translation_key
+    WHERE key_code IN (
+        'notification.customer_ownership_triage_opened.title',
+        'notification.customer_ownership_triage_opened.body'
+    )
+);
+
+DELETE FROM i18n.translation_key
+WHERE key_code IN (
+    'notification.customer_ownership_triage_opened.title',
+    'notification.customer_ownership_triage_opened.body'
+);

--- a/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
+++ b/src/test/java/com/fabricmanagement/architecture/ConstitutionArchTest.java
@@ -850,6 +850,8 @@ class ConstitutionArchTest {
       //   - QuoteApprovalService         : Public quote token→tenant lookup before tenant context
       //   - QuoteRetentionPurgeJob       : Scheduled sales retention purge across tenant data
       //   - BatchLotQuantityIntentExpiryJob : Scheduled lot-intent expiry across tenants
+      //   - OwnershipAssignmentReconciliationMonitor : Scheduled cross-tenant ownership
+      // reconciliation
       //   - SystemDataSourceConfig       : Altyapı: DataSource bean konfigürasyonu
       //   - SystemTransactionExecutor    : Self-reference (class itself)
 
@@ -883,6 +885,8 @@ class ConstitutionArchTest {
               .doNotHaveSimpleName("QuoteRetentionPurgeJob")
               .and()
               .doNotHaveSimpleName("BatchLotQuantityIntentExpiryJob")
+              .and()
+              .doNotHaveSimpleName("OwnershipAssignmentReconciliationMonitor")
               .and()
               // The outbox worker is a @Scheduled job with no ambient tenant. Under RLS its
               // tenant-scoped query matched nothing, so 80 emails sat PENDING while the worker

--- a/src/test/java/com/fabricmanagement/notification/hub/app/listener/SalesNotificationListenerTest.java
+++ b/src/test/java/com/fabricmanagement/notification/hub/app/listener/SalesNotificationListenerTest.java
@@ -1,0 +1,68 @@
+package com.fabricmanagement.notification.hub.app.listener;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.notification.hub.app.NotificationHubService;
+import com.fabricmanagement.notification.hub.domain.NotificationEventType;
+import com.fabricmanagement.notification.hub.domain.port.DepartmentRecipientPort;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipTriageOpenedEvent;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SalesNotificationListenerTest {
+
+  @Mock private NotificationHubService notificationHubService;
+  @Mock private DepartmentRecipientPort departmentRecipientPort;
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+
+  @Test
+  void routesTheSalesEventToSalesManagers() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    UUID managerId = UUID.randomUUID();
+    CustomerOwnershipTriageOpenedEvent event =
+        new CustomerOwnershipTriageOpenedEvent(
+            tenantId, customerId, "Acme", Instant.parse("2026-07-28T10:00:00Z"), 3);
+    SalesNotificationListener listener =
+        new SalesNotificationListener(
+            notificationHubService, departmentRecipientPort, idempotentEventHandler);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              invocation.getArgument(3, Runnable.class).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(
+            eq(event.getEventId()),
+            eq(SalesNotificationListener.class),
+            eq("onCustomerOwnershipTriageOpened"),
+            any(Runnable.class));
+    when(departmentRecipientPort.findManagersByDepartmentKeyword(tenantId, "SALES"))
+        .thenReturn(List.of(managerId));
+
+    listener.onCustomerOwnershipTriageOpened(event);
+
+    verify(notificationHubService)
+        .notifyAll(
+            List.of(managerId),
+            tenantId,
+            NotificationEventType.CUSTOMER_OWNERSHIP_TRIAGE_OPENED,
+            Map.of(
+                "customerName", "Acme",
+                "gapStartedAt", "2026-07-28T10:00:00Z",
+                "unassignedQuoteCount", "3"),
+            customerId,
+            "CUSTOMER");
+  }
+}

--- a/src/test/java/com/fabricmanagement/notification/hub/infra/SalesTriageNotificationSeedIT.java
+++ b/src/test/java/com/fabricmanagement/notification/hub/infra/SalesTriageNotificationSeedIT.java
@@ -1,0 +1,94 @@
+package com.fabricmanagement.notification.hub.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.platform.organization.domain.SystemDepartment;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class SalesTriageNotificationSeedIT extends AbstractIntegrationTest {
+
+  @Autowired private JdbcTemplate jdbc;
+
+  @Test
+  void goldenTemplateContainsTheSalesTriageTemplateAndTranslations() {
+    Integer templates =
+        jdbc.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM notification.notification_template
+            WHERE tenant_id = ?
+              AND event_type = 'CUSTOMER_OWNERSHIP_TRIAGE_OPENED'
+              AND channel = 'IN_APP'
+              AND title_key = 'notification.customer_ownership_triage_opened.title'
+              AND body_key = 'notification.customer_ownership_triage_opened.body'
+            """,
+            Integer.class,
+            TenantContext.TEMPLATE_TENANT_ID);
+    Integer keys =
+        jdbc.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM i18n.translation_key
+            WHERE tenant_id = ?
+              AND key_code IN (
+                'notification.customer_ownership_triage_opened.title',
+                'notification.customer_ownership_triage_opened.body'
+              )
+            """,
+            Integer.class,
+            TenantContext.TEMPLATE_TENANT_ID);
+    Integer turkishValues =
+        jdbc.queryForObject(
+            """
+            SELECT COUNT(*)
+            FROM i18n.translation_value value
+            JOIN i18n.translation_key translation_key
+              ON translation_key.id = value.translation_key_id
+             AND translation_key.tenant_id = value.tenant_id
+            WHERE value.tenant_id = ?
+              AND value.locale = 'TR'
+              AND translation_key.key_code IN (
+                'notification.customer_ownership_triage_opened.title',
+                'notification.customer_ownership_triage_opened.body'
+              )
+            """,
+            Integer.class,
+            TenantContext.TEMPLATE_TENANT_ID);
+
+    assertThat(templates).isEqualTo(1);
+    assertThat(keys).isEqualTo(2);
+    assertThat(turkishValues).isEqualTo(2);
+  }
+
+  @Test
+  void operationalTenantSeederIncludesTheCanonicalSalesDepartment() throws Exception {
+    String tenantSeedSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/fabricmanagement/platform/subscription/app/"
+                    + "TenantSeedService.java"));
+
+    assertThat(SystemDepartment.fromCode("SALES")).contains(SystemDepartment.SALES);
+    assertThat(tenantSeedSource)
+        .contains("createDepartment(organizationId, SystemDepartment.SALES, parent);");
+  }
+
+  @Test
+  void tenantClonerIncludesNotificationTemplatesAndTranslations() throws Exception {
+    String clonerSource =
+        Files.readString(
+            Path.of(
+                "src/main/java/com/fabricmanagement/platform/tenant/app/"
+                    + "TenantClonerService.java"));
+
+    assertThat(clonerSource)
+        .contains("\"notification.notification_template\"")
+        .contains("cloneI18nKeysAndValues(");
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/communication/api/facade/CustomerEmailFacadeTest.java
+++ b/src/test/java/com/fabricmanagement/platform/communication/api/facade/CustomerEmailFacadeTest.java
@@ -1,0 +1,42 @@
+package com.fabricmanagement.platform.communication.api.facade;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.communication.app.EmailTemplateRenderer;
+import com.fabricmanagement.platform.communication.app.NotificationService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerEmailFacadeTest {
+
+  @Mock private NotificationService notificationService;
+  @Mock private EmailTemplateRenderer emailTemplateRenderer;
+
+  @Test
+  void rendersAndSendsQuoteApprovalEmailWithoutExposingCommunicationInternals() {
+    UUID tenantId = UUID.randomUUID();
+    CustomerEmailFacade facade =
+        new CustomerEmailFacade(notificationService, emailTemplateRenderer);
+    when(emailTemplateRenderer.renderQuoteApproval(
+            "Heading", "Body", "Review", "Expires soon", "https://example.com/approve"))
+        .thenReturn("<p>Rendered</p>");
+
+    facade.sendQuoteApprovalEmail(
+        tenantId,
+        "buyer@example.com",
+        "Quote ready",
+        "Heading",
+        "Body",
+        "Review",
+        "Expires soon",
+        "https://example.com/approve");
+
+    verify(notificationService)
+        .sendNotificationSync(tenantId, "buyer@example.com", "Quote ready", "<p>Rendered</p>");
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/communication/api/facade/SystemEmailFacadeTest.java
+++ b/src/test/java/com/fabricmanagement/platform/communication/api/facade/SystemEmailFacadeTest.java
@@ -1,0 +1,27 @@
+package com.fabricmanagement.platform.communication.api.facade;
+
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.platform.communication.app.EmailOutboxService;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SystemEmailFacadeTest {
+
+  @Mock private EmailOutboxService emailOutboxService;
+
+  @Test
+  void delegatesToTheTransactionalOutboxWithoutExposingItsEntity() {
+    UUID tenantId = UUID.randomUUID();
+    SystemEmailFacade facade = new SystemEmailFacade(emailOutboxService);
+
+    facade.queueSystemEmail(tenantId, "ops@example.com", "Subject", "<p>Body</p>");
+
+    verify(emailOutboxService)
+        .queueSystemEmail(tenantId, "ops@example.com", "Subject", "<p>Body</p>");
+  }
+}

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/PurgeSchemaCoverageIT.java
@@ -178,6 +178,10 @@ class PurgeSchemaCoverageIT extends AbstractIntegrationTest {
         "common_company.partner_trading_partner_certification",
         "Partner certifications are deleted by dedicated trading-partner cleanup.");
     tables.put("common_policy.common_policy", "Tenant policy configuration is retained.");
+    tables.put(
+        "sales.ownership_policy",
+        "Sales ownership configuration is retained across demo reset; only tenant hard-delete "
+            + "removes it.");
     tables.put("common_user.common_role", "Roles are retained.");
     tables.put(
         "common_user.common_user",

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantClonerServiceIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantClonerServiceIntegrationTest.java
@@ -203,6 +203,16 @@ class TenantClonerServiceIntegrationTest extends AbstractIntegrationTest {
             pg.getId());
     assertThat(routingCount).as("Routing configs should be cloned").isGreaterThanOrEqualTo(0);
 
+    Integer ownershipPolicyCount =
+        jdbc.queryForObject(
+            "SELECT count(*) FROM sales.ownership_policy WHERE tenant_id = ? "
+                + "AND default_mode = 'REQUIRED' AND assignment_ladder_enabled = FALSE",
+            Integer.class,
+            pg.getId());
+    assertThat(ownershipPolicyCount)
+        .as("A disabled default sales ownership policy should be cloned")
+        .isEqualTo(1);
+
     // Verify UIDs are fresh (not copied from template) — CR-5
     List<String> playgroundOrgUids =
         jdbc.queryForList(

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -80,6 +80,7 @@ class TenantTransactionalPurgeServiceTest {
         .containsKeys(
             "sales.quote_send_request",
             "sales.quote",
+            "sales.customer_commercial_assignment",
             "procurement.purchase_order",
             "production.prod_product",
             "production.production_execution_batch_color_archive",
@@ -98,6 +99,10 @@ class TenantTransactionalPurgeServiceTest {
             "human.human_employee_number_sequence",
             "common_user.common_user(seed-demo-users)");
     verify(jdbc).update(contains("DELETE FROM sales.quote WHERE tenant_id = ?"), eq(TENANT_ID));
+    verify(jdbc)
+        .update(
+            contains("DELETE FROM sales.customer_commercial_assignment WHERE tenant_id = ?"),
+            eq(TENANT_ID));
     verify(jdbc)
         .update(
             contains("DELETE FROM sales.quote_send_request WHERE tenant_id = ?"), eq(TENANT_ID));

--- a/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tradingpartner/app/TradingPartnerServiceTest.java
@@ -16,6 +16,8 @@ import com.fabricmanagement.platform.tradingpartner.domain.PartnerStatus;
 import com.fabricmanagement.platform.tradingpartner.domain.PartnerType;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartner;
 import com.fabricmanagement.platform.tradingpartner.domain.TradingPartnerRegistry;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipEstablishedEvent;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipSourceGate;
 import com.fabricmanagement.platform.tradingpartner.domain.event.TradingPartnerCreatedEvent;
 import com.fabricmanagement.platform.tradingpartner.dto.CreateTradingPartnerRequest;
 import com.fabricmanagement.platform.tradingpartner.dto.QuickCreateCustomerContactRequest;
@@ -209,6 +211,15 @@ class TradingPartnerServiceTest {
       assertThat(result.getPartnerType()).isEqualTo(PartnerType.BOTH);
       assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
       assertThat(existing.getAcquiredById()).isEqualTo(acquirerId);
+      assertThat(existing.getCustomerRelationshipEstablishedAt()).isNotNull();
+      ArgumentCaptor<CustomerRelationshipEstablishedEvent> eventCaptor =
+          ArgumentCaptor.forClass(CustomerRelationshipEstablishedEvent.class);
+      verify(eventPublisher).publish(eventCaptor.capture());
+      assertThat(eventCaptor.getValue().getSourceGate())
+          .isEqualTo(CustomerRelationshipSourceGate.CREATE);
+      assertThat(eventCaptor.getValue().getAcquiredById()).isEqualTo(acquirerId);
+      assertThat(eventCaptor.getValue().getEstablishedAt())
+          .isEqualTo(existing.getCustomerRelationshipEstablishedAt());
     }
 
     @Test
@@ -244,6 +255,7 @@ class TradingPartnerServiceTest {
       TradingPartnerDto result = service.createPartner(request, acquirerId);
 
       assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+      assertThat(result.getCustomerRelationshipEstablishedAt()).isNotNull();
     }
 
     @Test
@@ -418,6 +430,13 @@ class TradingPartnerServiceTest {
 
       assertThat(result.getPartnerType()).isEqualTo(PartnerType.CUSTOMER);
       assertThat(result.getAcquiredById()).isEqualTo(acquirerId);
+      ArgumentCaptor<CustomerRelationshipEstablishedEvent> eventCaptor =
+          ArgumentCaptor.forClass(CustomerRelationshipEstablishedEvent.class);
+      verify(eventPublisher).publish(eventCaptor.capture());
+      assertThat(eventCaptor.getValue().getSourceGate())
+          .isEqualTo(CustomerRelationshipSourceGate.SUPPLIER_CONVERSION);
+      assertThat(eventCaptor.getValue().getEstablishedAt())
+          .isEqualTo(partner.getCustomerRelationshipEstablishedAt());
     }
 
     @Test
@@ -494,6 +513,14 @@ class TradingPartnerServiceTest {
 
       assertThat(result.getPartnerType()).isEqualTo(PartnerType.CUSTOMER);
       assertThat(result.isPendingAccountingReview()).isTrue();
+      ArgumentCaptor<CustomerRelationshipEstablishedEvent> relationshipEventCaptor =
+          ArgumentCaptor.forClass(CustomerRelationshipEstablishedEvent.class);
+      verify(eventPublisher).publish(relationshipEventCaptor.capture());
+      assertThat(relationshipEventCaptor.getValue().getSourceGate())
+          .isEqualTo(CustomerRelationshipSourceGate.QUICK_CREATE);
+      assertThat(relationshipEventCaptor.getValue().getAcquiredById()).isNull();
+      assertThat(relationshipEventCaptor.getValue().getEstablishedAt())
+          .isEqualTo(result.getCustomerRelationshipEstablishedAt());
 
       ArgumentCaptor<TradingPartner> partnerCaptor = ArgumentCaptor.forClass(TradingPartner.class);
       verify(partnerRepository, org.mockito.Mockito.times(2)).save(partnerCaptor.capture());

--- a/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
@@ -9,6 +9,9 @@ import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialA
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.repository.CrudRepository;
@@ -51,5 +54,42 @@ class SalesOwnershipArchTest {
         .noneMatch(
             method ->
                 method.getName().startsWith("delete") || method.getName().startsWith("remove"));
+  }
+
+  @Test
+  void salesPublishesEventsWithoutDependingOnNotificationInternals() {
+    noClasses()
+        .that()
+        .resideInAPackage("com.fabricmanagement.sales..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("com.fabricmanagement.notification..")
+        .check(productionClasses);
+  }
+
+  @Test
+  void salesUsesOnlyThePublicCommunicationFacade() {
+    noClasses()
+        .that()
+        .resideInAPackage("com.fabricmanagement.sales..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("com.fabricmanagement.platform.communication.app..")
+        .check(productionClasses);
+  }
+
+  @Test
+  void triageCaseLogMigrationHasPhysicalDedupAndRls() throws IOException {
+    String migration =
+        Files.readString(
+            Path.of(
+                "src/main/resources/db/migration/"
+                    + "V20260728130000__create_ownership_triage_case_log.sql"));
+
+    assertThat(migration)
+        .contains("UNIQUE (tenant_id, customer_id, gap_started_at)")
+        .contains("ENABLE ROW LEVEL SECURITY")
+        .contains("FORCE ROW LEVEL SECURITY")
+        .doesNotContain("FOREIGN KEY");
   }
 }

--- a/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/SalesOwnershipArchTest.java
@@ -5,11 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fabricmanagement.common.infrastructure.persistence.BaseJunctionEntity;
 import com.fabricmanagement.sales.ownership.domain.CustomerAccountTeamMember;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialAssignmentRepository;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
 
 class SalesOwnershipArchTest {
 
@@ -28,6 +30,8 @@ class SalesOwnershipArchTest {
     noClasses()
         .that()
         .resideInAPackage("com.fabricmanagement.sales.ownership..")
+        .and()
+        .haveSimpleNameNotEndingWith("Listener")
         .should()
         .dependOnClassesThat()
         .resideInAPackage("com.fabricmanagement.platform..domain..")
@@ -37,5 +41,15 @@ class SalesOwnershipArchTest {
   @Test
   void accountTeamMemberReusesJunctionAuditAndSoftDeleteContract() {
     assertThat(CustomerAccountTeamMember.class.getSuperclass()).isEqualTo(BaseJunctionEntity.class);
+  }
+
+  @Test
+  void commercialAssignmentRepositoryExposesNoRowDeleteSurface() {
+    assertThat(CrudRepository.class.isAssignableFrom(CustomerCommercialAssignmentRepository.class))
+        .isFalse();
+    assertThat(CustomerCommercialAssignmentRepository.class.getMethods())
+        .noneMatch(
+            method ->
+                method.getName().startsWith("delete") || method.getName().startsWith("remove"));
   }
 }

--- a/src/test/java/com/fabricmanagement/sales/ownership/api/controller/OwnershipTriageControllerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/api/controller/OwnershipTriageControllerTest.java
@@ -1,0 +1,75 @@
+package com.fabricmanagement.sales.ownership.api.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.ownership.app.CustomerCommercialAssignmentService;
+import com.fabricmanagement.sales.ownership.app.OwnershipTriageService;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.dto.AssignPrimaryRepresentativeRequest;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class OwnershipTriageControllerTest {
+
+  @Mock private OwnershipTriageService triageService;
+  @Mock private CustomerCommercialAssignmentService assignmentService;
+
+  @AfterEach
+  void clearTenant() {
+    TenantContext.clear();
+  }
+
+  @Test
+  void resolutionEndpointUsesTheExistingAssignmentServiceWithTriageProvenance() {
+    UUID tenantId = UUID.randomUUID();
+    UUID actorId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    UUID representativeId = UUID.randomUUID();
+    TenantContext.setCurrentTenantId(tenantId);
+    TenantContext.setCurrentUserId(actorId);
+    CustomerCommercialAssignment assignment =
+        CustomerCommercialAssignment.open(
+            customerId,
+            representativeId,
+            Instant.parse("2026-07-28T12:00:00Z"),
+            AssignmentSource.TRIAGE_RESOLUTION,
+            ActorRef.user(actorId),
+            "OWNERSHIP_POLICY_V1",
+            null);
+    assignment.setId(UUID.randomUUID());
+    assignment.setTenantId(tenantId);
+    when(assignmentService.assignPrimary(
+            tenantId,
+            customerId,
+            representativeId,
+            AssignmentSource.TRIAGE_RESOLUTION,
+            ActorRef.user(actorId)))
+        .thenReturn(assignment);
+    OwnershipTriageController controller =
+        new OwnershipTriageController(triageService, assignmentService);
+
+    var response =
+        controller.resolve(customerId, new AssignPrimaryRepresentativeRequest(representativeId));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+    verify(assignmentService)
+        .assignPrimary(
+            tenantId,
+            customerId,
+            representativeId,
+            AssignmentSource.TRIAGE_RESOLUTION,
+            ActorRef.user(actorId));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/AssignmentFirstPolicyTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/AssignmentFirstPolicyTest.java
@@ -1,0 +1,142 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.domain.OwnershipMode;
+import com.fabricmanagement.sales.ownership.domain.OwnershipPolicy;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentFirstPolicyTest {
+
+  @Mock private CustomerEligibilityService customerEligibilityService;
+  @Mock private CustomerCommercialAssignmentService assignmentService;
+  @Mock private OwnershipPolicyService ownershipPolicyService;
+  @Mock private UserQueryService userQueryService;
+  @Mock private AcquirerFirstPolicy acquirerFirstPolicy;
+  @Mock private OwnershipPolicy ownershipPolicy;
+
+  private AssignmentFirstPolicy policy;
+  private UUID tenantId;
+  private UUID customerId;
+
+  @BeforeEach
+  void setUp() {
+    policy =
+        new AssignmentFirstPolicy(
+            customerEligibilityService,
+            assignmentService,
+            ownershipPolicyService,
+            userQueryService,
+            acquirerFirstPolicy);
+    tenantId = UUID.randomUUID();
+    customerId = UUID.randomUUID();
+    when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, null));
+  }
+
+  @Test
+  void explicitOverrideWinsBeforePrimaryAssignment() {
+    UUID primaryId = UUID.randomUUID();
+    UUID overrideId = UUID.randomUUID();
+    when(assignmentService.findCurrent(tenantId, customerId))
+        .thenReturn(Optional.of(assignment(primaryId)));
+    when(userQueryService.findById(tenantId, primaryId))
+        .thenReturn(Optional.of(activeUser(primaryId)));
+    when(acquirerFirstPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, overrideId)))
+        .thenReturn(new OwnerResolution(overrideId, OwnerResolutionReason.EXPLICIT_OVERRIDE));
+
+    OwnerResolution result =
+        policy.resolve(new OwnerResolutionContext(tenantId, customerId, overrideId));
+
+    assertThat(result.ownerId()).isEqualTo(overrideId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.EXPLICIT_OVERRIDE);
+  }
+
+  @Test
+  void activeAssignmentIsPrimaryAndHistoricalLadderStepsAreNotUsed() {
+    UUID primaryId = UUID.randomUUID();
+    when(assignmentService.findCurrent(tenantId, customerId))
+        .thenReturn(Optional.of(assignment(primaryId)));
+    when(userQueryService.findById(tenantId, primaryId))
+        .thenReturn(Optional.of(activeUser(primaryId)));
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isEqualTo(primaryId);
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.PRIMARY_ASSIGNMENT);
+  }
+
+  @Test
+  void inactiveAssignmentIsIgnoredAndRequiredModeNeedsTriage() {
+    UUID inactiveId = UUID.randomUUID();
+    when(assignmentService.findCurrent(tenantId, customerId))
+        .thenReturn(Optional.of(assignment(inactiveId)));
+    when(userQueryService.findById(tenantId, inactiveId))
+        .thenReturn(Optional.of(UserDto.builder().id(inactiveId).isActive(false).build()));
+    mode(OwnershipMode.REQUIRED);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isNull();
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.TRIAGE_REQUIRED);
+  }
+
+  @Test
+  void optionalModeAllowsUnassignedCustomer() {
+    when(assignmentService.findCurrent(tenantId, customerId)).thenReturn(Optional.empty());
+    mode(OwnershipMode.OPTIONAL);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isNull();
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.OPTIONAL_UNASSIGNED);
+  }
+
+  @Test
+  void exemptModeDoesNotRequireOwnership() {
+    when(assignmentService.findCurrent(tenantId, customerId)).thenReturn(Optional.empty());
+    mode(OwnershipMode.EXEMPT);
+
+    OwnerResolution result = policy.resolve(new OwnerResolutionContext(tenantId, customerId, null));
+
+    assertThat(result.ownerId()).isNull();
+    assertThat(result.reason()).isEqualTo(OwnerResolutionReason.OWNERSHIP_EXEMPT);
+  }
+
+  private void mode(OwnershipMode mode) {
+    when(ownershipPolicyService.requirePolicy(tenantId)).thenReturn(ownershipPolicy);
+    when(ownershipPolicy.getDefaultMode()).thenReturn(mode);
+  }
+
+  private UserDto activeUser(UUID userId) {
+    return UserDto.builder().id(userId).isActive(true).build();
+  }
+
+  private CustomerCommercialAssignment assignment(UUID representativeId) {
+    return CustomerCommercialAssignment.open(
+        customerId,
+        representativeId,
+        Instant.parse("2026-07-28T09:00:00Z"),
+        AssignmentSource.MANUAL,
+        ActorRef.user(UUID.randomUUID()),
+        "OWNERSHIP_POLICY_V1",
+        null);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentServiceTest.java
@@ -1,0 +1,182 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.platform.user.app.UserQueryService;
+import com.fabricmanagement.platform.user.dto.UserDto;
+import com.fabricmanagement.sales.common.exception.SalesDomainException;
+import com.fabricmanagement.sales.ownership.domain.ActorRef;
+import com.fabricmanagement.sales.ownership.domain.AssignmentActorType;
+import com.fabricmanagement.sales.ownership.domain.AssignmentClosureReason;
+import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
+import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialAssignmentRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerCommercialAssignmentServiceTest {
+
+  @Mock private CustomerCommercialAssignmentRepository repository;
+  @Mock private CustomerEligibilityService customerEligibilityService;
+  @Mock private UserQueryService userQueryService;
+  @InjectMocks private CustomerCommercialAssignmentService service;
+
+  private UUID tenantId;
+  private UUID customerId;
+  private UUID representativeId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    customerId = UUID.randomUUID();
+    representativeId = UUID.randomUUID();
+    lenient()
+        .when(customerEligibilityService.requireEligible(tenantId, customerId))
+        .thenReturn(new CustomerEligibilityService.EligibleCustomer(customerId, null));
+  }
+
+  @Test
+  void rejectsInactiveRepresentativeWithUnprocessableEntity() {
+    when(userQueryService.findById(tenantId, representativeId))
+        .thenReturn(Optional.of(UserDto.builder().id(representativeId).isActive(false).build()));
+
+    assertThatThrownBy(
+            () ->
+                service.assignPrimary(
+                    tenantId,
+                    customerId,
+                    representativeId,
+                    AssignmentSource.MANUAL,
+                    ActorRef.user(UUID.randomUUID())))
+        .isInstanceOfSatisfying(
+            SalesDomainException.class,
+            error -> {
+              assertThat(error.getHttpStatus()).isEqualTo(422);
+              assertThat(error.getErrorCode())
+                  .isEqualTo("SALES_021_COMMERCIAL_ASSIGNMENT_USER_INACTIVE");
+            });
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void closesAndFlushesCurrentAssignmentBeforeOpeningReplacement() {
+    UUID decidingUserId = UUID.randomUUID();
+    CustomerCommercialAssignment current =
+        assignment(representativeId, ActorRef.user(decidingUserId));
+    UUID replacementId = UUID.randomUUID();
+    when(userQueryService.findById(tenantId, replacementId))
+        .thenReturn(Optional.of(UserDto.builder().id(replacementId).isActive(true).build()));
+    when(repository.findByTenantIdAndCustomerIdAndValidToIsNull(tenantId, customerId))
+        .thenReturn(Optional.of(current));
+    when(repository.save(any(CustomerCommercialAssignment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    CustomerCommercialAssignment replacement =
+        service.assignPrimary(
+            tenantId,
+            customerId,
+            replacementId,
+            AssignmentSource.MANUAL,
+            ActorRef.user(UUID.randomUUID()));
+
+    assertThat(current.getClosureReason()).isEqualTo(AssignmentClosureReason.SUPERSEDED);
+    assertThat(current.getDecidedByType()).isEqualTo(AssignmentActorType.USER);
+    assertThat(current.getDecidedByUserId()).isEqualTo(decidingUserId);
+    assertThat(replacement.getRepresentativeId()).isEqualTo(replacementId);
+    assertThat(replacement.getSupersedesAssignmentId()).isEqualTo(current.getId());
+    verify(repository).flush();
+  }
+
+  @Test
+  void acquisitionConsumerDoesNothingForExistingHistory() {
+    when(repository.existsByTenantIdAndCustomerId(tenantId, customerId)).thenReturn(true);
+
+    assertThat(
+            service.createAcquisitionIfAbsent(
+                tenantId, customerId, representativeId, Instant.now()))
+        .isEmpty();
+    verify(userQueryService, never()).findById(any(), any());
+    verify(repository, never()).save(any());
+  }
+
+  @Test
+  void acquisitionConsumerUsesTheRelationshipTimestampForNewTruth() {
+    Instant establishedAt = Instant.parse("2026-07-28T07:30:00Z");
+    when(repository.existsByTenantIdAndCustomerId(tenantId, customerId)).thenReturn(false);
+    when(userQueryService.findById(tenantId, representativeId))
+        .thenReturn(Optional.of(UserDto.builder().id(representativeId).isActive(true).build()));
+    when(repository.save(any(CustomerCommercialAssignment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    CustomerCommercialAssignment assignment =
+        service
+            .createAcquisitionIfAbsent(tenantId, customerId, representativeId, establishedAt)
+            .orElseThrow();
+
+    assertThat(assignment.getValidFrom()).isEqualTo(establishedAt);
+    assertThat(assignment.getSource()).isEqualTo(AssignmentSource.ACQUISITION);
+    assertThat(assignment.getDecidedByType()).isEqualTo(AssignmentActorType.SYSTEM);
+    assertThat(assignment.getDecidedBySystemCode()).isEqualTo("OWNERSHIP_POLICY");
+  }
+
+  @Test
+  void deactivationClosesEveryOpenAssignmentWithoutChangingCreationActor() {
+    UUID decidingUserId = UUID.randomUUID();
+    CustomerCommercialAssignment first =
+        assignment(representativeId, ActorRef.user(decidingUserId));
+    CustomerCommercialAssignment second =
+        CustomerCommercialAssignment.open(
+            UUID.randomUUID(),
+            representativeId,
+            Instant.parse("2026-07-28T08:00:00Z"),
+            AssignmentSource.ACQUISITION,
+            ActorRef.system("OWNERSHIP_POLICY"),
+            "OWNERSHIP_POLICY_V1",
+            null);
+    Instant occurredAt = Instant.parse("2026-07-28T10:00:00Z");
+    when(repository.findAllByTenantIdAndRepresentativeIdAndValidToIsNullOrderByCustomerId(
+            tenantId, representativeId))
+        .thenReturn(List.of(first, second));
+
+    int closed =
+        service.closeAllForDeactivatedRepresentative(tenantId, representativeId, occurredAt);
+
+    assertThat(closed).isEqualTo(2);
+    assertThat(first.getValidTo()).isEqualTo(occurredAt);
+    assertThat(first.getDecidedByUserId()).isEqualTo(decidingUserId);
+    assertThat(second.getDecidedBySystemCode()).isEqualTo("OWNERSHIP_POLICY");
+    assertThat(first.getClosureReason())
+        .isEqualTo(AssignmentClosureReason.REPRESENTATIVE_DEACTIVATED);
+    assertThat(first.getClosedBySystemCode()).isEqualTo("OWNERSHIP_POLICY");
+  }
+
+  private CustomerCommercialAssignment assignment(UUID repId, ActorRef actor) {
+    CustomerCommercialAssignment assignment =
+        CustomerCommercialAssignment.open(
+            customerId,
+            repId,
+            Instant.parse("2026-07-28T09:00:00Z"),
+            AssignmentSource.MANUAL,
+            actor,
+            "OWNERSHIP_POLICY_V1",
+            null);
+    assignment.setId(UUID.randomUUID());
+    assignment.setTenantId(tenantId);
+    return assignment;
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerCommercialAssignmentServiceTest.java
@@ -16,6 +16,7 @@ import com.fabricmanagement.sales.ownership.domain.AssignmentActorType;
 import com.fabricmanagement.sales.ownership.domain.AssignmentClosureReason;
 import com.fabricmanagement.sales.ownership.domain.AssignmentSource;
 import com.fabricmanagement.sales.ownership.domain.CustomerCommercialAssignment;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipResolvedEvent;
 import com.fabricmanagement.sales.ownership.infra.repository.CustomerCommercialAssignmentRepository;
 import java.time.Instant;
 import java.util.List;
@@ -24,9 +25,11 @@ import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class CustomerCommercialAssignmentServiceTest {
@@ -34,6 +37,7 @@ class CustomerCommercialAssignmentServiceTest {
   @Mock private CustomerCommercialAssignmentRepository repository;
   @Mock private CustomerEligibilityService customerEligibilityService;
   @Mock private UserQueryService userQueryService;
+  @Mock private ApplicationEventPublisher eventPublisher;
   @InjectMocks private CustomerCommercialAssignmentService service;
 
   private UUID tenantId;
@@ -100,6 +104,30 @@ class CustomerCommercialAssignmentServiceTest {
     assertThat(replacement.getRepresentativeId()).isEqualTo(replacementId);
     assertThat(replacement.getSupersedesAssignmentId()).isEqualTo(current.getId());
     verify(repository).flush();
+  }
+
+  @Test
+  void triageResolutionPublishesTheResolutionEvent() {
+    when(userQueryService.findById(tenantId, representativeId))
+        .thenReturn(Optional.of(UserDto.builder().id(representativeId).isActive(true).build()));
+    when(repository.findByTenantIdAndCustomerIdAndValidToIsNull(tenantId, customerId))
+        .thenReturn(Optional.empty());
+    when(repository.save(any(CustomerCommercialAssignment.class)))
+        .thenAnswer(invocation -> invocation.getArgument(0));
+
+    service.assignPrimary(
+        tenantId,
+        customerId,
+        representativeId,
+        AssignmentSource.TRIAGE_RESOLUTION,
+        ActorRef.user(UUID.randomUUID()));
+
+    ArgumentCaptor<CustomerOwnershipResolvedEvent> eventCaptor =
+        ArgumentCaptor.forClass(CustomerOwnershipResolvedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getTenantId()).isEqualTo(tenantId);
+    assertThat(eventCaptor.getValue().getCustomerId()).isEqualTo(customerId);
+    assertThat(eventCaptor.getValue().getRepresentativeId()).isEqualTo(representativeId);
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerEligibilityServiceTest.java
@@ -30,7 +30,8 @@ class CustomerEligibilityServiceTest {
     UUID acquirerId = UUID.randomUUID();
     when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, requestedId))
         .thenReturn(
-            Optional.of(new TradingPartnerOwnershipSnapshot(canonicalId, acquirerId, true, true)));
+            Optional.of(
+                new TradingPartnerOwnershipSnapshot(canonicalId, acquirerId, null, true, true)));
 
     CustomerEligibilityService.EligibleCustomer result =
         service.requireEligible(tenantId, requestedId);
@@ -56,7 +57,7 @@ class CustomerEligibilityServiceTest {
     UUID customerId = UUID.randomUUID();
     when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, customerId))
         .thenReturn(
-            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, false, true)));
+            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, null, false, true)));
 
     assertThatThrownBy(() -> service.requireEligible(tenantId, customerId))
         .isInstanceOfSatisfying(
@@ -70,7 +71,7 @@ class CustomerEligibilityServiceTest {
     UUID customerId = UUID.randomUUID();
     when(tradingPartnerResolver.resolveOwnershipSnapshot(tenantId, customerId))
         .thenReturn(
-            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, true, false)));
+            Optional.of(new TradingPartnerOwnershipSnapshot(customerId, null, null, true, false)));
 
     assertThatThrownBy(() -> service.requireEligible(tenantId, customerId))
         .isInstanceOfSatisfying(

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerOwnershipResolvedListenerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerOwnershipResolvedListenerTest.java
@@ -1,0 +1,63 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipResolvedEvent;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageCaseLogRepository;
+import com.fabricmanagement.sales.quote.app.QuoteService;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerOwnershipResolvedListenerTest {
+
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+  @Mock private QuoteService quoteService;
+  @Mock private OwnershipTriageCaseLogRepository caseLogRepository;
+
+  @Test
+  void backfillsOnlyThroughTheScopedQuoteOperationAndResolvesTheLog() {
+    CustomerOwnershipResolvedEvent event =
+        new CustomerOwnershipResolvedEvent(
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID(),
+            Instant.parse("2026-07-28T12:00:00Z"));
+    CustomerOwnershipResolvedListener listener =
+        new CustomerOwnershipResolvedListener(
+            idempotentEventHandler, quoteService, caseLogRepository);
+    org.mockito.Mockito.doAnswer(
+            invocation -> {
+              invocation.getArgument(3, Runnable.class).run();
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(
+            eq(event.getEventId()),
+            eq(CustomerOwnershipResolvedListener.class),
+            eq("onCustomerOwnershipResolved"),
+            any(Runnable.class));
+    when(quoteService.backfillUnassignedActionableQuotes(
+            event.getTenantId(), event.getCustomerId(), event.getRepresentativeId()))
+        .thenReturn(2);
+    when(caseLogRepository.resolveOpenCases(
+            event.getTenantId(), event.getCustomerId(), event.getResolvedAt()))
+        .thenReturn(1);
+
+    listener.onCustomerOwnershipResolved(event);
+
+    verify(quoteService)
+        .backfillUnassignedActionableQuotes(
+            event.getTenantId(), event.getCustomerId(), event.getRepresentativeId());
+    verify(caseLogRepository)
+        .resolveOpenCases(event.getTenantId(), event.getCustomerId(), event.getResolvedAt());
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerRelationshipEstablishedListenerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/CustomerRelationshipEstablishedListenerTest.java
@@ -1,0 +1,101 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipEstablishedEvent;
+import com.fabricmanagement.platform.tradingpartner.domain.event.CustomerRelationshipSourceGate;
+import com.fabricmanagement.sales.ownership.domain.OwnershipMode;
+import com.fabricmanagement.sales.ownership.domain.OwnershipPolicy;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CustomerRelationshipEstablishedListenerTest {
+
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+  @Mock private OwnershipPolicyService ownershipPolicyService;
+  @Mock private CustomerCommercialAssignmentService assignmentService;
+  @Mock private OwnershipPolicy policy;
+
+  private CustomerRelationshipEstablishedListener listener;
+  private final Set<UUID> processedEventIds = new HashSet<>();
+
+  @BeforeEach
+  void setUp() {
+    listener =
+        new CustomerRelationshipEstablishedListener(
+            idempotentEventHandler, ownershipPolicyService, assignmentService);
+    doAnswer(
+            invocation -> {
+              UUID eventId = invocation.getArgument(0);
+              Runnable handler = invocation.getArgument(3);
+              if (processedEventIds.add(eventId)) {
+                handler.run();
+              }
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(UUID.class), any(Class.class), anyString(), any(Runnable.class));
+  }
+
+  @Test
+  void createsAcquisitionAssignmentOnceForNonExemptRelationship() {
+    CustomerRelationshipEstablishedEvent event = event(UUID.randomUUID());
+    when(ownershipPolicyService.requirePolicy(event.getTenantId())).thenReturn(policy);
+    when(policy.getDefaultMode()).thenReturn(OwnershipMode.REQUIRED);
+
+    listener.onCustomerRelationshipEstablished(event);
+    listener.onCustomerRelationshipEstablished(event);
+
+    verify(assignmentService)
+        .createAcquisitionIfAbsent(
+            event.getTenantId(),
+            event.getCustomerId(),
+            event.getAcquiredById(),
+            event.getEstablishedAt());
+  }
+
+  @Test
+  void nullAcquirerStillRepresentsAnEventButCreatesNoAssignment() {
+    CustomerRelationshipEstablishedEvent event = event(null);
+    when(ownershipPolicyService.requirePolicy(event.getTenantId())).thenReturn(policy);
+    when(policy.getDefaultMode()).thenReturn(OwnershipMode.REQUIRED);
+
+    listener.onCustomerRelationshipEstablished(event);
+
+    verify(assignmentService, never()).createAcquisitionIfAbsent(any(), any(), any(), any());
+  }
+
+  @Test
+  void exemptModeCreatesNoAssignment() {
+    CustomerRelationshipEstablishedEvent event = event(UUID.randomUUID());
+    when(ownershipPolicyService.requirePolicy(event.getTenantId())).thenReturn(policy);
+    when(policy.getDefaultMode()).thenReturn(OwnershipMode.EXEMPT);
+
+    listener.onCustomerRelationshipEstablished(event);
+
+    verify(assignmentService, never()).createAcquisitionIfAbsent(any(), any(), any(), any());
+  }
+
+  private CustomerRelationshipEstablishedEvent event(UUID acquiredById) {
+    return new CustomerRelationshipEstablishedEvent(
+        UUID.randomUUID(),
+        UUID.randomUUID(),
+        acquiredById,
+        Instant.parse("2026-07-28T09:00:00Z"),
+        CustomerRelationshipSourceGate.CREATE);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/FeatureFlaggedOwnerPolicyTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/FeatureFlaggedOwnerPolicyTest.java
@@ -1,0 +1,77 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.sales.ownership.domain.OwnerResolution;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
+import com.fabricmanagement.sales.ownership.domain.OwnershipPolicy;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class FeatureFlaggedOwnerPolicyTest {
+
+  @Mock private AcquirerFirstPolicy acquirerFirstPolicy;
+  @Mock private AssignmentFirstPolicy assignmentFirstPolicy;
+  @Mock private OwnershipPolicyService ownershipPolicyService;
+  @Mock private OwnershipPolicy ownershipPolicy;
+
+  @Test
+  void globalKillSwitchKeepsAcquirerFirstPolicyActive() {
+    UUID tenantId = UUID.randomUUID();
+    OwnerResolutionContext context = new OwnerResolutionContext(tenantId, UUID.randomUUID(), null);
+    OwnerResolution legacy = new OwnerResolution(UUID.randomUUID(), OwnerResolutionReason.ACQUIRER);
+    FeatureFlaggedOwnerPolicy policy =
+        new FeatureFlaggedOwnerPolicy(
+            acquirerFirstPolicy, assignmentFirstPolicy, ownershipPolicyService);
+    ReflectionTestUtils.setField(policy, "globalAssignmentLadderEnabled", false);
+    when(acquirerFirstPolicy.resolve(context)).thenReturn(legacy);
+
+    assertThat(policy.resolve(context)).isEqualTo(legacy);
+    verifyNoInteractions(assignmentFirstPolicy);
+    verifyNoInteractions(ownershipPolicyService);
+  }
+
+  @Test
+  void bothFlagsAreRequiredForAssignmentFirstPolicy() {
+    UUID tenantId = UUID.randomUUID();
+    OwnerResolutionContext context = new OwnerResolutionContext(tenantId, UUID.randomUUID(), null);
+    OwnerResolution assignment =
+        new OwnerResolution(UUID.randomUUID(), OwnerResolutionReason.PRIMARY_ASSIGNMENT);
+    FeatureFlaggedOwnerPolicy policy =
+        new FeatureFlaggedOwnerPolicy(
+            acquirerFirstPolicy, assignmentFirstPolicy, ownershipPolicyService);
+    ReflectionTestUtils.setField(policy, "globalAssignmentLadderEnabled", true);
+    when(ownershipPolicyService.requirePolicy(tenantId)).thenReturn(ownershipPolicy);
+    when(ownershipPolicy.isAssignmentLadderEnabled()).thenReturn(true);
+    when(assignmentFirstPolicy.resolve(context)).thenReturn(assignment);
+
+    assertThat(policy.resolve(context)).isEqualTo(assignment);
+    verifyNoInteractions(acquirerFirstPolicy);
+  }
+
+  @Test
+  void tenantFlagKeepsLegacyPolicyWhenGlobalGateIsAvailable() {
+    UUID tenantId = UUID.randomUUID();
+    OwnerResolutionContext context = new OwnerResolutionContext(tenantId, UUID.randomUUID(), null);
+    OwnerResolution legacy =
+        new OwnerResolution(UUID.randomUUID(), OwnerResolutionReason.ACCOUNT_TEAM);
+    FeatureFlaggedOwnerPolicy policy =
+        new FeatureFlaggedOwnerPolicy(
+            acquirerFirstPolicy, assignmentFirstPolicy, ownershipPolicyService);
+    ReflectionTestUtils.setField(policy, "globalAssignmentLadderEnabled", true);
+    when(ownershipPolicyService.requirePolicy(tenantId)).thenReturn(ownershipPolicy);
+    when(ownershipPolicy.isAssignmentLadderEnabled()).thenReturn(false);
+    when(acquirerFirstPolicy.resolve(context)).thenReturn(legacy);
+
+    assertThat(policy.resolve(context)).isEqualTo(legacy);
+    verifyNoInteractions(assignmentFirstPolicy);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageProcessorTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/OwnershipTriageProcessorTest.java
@@ -1,0 +1,102 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import com.fabricmanagement.sales.ownership.domain.event.CustomerOwnershipTriageOpenedEvent;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageCaseLogRepository;
+import com.fabricmanagement.sales.ownership.infra.repository.OwnershipTriageQueryRepository;
+import java.lang.reflect.Method;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.annotation.Transactional;
+
+@ExtendWith(MockitoExtension.class)
+class OwnershipTriageProcessorTest {
+
+  private static final Instant NOW = Instant.parse("2026-07-28T12:00:00Z");
+
+  @Mock private OwnershipTriageQueryRepository queryRepository;
+  @Mock private OwnershipTriageCaseLogRepository caseLogRepository;
+  @Mock private OwnershipTriageAgingEmailAdapter agingEmailAdapter;
+  @Mock private ApplicationEventPublisher eventPublisher;
+
+  private OwnershipTriageProcessor processor;
+  private UUID tenantId;
+  private OwnershipTriageCase triageCase;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    triageCase =
+        new OwnershipTriageCase(
+            UUID.randomUUID(), "Acme", 2, NOW.minusSeconds(7_200), NOW.minusSeconds(90_000), 24);
+    processor =
+        new OwnershipTriageProcessor(
+            queryRepository,
+            caseLogRepository,
+            agingEmailAdapter,
+            eventPublisher,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+    org.mockito.Mockito.lenient()
+        .when(queryRepository.findAll(tenantId))
+        .thenReturn(List.of(triageCase));
+    when(caseLogRepository.countUnresolvedConflicts(tenantId)).thenReturn(0L);
+  }
+
+  @Test
+  void onlyDatabaseWinnersPublishAndQueueAcrossRepeatedRuns() throws NoSuchMethodException {
+    Method processTenant = OwnershipTriageProcessor.class.getMethod("processTenant", UUID.class);
+    assertThat(processTenant.getAnnotation(Transactional.class)).isNotNull();
+
+    when(caseLogRepository.tryRecordNotificationRequested(
+            tenantId, triageCase.customerId(), triageCase.gapStartedAt(), NOW))
+        .thenReturn(true, false);
+    when(caseLogRepository.tryMarkAgingAlertQueued(
+            tenantId, triageCase.customerId(), triageCase.gapStartedAt(), NOW))
+        .thenReturn(true, false);
+
+    OwnershipTriageProcessor.ProcessingSummary first = processor.processTenant(tenantId);
+    OwnershipTriageProcessor.ProcessingSummary second = processor.processTenant(tenantId);
+
+    assertThat(first.notificationsRequested()).isEqualTo(1);
+    assertThat(first.agingAlertsQueued()).isEqualTo(1);
+    assertThat(second.notificationsRequested()).isZero();
+    assertThat(second.agingAlertsQueued()).isZero();
+    ArgumentCaptor<CustomerOwnershipTriageOpenedEvent> eventCaptor =
+        ArgumentCaptor.forClass(CustomerOwnershipTriageOpenedEvent.class);
+    verify(eventPublisher).publishEvent(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().getCustomerId()).isEqualTo(triageCase.customerId());
+    verify(agingEmailAdapter).queue(tenantId, triageCase);
+  }
+
+  @Test
+  void youngCasesNeverAttemptTheAgingClaim() {
+    OwnershipTriageCase youngCase =
+        new OwnershipTriageCase(
+            triageCase.customerId(), "Acme", 0, null, NOW.minusSeconds(3_600), 24);
+    when(queryRepository.findAll(tenantId)).thenReturn(List.of(youngCase));
+    when(caseLogRepository.tryRecordNotificationRequested(
+            tenantId, youngCase.customerId(), youngCase.gapStartedAt(), NOW))
+        .thenReturn(false);
+
+    processor.processTenant(tenantId);
+
+    verify(caseLogRepository, never()).tryMarkAgingAlertQueued(any(), any(), any(), any());
+    verify(agingEmailAdapter, never()).queue(any(), any());
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/app/UserDeactivatedAssignmentListenerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/app/UserDeactivatedAssignmentListenerTest.java
@@ -1,0 +1,66 @@
+package com.fabricmanagement.sales.ownership.app;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+
+import com.fabricmanagement.common.infrastructure.events.IdempotentEventHandler;
+import com.fabricmanagement.platform.user.domain.event.UserDeactivatedEvent;
+import java.time.Instant;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserDeactivatedAssignmentListenerTest {
+
+  @Mock private IdempotentEventHandler idempotentEventHandler;
+  @Mock private CustomerCommercialAssignmentService assignmentService;
+
+  private UserDeactivatedAssignmentListener listener;
+  private final Set<UUID> processedEventIds = new HashSet<>();
+
+  @BeforeEach
+  void setUp() {
+    listener = new UserDeactivatedAssignmentListener(idempotentEventHandler, assignmentService);
+    doAnswer(
+            invocation -> {
+              UUID eventId = invocation.getArgument(0);
+              Runnable handler = invocation.getArgument(3);
+              if (processedEventIds.add(eventId)) {
+                handler.run();
+              }
+              return null;
+            })
+        .when(idempotentEventHandler)
+        .executeOnce(any(UUID.class), any(Class.class), anyString(), any(Runnable.class));
+  }
+
+  @Test
+  void closesAllAssignmentsAtEventOccurrenceAndIsIdempotent() {
+    UUID eventId = UUID.randomUUID();
+    UUID tenantId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    Instant occurredAt = Instant.parse("2026-07-28T09:30:00Z");
+    UserDeactivatedEvent event =
+        new UserDeactivatedEvent(
+            eventId,
+            tenantId,
+            "USER_DEACTIVATED",
+            occurredAt,
+            eventId.toString(),
+            userId,
+            "left company");
+
+    listener.onUserDeactivated(event);
+    listener.onUserDeactivated(event);
+
+    verify(assignmentService).closeAllForDeactivatedRepresentative(tenantId, userId, occurredAt);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/domain/CustomerCommercialAssignmentTest.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/domain/CustomerCommercialAssignmentTest.java
@@ -1,0 +1,50 @@
+package com.fabricmanagement.sales.ownership.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class CustomerCommercialAssignmentTest {
+
+  @Test
+  void closureFillsOnlyClosureProvenanceAndCannotBeRepeated() {
+    UUID representativeId = UUID.randomUUID();
+    UUID decidingUserId = UUID.randomUUID();
+    Instant validFrom = Instant.parse("2026-07-28T09:00:00Z");
+    CustomerCommercialAssignment assignment =
+        CustomerCommercialAssignment.open(
+            UUID.randomUUID(),
+            representativeId,
+            validFrom,
+            AssignmentSource.MANUAL,
+            ActorRef.user(decidingUserId),
+            "OWNERSHIP_POLICY_V1",
+            null);
+
+    assignment.close(
+        validFrom.plusSeconds(60),
+        AssignmentClosureReason.REPRESENTATIVE_DEACTIVATED,
+        ActorRef.system("OWNERSHIP_POLICY"));
+
+    assertThat(assignment.getRepresentativeId()).isEqualTo(representativeId);
+    assertThat(assignment.getDecidedByType()).isEqualTo(AssignmentActorType.USER);
+    assertThat(assignment.getDecidedByUserId()).isEqualTo(decidingUserId);
+    assertThat(assignment.getDecidedBySystemCode()).isNull();
+    assertThat(assignment.getClosedByType()).isEqualTo(AssignmentActorType.SYSTEM);
+    assertThat(assignment.getClosedByUserId()).isNull();
+    assertThat(assignment.getClosedBySystemCode()).isEqualTo("OWNERSHIP_POLICY");
+
+    assertThatThrownBy(
+            () ->
+                assignment.close(
+                    validFrom.plusSeconds(120),
+                    AssignmentClosureReason.SUPERSEDED,
+                    ActorRef.user(UUID.randomUUID())))
+        .isInstanceOf(IllegalStateException.class);
+    assertThatThrownBy(assignment::delete).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(assignment::activate).isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/infra/OwnershipTruthMigrationIT.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/infra/OwnershipTruthMigrationIT.java
@@ -1,0 +1,477 @@
+package com.fabricmanagement.sales.ownership.infra;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.UUID;
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+@Testcontainers
+class OwnershipTruthMigrationIT {
+
+  private static final String TENANT_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+  private static final String TENANT_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+  private static final String ACQUIRER = "aaaaaaaa-0000-4000-8000-000000000001";
+  private static final String SOLE_MEMBER = "aaaaaaaa-0000-4000-8000-000000000002";
+  private static final String SECOND_MEMBER = "aaaaaaaa-0000-4000-8000-000000000003";
+  private static final String CUSTOMER_ACQUIRER = "aaaaaaaa-0000-4000-8000-000000000011";
+  private static final String CUSTOMER_SOLE_TEAM = "aaaaaaaa-0000-4000-8000-000000000012";
+  private static final String CUSTOMER_MULTI_TEAM = "aaaaaaaa-0000-4000-8000-000000000013";
+  private static final String CUSTOMER_EXEMPT = "bbbbbbbb-0000-4000-8000-000000000011";
+
+  @Container
+  static final PostgreSQLContainer<?> POSTGRES =
+      new PostgreSQLContainer<>(DockerImageName.parse("postgres:16.2-alpine"))
+          .withDatabaseName("ownership_truth_migration")
+          .withUsername("fabric_owner")
+          .withPassword("fabric123");
+
+  @BeforeAll
+  static void migrateAndSeed() throws SQLException {
+    migrateTo("20260724131000");
+    seedLegacyData();
+    migrateTo("20260728121000");
+    execute(
+        "UPDATE sales.ownership_policy SET default_mode = 'EXEMPT' WHERE tenant_id = '"
+            + TENANT_B
+            + "'");
+    migrateTo("20260728124000");
+  }
+
+  @Test
+  void backfillIsModeScopedDeterministicAndDoesNotInventLegacyTime() throws SQLException {
+    assertThat(
+            scalar(
+                "SELECT source FROM sales.customer_commercial_assignment WHERE customer_id = '"
+                    + CUSTOMER_ACQUIRER
+                    + "'"))
+        .isEqualTo("BACKFILL_ACQUIRER");
+    assertThat(
+            scalar(
+                "SELECT representative_id::text FROM sales.customer_commercial_assignment "
+                    + "WHERE customer_id = '"
+                    + CUSTOMER_ACQUIRER
+                    + "'"))
+        .isEqualTo(ACQUIRER);
+    assertThat(
+            scalar(
+                "SELECT source FROM sales.customer_commercial_assignment WHERE customer_id = '"
+                    + CUSTOMER_SOLE_TEAM
+                    + "'"))
+        .isEqualTo("BACKFILL_SOLE_TEAM_MEMBER");
+    assertThat(
+            scalar(
+                "SELECT representative_id::text FROM sales.customer_commercial_assignment "
+                    + "WHERE customer_id = '"
+                    + CUSTOMER_SOLE_TEAM
+                    + "'"))
+        .isEqualTo(SOLE_MEMBER);
+    assertThat(countForCustomer(CUSTOMER_MULTI_TEAM)).isZero();
+    assertThat(countForCustomer(CUSTOMER_EXEMPT)).isZero();
+    assertThat(
+            scalar(
+                "SELECT policy_version FROM sales.customer_commercial_assignment "
+                    + "WHERE customer_id = '"
+                    + CUSTOMER_ACQUIRER
+                    + "'"))
+        .isEqualTo("OWNERSHIP_BACKFILL_V1");
+    assertThat(
+            scalar(
+                "SELECT customer_relationship_established_at::text "
+                    + "FROM common_company.common_trading_partner WHERE id = '"
+                    + CUSTOMER_ACQUIRER
+                    + "'"))
+        .isNull();
+    assertThat(
+            scalar(
+                "SELECT owner_resolution_reason FROM sales.quote "
+                    + "WHERE quote_number = 'LEGACY-OWNED'"))
+        .isEqualTo("LEGACY_UNKNOWN");
+    assertThat(
+            scalar(
+                "SELECT assigned_to_id::text FROM sales.quote "
+                    + "WHERE quote_number = 'LEGACY-OWNED'"))
+        .isEqualTo(ACQUIRER);
+  }
+
+  @Test
+  void relationshipEstablishedAtIsWriteOnceAndLegacyRowsRemainNull() throws SQLException {
+    execute(
+        "UPDATE common_company.common_trading_partner "
+            + "SET customer_relationship_established_at = '2026-07-28T09:00:00Z' "
+            + "WHERE id = '"
+            + CUSTOMER_EXEMPT
+            + "'");
+
+    assertThatThrownBy(
+            () ->
+                execute(
+                    "UPDATE common_company.common_trading_partner "
+                        + "SET customer_relationship_established_at = '2026-07-28T10:00:00Z' "
+                        + "WHERE id = '"
+                        + CUSTOMER_EXEMPT
+                        + "'"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("immutable");
+    assertThat(
+            scalar(
+                "SELECT customer_relationship_established_at::text "
+                    + "FROM common_company.common_trading_partner WHERE id = '"
+                    + CUSTOMER_SOLE_TEAM
+                    + "'"))
+        .isNull();
+  }
+
+  @Test
+  void quoteOwnerIsNullableAndReasonIsPersistedIndependentlyOfTheFlag() throws SQLException {
+    String quoteId = UUID.randomUUID().toString();
+    execute(
+        "INSERT INTO sales.quote "
+            + "(id, tenant_id, uid, quote_number, customer_id, assigned_to_id, module_type, "
+            + "valid_until, owner_resolution_reason) VALUES ('"
+            + quoteId
+            + "', '"
+            + TENANT_A
+            + "', gen_random_uuid()::text, 'NULL-OWNER-"
+            + quoteId
+            + "', '"
+            + CUSTOMER_MULTI_TEAM
+            + "', NULL, 'FABRIC', CURRENT_DATE + 30, 'OPTIONAL_UNASSIGNED')");
+
+    assertThat(scalar("SELECT assigned_to_id::text FROM sales.quote WHERE id = '" + quoteId + "'"))
+        .isNull();
+    assertThat(
+            scalar("SELECT owner_resolution_reason FROM sales.quote WHERE id = '" + quoteId + "'"))
+        .isEqualTo("OPTIONAL_UNASSIGNED");
+  }
+
+  @Test
+  void partialUniqueAllowsOnlyCloseThenInsert() throws SQLException {
+    String customerId = UUID.randomUUID().toString();
+    insertOpen(customerId, "USER", ACQUIRER, null);
+
+    assertThatThrownBy(() -> insertOpen(customerId, "SYSTEM", null, "OWNERSHIP_POLICY"))
+        .isInstanceOf(SQLException.class)
+        .hasMessageContaining("uq_customer_commercial_assignment_open");
+
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement()) {
+      connection.setAutoCommit(false);
+      statement.executeUpdate(
+          "UPDATE sales.customer_commercial_assignment "
+              + "SET valid_to = now(), closure_reason = 'SUPERSEDED', "
+              + "closed_by_type = 'SYSTEM', "
+              + "closed_by_system_code = 'OWNERSHIP_POLICY' WHERE customer_id = '"
+              + customerId
+              + "'");
+      statement.execute(
+          insertSql(customerId, "SYSTEM", null, "OWNERSHIP_POLICY", null, null, null, null));
+      connection.commit();
+    }
+
+    assertThat(
+            count(
+                "SELECT count(*) FROM sales.customer_commercial_assignment WHERE customer_id = '"
+                    + customerId
+                    + "' AND valid_to IS NULL"))
+        .isEqualTo(1);
+  }
+
+  @Test
+  void actorAndStateChecksRejectEveryInvalidTuple() {
+    assertInsertRejected("USER", null, "OWNERSHIP_POLICY", null, null, null, null);
+    assertInsertRejected("SYSTEM", ACQUIRER, null, null, null, null, null);
+    assertInsertRejected("USER", ACQUIRER, null, "SYSTEM", ACQUIRER, null, "SUPERSEDED");
+    assertInsertRejected("USER", ACQUIRER, null, "USER", null, "OWNERSHIP_POLICY", "SUPERSEDED");
+    assertInsertRejected("USER", ACQUIRER, null, "SYSTEM", null, "OWNERSHIP_POLICY", null);
+    assertInsertRejected("USER", ACQUIRER, null, null, null, null, "SUPERSEDED");
+  }
+
+  @Test
+  void creationProvenanceClosedRowsAndDeletesAreDatabaseGuarded() throws SQLException {
+    String customerId = UUID.randomUUID().toString();
+    insertOpen(customerId, "USER", ACQUIRER, null);
+
+    assertMutationRejected(
+        "UPDATE sales.customer_commercial_assignment SET representative_id = '"
+            + SOLE_MEMBER
+            + "' WHERE customer_id = '"
+            + customerId
+            + "'");
+    assertMutationRejected(
+        "DELETE FROM sales.customer_commercial_assignment WHERE customer_id = '"
+            + customerId
+            + "'");
+
+    execute(
+        "UPDATE sales.customer_commercial_assignment "
+            + "SET valid_to = now(), closure_reason = 'SUPERSEDED', closed_by_type = 'SYSTEM', "
+            + "closed_by_system_code = 'OWNERSHIP_POLICY' WHERE customer_id = '"
+            + customerId
+            + "'");
+    assertMutationRejected(
+        "UPDATE sales.customer_commercial_assignment SET valid_to = NULL, "
+            + "closure_reason = NULL, closed_by_type = NULL, closed_by_system_code = NULL "
+            + "WHERE customer_id = '"
+            + customerId
+            + "'");
+  }
+
+  @Test
+  void tenantWholePurgeIsTheOnlyDeleteEscapeHatch() throws SQLException {
+    String customerId = UUID.randomUUID().toString();
+    insertOpen(customerId, "SYSTEM", null, "OWNERSHIP_POLICY");
+
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement()) {
+      connection.setAutoCommit(false);
+      statement.execute(
+          "SELECT set_config('app.customer_commercial_assignment_purge_tenant', '"
+              + TENANT_A
+              + "', true)");
+      assertThat(
+              statement.executeUpdate(
+                  "DELETE FROM sales.customer_commercial_assignment WHERE customer_id = '"
+                      + customerId
+                      + "'"))
+          .isEqualTo(1);
+      connection.rollback();
+    }
+
+    assertThat(countForCustomer(customerId)).isEqualTo(1);
+  }
+
+  private static void seedLegacyData() throws SQLException {
+    execute(
+        """
+        INSERT INTO common_tenant.common_tenant (id, uid, slug, name, status)
+        VALUES
+          ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', 'OWN-A', 'ownership-a',
+           'Ownership A', 'ACTIVE'),
+          ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', 'OWN-B', 'ownership-b',
+           'Ownership B', 'ACTIVE');
+
+        INSERT INTO common_company.common_organization
+          (id, tenant_id, uid, name, tax_id, organization_type)
+        VALUES
+          ('aaaaaaaa-1000-4000-8000-000000000001',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-ORG-A', 'Ownership Org A', 'OWN-A', 'VERTICAL_MILL'),
+          ('bbbbbbbb-1000-4000-8000-000000000001',
+           'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+           'OWN-ORG-B', 'Ownership Org B', 'OWN-B', 'VERTICAL_MILL');
+
+        INSERT INTO common_user.common_user
+          (id, tenant_id, uid, first_name, last_name, organization_id, user_type, is_active)
+        VALUES
+          ('aaaaaaaa-0000-4000-8000-000000000001',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-ACQUIRER', 'Active', 'Acquirer',
+           'aaaaaaaa-1000-4000-8000-000000000001', 'INTERNAL', TRUE),
+          ('aaaaaaaa-0000-4000-8000-000000000002',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-SOLE', 'Sole', 'Member',
+           'aaaaaaaa-1000-4000-8000-000000000001', 'INTERNAL', TRUE),
+          ('aaaaaaaa-0000-4000-8000-000000000003',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-SECOND', 'Second', 'Member',
+           'aaaaaaaa-1000-4000-8000-000000000001', 'INTERNAL', TRUE);
+
+        INSERT INTO common_company.trading_partner_registry
+          (id, uid, official_name, country)
+        VALUES
+          ('aaaaaaaa-2000-4000-8000-000000000001', 'OWN-REG-1', 'Acquirer Customer', 'GBR'),
+          ('aaaaaaaa-2000-4000-8000-000000000002', 'OWN-REG-2', 'Sole Team Customer', 'GBR'),
+          ('aaaaaaaa-2000-4000-8000-000000000003', 'OWN-REG-3', 'Multi Team Customer', 'GBR'),
+          ('bbbbbbbb-2000-4000-8000-000000000001', 'OWN-REG-4', 'Exempt Customer', 'GBR');
+
+        INSERT INTO common_company.common_trading_partner
+          (id, tenant_id, uid, registry_id, partner_type, status, acquired_by_id)
+        VALUES
+          ('aaaaaaaa-0000-4000-8000-000000000011',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-CUSTOMER-1', 'aaaaaaaa-2000-4000-8000-000000000001',
+           'CUSTOMER', 'ACTIVE', 'aaaaaaaa-0000-4000-8000-000000000001'),
+          ('aaaaaaaa-0000-4000-8000-000000000012',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-CUSTOMER-2', 'aaaaaaaa-2000-4000-8000-000000000002',
+           'CUSTOMER', 'ACTIVE', NULL),
+          ('aaaaaaaa-0000-4000-8000-000000000013',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-CUSTOMER-3', 'aaaaaaaa-2000-4000-8000-000000000003',
+           'CUSTOMER', 'ACTIVE', NULL),
+          ('bbbbbbbb-0000-4000-8000-000000000011',
+           'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+           'OWN-CUSTOMER-4', 'bbbbbbbb-2000-4000-8000-000000000001',
+           'CUSTOMER', 'ACTIVE', NULL);
+
+        INSERT INTO sales.customer_account_team_member
+          (tenant_id, customer_id, user_id, uid)
+        VALUES
+          ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'aaaaaaaa-0000-4000-8000-000000000012',
+           'aaaaaaaa-0000-4000-8000-000000000002', 'OWN-TEAM-1'),
+          ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'aaaaaaaa-0000-4000-8000-000000000013',
+           'aaaaaaaa-0000-4000-8000-000000000002', 'OWN-TEAM-2'),
+          ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'aaaaaaaa-0000-4000-8000-000000000013',
+           'aaaaaaaa-0000-4000-8000-000000000003', 'OWN-TEAM-3');
+
+        INSERT INTO sales.quote
+          (id, tenant_id, uid, quote_number, customer_id, assigned_to_id,
+           module_type, valid_until)
+        VALUES
+          ('aaaaaaaa-3000-4000-8000-000000000001',
+           'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+           'OWN-QUOTE-1', 'LEGACY-OWNED',
+           'aaaaaaaa-0000-4000-8000-000000000011',
+           'aaaaaaaa-0000-4000-8000-000000000001',
+           'FABRIC', CURRENT_DATE + 30);
+        """);
+  }
+
+  private static void insertOpen(
+      String customerId, String actorType, String userId, String systemCode) throws SQLException {
+    execute(insertSql(customerId, actorType, userId, systemCode, null, null, null, null));
+  }
+
+  private static void assertInsertRejected(
+      String decidedType,
+      String decidedUserId,
+      String decidedSystemCode,
+      String closedType,
+      String closedUserId,
+      String closedSystemCode,
+      String closureReason) {
+    assertThatThrownBy(
+            () ->
+                execute(
+                    insertSql(
+                        UUID.randomUUID().toString(),
+                        decidedType,
+                        decidedUserId,
+                        decidedSystemCode,
+                        closedType,
+                        closedUserId,
+                        closedSystemCode,
+                        closureReason)))
+        .isInstanceOf(SQLException.class);
+  }
+
+  private static String insertSql(
+      String customerId,
+      String decidedType,
+      String decidedUserId,
+      String decidedSystemCode,
+      String closedType,
+      String closedUserId,
+      String closedSystemCode,
+      String closureReason) {
+    boolean closed =
+        closedType != null
+            || closedUserId != null
+            || closedSystemCode != null
+            || closureReason != null;
+    return """
+        INSERT INTO sales.customer_commercial_assignment (
+          id, tenant_id, uid, customer_id, representative_id, valid_from, valid_to,
+          source, decided_by_type, decided_by_user_id, decided_by_system_code,
+          closed_by_type, closed_by_user_id, closed_by_system_code, closure_reason,
+          policy_version, created_at, updated_at, is_active, version
+        ) VALUES (
+          gen_random_uuid(), '%s', gen_random_uuid()::text, '%s', '%s', now() - interval '1 hour',
+          %s, 'MANUAL', '%s', %s, %s, %s, %s, %s, %s,
+          'OWNERSHIP_POLICY_V1', now(), now(), TRUE, 0
+        )
+        """
+        .formatted(
+            TENANT_A,
+            customerId,
+            ACQUIRER,
+            closed ? "now()" : "NULL",
+            decidedType,
+            sqlUuid(decidedUserId),
+            sqlText(decidedSystemCode),
+            sqlText(closedType),
+            sqlUuid(closedUserId),
+            sqlText(closedSystemCode),
+            sqlText(closureReason));
+  }
+
+  private static String sqlUuid(String value) {
+    return value == null ? "NULL" : "'" + value + "'::UUID";
+  }
+
+  private static String sqlText(String value) {
+    return value == null ? "NULL" : "'" + value + "'";
+  }
+
+  private static void assertMutationRejected(String sql) {
+    assertThatThrownBy(() -> execute(sql))
+        .isInstanceOf(SQLException.class)
+        .satisfies(
+            error ->
+                assertThat(error.getMessage())
+                    .containsAnyOf("retention-stable", "one-time closure"));
+  }
+
+  private static long countForCustomer(String customerId) throws SQLException {
+    return count(
+        "SELECT count(*) FROM sales.customer_commercial_assignment WHERE customer_id = '"
+            + customerId
+            + "'");
+  }
+
+  private static long count(String sql) throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery(sql)) {
+      result.next();
+      return result.getLong(1);
+    }
+  }
+
+  private static String scalar(String sql) throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement();
+        ResultSet result = statement.executeQuery(sql)) {
+      result.next();
+      return result.getString(1);
+    }
+  }
+
+  private static void execute(String sql) throws SQLException {
+    try (Connection connection = connection();
+        Statement statement = connection.createStatement()) {
+      statement.execute(sql);
+    }
+  }
+
+  private static void migrateTo(String target) {
+    Flyway.configure()
+        .dataSource(POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword())
+        .locations("classpath:db/migration")
+        .schemas("common_tenant")
+        .defaultSchema("common_tenant")
+        .target(target)
+        .load()
+        .migrate();
+  }
+
+  private static Connection connection() throws SQLException {
+    return DriverManager.getConnection(
+        POSTGRES.getJdbcUrl(), POSTGRES.getUsername(), POSTGRES.getPassword());
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageDedupIT.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageDedupIT.java
@@ -1,0 +1,182 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fabricmanagement.sales.ownership.app.OwnershipTriageAgingEmailAdapter;
+import com.fabricmanagement.sales.ownership.app.OwnershipTriageProcessor;
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+class OwnershipTriageDedupIT extends AbstractIntegrationTest {
+
+  private static final Instant NOW = Instant.parse("2026-07-28T12:00:00Z");
+
+  @Autowired private OwnershipTriageCaseLogRepository caseLogRepository;
+  @Autowired private TransactionTemplate transactionTemplate;
+  @Autowired private JdbcTemplate jdbc;
+
+  @Test
+  void concurrentInstancesHaveOneNotificationClaimAndOneAgingClaim() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    Instant gapStartedAt = NOW.minusSeconds(172_800);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Boolean> first =
+          CompletableFuture.supplyAsync(
+              () -> claimNotification(tenantId, customerId, gapStartedAt), executor);
+      CompletableFuture<Boolean> second =
+          CompletableFuture.supplyAsync(
+              () -> claimNotification(tenantId, customerId, gapStartedAt), executor);
+
+      assertThat(List.of(first.join(), second.join())).containsExactlyInAnyOrder(true, false);
+    }
+
+    assertThat(
+            jdbc.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM sales.ownership_triage_case_log
+                WHERE tenant_id = ? AND customer_id = ? AND gap_started_at = ?
+                """,
+                Long.class,
+                tenantId,
+                customerId,
+                java.sql.Timestamp.from(gapStartedAt)))
+        .isEqualTo(1);
+
+    try (ExecutorService executor = Executors.newFixedThreadPool(2)) {
+      CompletableFuture<Boolean> first =
+          CompletableFuture.supplyAsync(
+              () -> claimAging(tenantId, customerId, gapStartedAt), executor);
+      CompletableFuture<Boolean> second =
+          CompletableFuture.supplyAsync(
+              () -> claimAging(tenantId, customerId, gapStartedAt), executor);
+
+      assertThat(List.of(first.join(), second.join())).containsExactlyInAnyOrder(true, false);
+    }
+  }
+
+  @Test
+  void anEmailFailureRollsBackTheAgingStamp() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    Instant gapStartedAt = NOW.minusSeconds(172_800);
+    transactionTemplate.executeWithoutResult(
+        ignored ->
+            caseLogRepository.tryRecordNotificationRequested(
+                tenantId, customerId, gapStartedAt, NOW.minusSeconds(86_400)));
+
+    OwnershipTriageQueryRepository queryRepository = mock(OwnershipTriageQueryRepository.class);
+    OwnershipTriageAgingEmailAdapter emailAdapter = mock(OwnershipTriageAgingEmailAdapter.class);
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    OwnershipTriageCase triageCase =
+        new OwnershipTriageCase(customerId, "Acme", 1, NOW.minusSeconds(3_600), gapStartedAt, 24);
+    when(queryRepository.findAll(tenantId)).thenReturn(List.of(triageCase));
+    org.mockito.Mockito.doThrow(new IllegalStateException("outbox unavailable"))
+        .when(emailAdapter)
+        .queue(tenantId, triageCase);
+    OwnershipTriageProcessor processor =
+        new OwnershipTriageProcessor(
+            queryRepository,
+            caseLogRepository,
+            emailAdapter,
+            publisher,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThatThrownBy(
+            () ->
+                transactionTemplate.executeWithoutResult(
+                    ignored -> processor.processTenant(tenantId)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("outbox unavailable");
+
+    assertThat(
+            jdbc.queryForObject(
+                """
+                SELECT aging_alert_queued_at IS NULL
+                FROM sales.ownership_triage_case_log
+                WHERE tenant_id = ? AND customer_id = ? AND gap_started_at = ?
+                """,
+                Boolean.class,
+                tenantId,
+                customerId,
+                java.sql.Timestamp.from(gapStartedAt)))
+        .isTrue();
+  }
+
+  @Test
+  void anEventPublicationFailureRollsBackTheNotificationStamp() {
+    UUID tenantId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    Instant gapStartedAt = NOW.minusSeconds(3_600);
+    OwnershipTriageQueryRepository queryRepository = mock(OwnershipTriageQueryRepository.class);
+    OwnershipTriageAgingEmailAdapter emailAdapter = mock(OwnershipTriageAgingEmailAdapter.class);
+    ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+    OwnershipTriageCase triageCase =
+        new OwnershipTriageCase(customerId, "Acme", 0, null, gapStartedAt, 24);
+    when(queryRepository.findAll(tenantId)).thenReturn(List.of(triageCase));
+    org.mockito.Mockito.doThrow(new IllegalStateException("event outbox unavailable"))
+        .when(publisher)
+        .publishEvent(org.mockito.ArgumentMatchers.any(Object.class));
+    OwnershipTriageProcessor processor =
+        new OwnershipTriageProcessor(
+            queryRepository,
+            caseLogRepository,
+            emailAdapter,
+            publisher,
+            Clock.fixed(NOW, ZoneOffset.UTC));
+
+    assertThatThrownBy(
+            () ->
+                transactionTemplate.executeWithoutResult(
+                    ignored -> processor.processTenant(tenantId)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("event outbox unavailable");
+
+    assertThat(
+            jdbc.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM sales.ownership_triage_case_log
+                WHERE tenant_id = ? AND customer_id = ? AND gap_started_at = ?
+                """,
+                Long.class,
+                tenantId,
+                customerId,
+                java.sql.Timestamp.from(gapStartedAt)))
+        .isZero();
+  }
+
+  private boolean claimNotification(UUID tenantId, UUID customerId, Instant gapStartedAt) {
+    return Boolean.TRUE.equals(
+        transactionTemplate.execute(
+            ignored ->
+                caseLogRepository.tryRecordNotificationRequested(
+                    tenantId, customerId, gapStartedAt, NOW)));
+  }
+
+  private boolean claimAging(UUID tenantId, UUID customerId, Instant gapStartedAt) {
+    return Boolean.TRUE.equals(
+        transactionTemplate.execute(
+            ignored ->
+                caseLogRepository.tryMarkAgingAlertQueued(
+                    tenantId, customerId, gapStartedAt, NOW)));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageQueryRepositoryIT.java
+++ b/src/test/java/com/fabricmanagement/sales/ownership/infra/repository/OwnershipTriageQueryRepositoryIT.java
@@ -1,0 +1,256 @@
+package com.fabricmanagement.sales.ownership.infra.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fabricmanagement.sales.ownership.domain.OwnershipTriageCase;
+import com.fabricmanagement.testsupport.AbstractIntegrationTest;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+class OwnershipTriageQueryRepositoryIT extends AbstractIntegrationTest {
+
+  private static final Instant MODE_EFFECTIVE_AT = Instant.parse("2026-01-01T00:00:00Z");
+  private static final Instant RELATIONSHIP_ESTABLISHED_AT = Instant.parse("2026-07-01T00:00:00Z");
+
+  @Autowired private JdbcTemplate jdbc;
+  @Autowired private OwnershipTriageQueryRepository repository;
+
+  private UUID tenantId;
+  private UUID organizationId;
+
+  @BeforeEach
+  void setUp() {
+    tenantId = UUID.randomUUID();
+    organizationId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO common_tenant.common_tenant
+            (id, uid, slug, name, status, type)
+        VALUES (?, ?, ?, 'Triage Query Test', 'ACTIVE', 'REGULAR')
+        """,
+        tenantId,
+        "TRIAGE-" + tenantId,
+        "triage-" + tenantId);
+    jdbc.update(
+        """
+        INSERT INTO common_company.common_organization
+            (id, tenant_id, uid, name, tax_id, organization_type)
+        VALUES (?, ?, ?, 'Triage Org', ?, 'VERTICAL_MILL')
+        """,
+        organizationId,
+        tenantId,
+        "TRIAGE-ORG-" + organizationId,
+        "TAX-" + organizationId);
+    jdbc.update(
+        """
+        INSERT INTO sales.ownership_policy
+            (id, tenant_id, uid, default_mode, mode_effective_at,
+             assignment_ladder_enabled, triage_age_threshold_hours)
+        VALUES (gen_random_uuid(), ?, gen_random_uuid()::VARCHAR, 'REQUIRED', ?, FALSE, 24)
+        """,
+        tenantId,
+        Timestamp.from(MODE_EFFECTIVE_AT));
+  }
+
+  @Test
+  void gapStartsAtTheLatestAnchorAndQuoteDeletionCannotChangeTheCaseKey() {
+    UUID customerId = insertCustomer(RELATIONSHIP_ESTABLISHED_AT);
+    UUID quoteId = insertQuote(customerId, Instant.parse("2026-07-02T00:00:00Z"));
+
+    OwnershipTriageCase initial = onlyCase();
+
+    assertThat(initial.gapStartedAt()).isEqualTo(RELATIONSHIP_ESTABLISHED_AT);
+    assertThat(initial.unassignedOpenQuoteCount()).isEqualTo(1);
+
+    jdbc.update("UPDATE sales.quote SET is_active = FALSE WHERE id = ?", quoteId);
+    OwnershipTriageCase afterQuoteDeletion = onlyCase();
+
+    assertThat(afterQuoteDeletion.gapStartedAt()).isEqualTo(initial.gapStartedAt());
+    assertThat(afterQuoteDeletion.unassignedOpenQuoteCount()).isZero();
+  }
+
+  @Test
+  void theLatestAssignmentClosureWinsAndCreatesANewCaseKey() {
+    UUID customerId = insertCustomer(RELATIONSHIP_ESTABLISHED_AT);
+    Instant closedAt = Instant.parse("2026-07-20T00:00:00Z");
+    insertClosedAssignment(customerId, closedAt);
+
+    OwnershipTriageCase triageCase = onlyCase();
+
+    assertThat(triageCase.gapStartedAt()).isEqualTo(closedAt);
+    jdbc.update(
+        """
+        INSERT INTO sales.ownership_triage_case_log
+            (tenant_id, uid, customer_id, gap_started_at, notification_requested_at)
+        VALUES (?, gen_random_uuid()::VARCHAR, ?, ?, ?)
+        """,
+        tenantId,
+        customerId,
+        Timestamp.from(RELATIONSHIP_ESTABLISHED_AT),
+        Timestamp.from(RELATIONSHIP_ESTABLISHED_AT));
+    jdbc.update(
+        """
+        INSERT INTO sales.ownership_triage_case_log
+            (tenant_id, uid, customer_id, gap_started_at, notification_requested_at)
+        VALUES (?, gen_random_uuid()::VARCHAR, ?, ?, ?)
+        """,
+        tenantId,
+        customerId,
+        Timestamp.from(closedAt),
+        Timestamp.from(closedAt));
+
+    assertThat(
+            jdbc.queryForObject(
+                """
+                SELECT COUNT(*)
+                FROM sales.ownership_triage_case_log
+                WHERE tenant_id = ? AND customer_id = ?
+                """,
+                Long.class,
+                tenantId,
+                customerId))
+        .isEqualTo(2);
+  }
+
+  @Test
+  void legacyCustomerWithoutRelationshipTimestampUsesModeEffectiveAt() {
+    insertCustomer(null);
+
+    assertThat(onlyCase().gapStartedAt()).isEqualTo(MODE_EFFECTIVE_AT);
+  }
+
+  @Test
+  void anOpenAssignmentIsEligibleOnlyWhileItsRepresentativeIsActive() {
+    UUID customerId = insertCustomer(RELATIONSHIP_ESTABLISHED_AT);
+    UUID representativeId = insertRepresentative(true);
+    insertOpenAssignment(customerId, representativeId);
+
+    assertThat(repository.findAll(tenantId)).isEmpty();
+
+    jdbc.update(
+        "UPDATE common_user.common_user SET is_active = FALSE WHERE id = ?", representativeId);
+
+    assertThat(onlyCase().customerId()).isEqualTo(customerId);
+  }
+
+  @Test
+  void queryUsesGreatestInsteadOfACoalesceFallbackChain() {
+    assertThat(OwnershipTriageQueryRepository.DERIVED_TRIAGE_CTE)
+        .contains("GREATEST(")
+        .doesNotContainIgnoringCase("COALESCE(");
+  }
+
+  private OwnershipTriageCase onlyCase() {
+    List<OwnershipTriageCase> cases = repository.findAll(tenantId);
+    assertThat(cases).hasSize(1);
+    return cases.getFirst();
+  }
+
+  private UUID insertCustomer(Instant establishedAt) {
+    UUID registryId = UUID.randomUUID();
+    UUID customerId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO common_company.trading_partner_registry
+            (id, uid, official_name, country)
+        VALUES (?, ?, 'Triage Customer', 'GBR')
+        """,
+        registryId,
+        "TRIAGE-REG-" + registryId);
+    jdbc.update(
+        """
+        INSERT INTO common_company.common_trading_partner
+            (id, tenant_id, uid, registry_id, custom_name, partner_type, status,
+             customer_relationship_established_at)
+        VALUES (?, ?, ?, ?, 'Triage Customer', 'CUSTOMER', 'ACTIVE', ?)
+        """,
+        customerId,
+        tenantId,
+        "TRIAGE-CUSTOMER-" + customerId,
+        registryId,
+        establishedAt == null ? null : Timestamp.from(establishedAt));
+    return customerId;
+  }
+
+  private UUID insertQuote(UUID customerId, Instant createdAt) {
+    UUID quoteId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO sales.quote
+            (id, tenant_id, uid, quote_number, customer_id, assigned_to_id,
+             owner_resolution_reason, module_type, status, valid_until, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, NULL, 'TRIAGE_REQUIRED', 'FABRIC', 'DRAFT',
+                CURRENT_DATE + 30, ?, ?)
+        """,
+        quoteId,
+        tenantId,
+        "TRIAGE-QUOTE-" + quoteId,
+        "QT-" + quoteId,
+        customerId,
+        Timestamp.from(createdAt),
+        Timestamp.from(createdAt));
+    return quoteId;
+  }
+
+  private UUID insertRepresentative(boolean active) {
+    UUID representativeId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO common_user.common_user
+            (id, tenant_id, uid, first_name, last_name, organization_id, user_type, is_active)
+        VALUES (?, ?, ?, 'Triage', 'Representative', ?, 'INTERNAL', ?)
+        """,
+        representativeId,
+        tenantId,
+        "TRIAGE-USER-" + representativeId,
+        organizationId,
+        active);
+    return representativeId;
+  }
+
+  private void insertClosedAssignment(UUID customerId, Instant validTo) {
+    UUID representativeId = insertRepresentative(true);
+    jdbc.update(
+        """
+        INSERT INTO sales.customer_commercial_assignment
+            (id, tenant_id, uid, customer_id, representative_id, valid_from, valid_to,
+             source, decided_by_type, decided_by_system_code, closed_by_type,
+             closed_by_system_code, closure_reason, policy_version)
+        VALUES (
+            gen_random_uuid(), ?, gen_random_uuid()::VARCHAR, ?, ?,
+            ?, ?, 'MANUAL', 'SYSTEM', 'OWNERSHIP_TEST',
+            'SYSTEM', 'OWNERSHIP_TEST', 'SUPERSEDED', 'OWNERSHIP_POLICY_V1'
+        )
+        """,
+        tenantId,
+        customerId,
+        representativeId,
+        Timestamp.from(validTo.minusSeconds(3_600)),
+        Timestamp.from(validTo));
+  }
+
+  private void insertOpenAssignment(UUID customerId, UUID representativeId) {
+    jdbc.update(
+        """
+        INSERT INTO sales.customer_commercial_assignment
+            (id, tenant_id, uid, customer_id, representative_id, valid_from,
+             source, decided_by_type, decided_by_system_code, policy_version)
+        VALUES (
+            gen_random_uuid(), ?, gen_random_uuid()::VARCHAR, ?, ?, ?,
+            'MANUAL', 'SYSTEM', 'OWNERSHIP_TEST', 'OWNERSHIP_POLICY_V1'
+        )
+        """,
+        tenantId,
+        customerId,
+        representativeId,
+        Timestamp.from(RELATIONSHIP_ESTABLISHED_AT));
+  }
+}

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteApprovalEmailListenerTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteApprovalEmailListenerTest.java
@@ -7,8 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.fabricmanagement.common.infrastructure.config.FrontendUrlProvider;
 import com.fabricmanagement.common.infrastructure.web.LocalizationService;
-import com.fabricmanagement.platform.communication.app.EmailTemplateRenderer;
-import com.fabricmanagement.platform.communication.app.NotificationService;
+import com.fabricmanagement.platform.communication.api.facade.CustomerEmailFacade;
 import com.fabricmanagement.sales.quote.domain.QuoteApprovalChannel;
 import com.fabricmanagement.sales.quote.domain.event.QuoteApprovalTokenGeneratedEvent;
 import java.util.Arrays;
@@ -22,8 +21,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class QuoteApprovalEmailListenerTest {
 
-  @Mock private NotificationService notificationService;
-  @Mock private EmailTemplateRenderer emailTemplateRenderer;
+  @Mock private CustomerEmailFacade customerEmailFacade;
   @Mock private LocalizationService localizationService;
   @Mock private FrontendUrlProvider frontendUrlProvider;
 
@@ -31,7 +29,7 @@ class QuoteApprovalEmailListenerTest {
   void rendersApprovalLinkAndSendsEmailToCustomer() {
     QuoteApprovalEmailListener listener =
         new QuoteApprovalEmailListener(
-            notificationService, emailTemplateRenderer, localizationService, frontendUrlProvider);
+            customerEmailFacade, localizationService, frontendUrlProvider);
     QuoteApprovalTokenGeneratedEvent event =
         new QuoteApprovalTokenGeneratedEvent(
             UUID.randomUUID(),
@@ -60,28 +58,18 @@ class QuoteApprovalEmailListenerTest {
         .thenReturn("Review and approve quote");
     when(localizationService.getMessage("email.quote.approval.expires", null, Locale.ENGLISH))
         .thenReturn("This approval link will expire in 7 days.");
-    when(emailTemplateRenderer.renderQuoteApproval(
-            "Quote ready for approval",
-            "Quote Q-2026-001 is ready for your review and approval.",
-            "Review and approve quote",
-            "This approval link will expire in 7 days.",
-            "https://app.example.com/quotes/approve/token-123"))
-        .thenReturn("email body");
 
     listener.onQuoteApprovalTokenGenerated(event);
 
-    verify(emailTemplateRenderer)
-        .renderQuoteApproval(
+    verify(customerEmailFacade)
+        .sendQuoteApprovalEmail(
+            event.getTenantId(),
+            "buyer@example.com",
+            "Quote Q-2026-001 is ready for approval",
             "Quote ready for approval",
             "Quote Q-2026-001 is ready for your review and approval.",
             "Review and approve quote",
             "This approval link will expire in 7 days.",
             "https://app.example.com/quotes/approve/token-123");
-    verify(notificationService)
-        .sendNotificationSync(
-            event.getTenantId(),
-            "buyer@example.com",
-            "Quote Q-2026-001 is ready for approval",
-            "email body");
   }
 }

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -158,6 +158,7 @@ class QuoteServiceTest {
 
     assertEquals("GBP", created.getCurrency());
     assertEquals(QuoteStatus.DRAFT, created.getStatus());
+    assertEquals(OwnerResolutionReason.EXPLICIT_OVERRIDE, created.getOwnerResolutionReason());
   }
 
   @Test
@@ -177,6 +178,39 @@ class QuoteServiceTest {
 
     assertEquals(userId, created.getAssignedToId());
     assertNotNull(created.getAssignedToId());
+    assertEquals(OwnerResolutionReason.CREATOR_FALLBACK, created.getOwnerResolutionReason());
+  }
+
+  @Test
+  @DisplayName("Should persist the policy reason while the legacy ladder remains active")
+  void shouldPersistLegacyPolicyReason() {
+    UUID acquirerId = UUID.randomUUID();
+    QuoteCreateRequest req = new QuoteCreateRequest();
+    req.setCustomerId(customerId);
+    req.setModuleType("FABRIC");
+    req.setQuoteNumber("Q-2026-ACQUIRER");
+    req.setCurrency("GBP");
+    req.setValidUntil(LocalDate.now().plusDays(5));
+    when(defaultOwnerPolicy.resolve(new OwnerResolutionContext(tenantId, customerId, null)))
+        .thenReturn(new OwnerResolution(acquirerId, OwnerResolutionReason.ACQUIRER));
+    when(quoteRepository.save(any(Quote.class))).thenAnswer(inv -> inv.getArgument(0));
+
+    Quote created = quoteService.createQuote(req);
+
+    assertEquals(acquirerId, created.getAssignedToId());
+    assertEquals(OwnerResolutionReason.ACQUIRER, created.getOwnerResolutionReason());
+  }
+
+  @Test
+  @DisplayName("Should safely map a legacy quote without an assigned owner")
+  void shouldMapQuoteWithoutAssignedOwner() {
+    quote.setAssignedToId(null);
+    quote.setOwnerResolutionReason(OwnerResolutionReason.LEGACY_UNKNOWN);
+
+    QuoteResponse response = QuoteResponse.from(quote);
+
+    assertNull(response.getAssignedToId());
+    assertEquals(OwnerResolutionReason.LEGACY_UNKNOWN, response.getOwnerResolutionReason());
   }
 
   @Test

--- a/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/app/QuoteServiceTest.java
@@ -214,6 +214,27 @@ class QuoteServiceTest {
   }
 
   @Test
+  @DisplayName("Should keep null owners safe in list and detail read paths")
+  void shouldKeepNullOwnersSafeAcrossReadPaths() {
+    quote.setAssignedToId(null);
+    quote.setOwnerResolutionReason(OwnerResolutionReason.TRIAGE_REQUIRED);
+    PageRequest pageable = PageRequest.of(0, 20);
+    when(quoteRepository.findAllByTenantIdAndIsActiveTrue(tenantId, pageable))
+        .thenReturn(new PageImpl<>(List.of(quote), pageable, 1));
+    when(quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId))
+        .thenReturn(Optional.of(quote));
+    when(tradingPartnerResolver.resolveDisplayNames(tenantId, List.of(customerId)))
+        .thenReturn(Map.of(customerId, "Acme Textiles"));
+
+    QuoteResponse listItem = quoteService.findAllResponses(pageable).getContent().getFirst();
+    QuoteResponse detail = quoteService.findResponseById(quoteId).orElseThrow();
+
+    assertNull(listItem.getAssignedToId());
+    assertNull(detail.getAssignedToId());
+    assertEquals(OwnerResolutionReason.TRIAGE_REQUIRED, detail.getOwnerResolutionReason());
+  }
+
+  @Test
   @DisplayName("Should not create quote when customer eligibility fails")
   void shouldNotCreateQuoteWhenCustomerEligibilityFails() {
     QuoteCreateRequest req = new QuoteCreateRequest();

--- a/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/sales/quote/infra/repository/QuoteRepositoryIntegrationTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import com.fabricmanagement.common.infrastructure.persistence.LikePattern;
 import com.fabricmanagement.common.infrastructure.persistence.TenantContext;
+import com.fabricmanagement.sales.ownership.domain.OwnerResolutionReason;
 import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationMethod;
 import com.fabricmanagement.sales.quote.domain.FulfillmentDeterminationStatus;
 import com.fabricmanagement.sales.quote.domain.FulfillmentMode;
@@ -164,6 +165,63 @@ class QuoteRepositoryIntegrationTest extends AbstractIntegrationTest {
   }
 
   @Test
+  @DisplayName("triage resolution backfills only unassigned actionable quotes")
+  void backfillUnassignedActionableQuotes_preservesOwnedAndTerminalQuotes() {
+    UUID triageCustomerId = UUID.randomUUID();
+    UUID newRepresentativeId = UUID.randomUUID();
+    Quote draft =
+        quote(
+            tenantId,
+            "QT-TRIAGE-D-" + UUID.randomUUID(),
+            triageCustomerId,
+            QuoteStatus.DRAFT,
+            true);
+    draft.setAssignedToId(null);
+    Quote approved =
+        quote(
+            tenantId,
+            "QT-TRIAGE-A-" + UUID.randomUUID(),
+            triageCustomerId,
+            QuoteStatus.APPROVED,
+            true);
+    approved.setAssignedToId(null);
+    Quote rejected =
+        quote(
+            tenantId,
+            "QT-TRIAGE-R-" + UUID.randomUUID(),
+            triageCustomerId,
+            QuoteStatus.REJECTED,
+            true);
+    rejected.setAssignedToId(null);
+    Quote owned =
+        quote(
+            tenantId,
+            "QT-TRIAGE-O-" + UUID.randomUUID(),
+            triageCustomerId,
+            QuoteStatus.DRAFT,
+            true);
+    UUID existingOwnerId = owned.getAssignedToId();
+    UUID draftId = persist(draft);
+    UUID approvedId = persist(approved);
+    UUID rejectedId = persist(rejected);
+    UUID ownedId = persist(owned);
+
+    int updated =
+        transactionTemplate.execute(
+            status ->
+                quoteRepository.backfillUnassignedActionableQuotes(
+                    tenantId, triageCustomerId, newRepresentativeId));
+
+    assertThat(updated).isEqualTo(2);
+    assertThat(load(draftId).getAssignedToId()).isEqualTo(newRepresentativeId);
+    assertThat(load(draftId).getOwnerResolutionReason())
+        .isEqualTo(OwnerResolutionReason.PRIMARY_ASSIGNMENT);
+    assertThat(load(approvedId).getAssignedToId()).isEqualTo(newRepresentativeId);
+    assertThat(load(rejectedId).getAssignedToId()).isNull();
+    assertThat(load(ownedId).getAssignedToId()).isEqualTo(existingOwnerId);
+  }
+
+  @Test
   @DisplayName("fulfillment mode and status combination is protected by a database constraint")
   void fulfillmentModeStatusCombination_isProtectedByDatabaseConstraint() {
     Quote invalid = quoteWithLine();
@@ -197,6 +255,12 @@ class QuoteRepositoryIntegrationTest extends AbstractIntegrationTest {
 
   private UUID persist(Quote quote) {
     return transactionTemplate.execute(status -> quoteRepository.saveAndFlush(quote).getId());
+  }
+
+  private Quote load(UUID quoteId) {
+    return transactionTemplate.execute(
+        status ->
+            quoteRepository.findByTenantIdAndIdAndIsActiveTrue(tenantId, quoteId).orElseThrow());
   }
 
   private Quote quote(


### PR DESCRIPTION
…ip event (RSF-3a)

Ownership becomes a dated fact instead of an implicit policy output. CustomerCommercialAssignment carries creation and closure provenance with XOR actor checks, an open-row partial unique, and a DB trigger that permits only one-time closure - no row delete outside whole-tenant purge, which grounds the RSF-4 attribution derivation.

CustomerRelationshipEstablishedEvent is published at all three partner gates, null acquirer included, and consumed idempotently: EXEMPT tenants and already-assigned customers write nothing. UserDeactivatedEvent closes a leaver's open assignments reactively. The sales-owned ownership_policy row seeds REQUIRED with the ladder flag off; AssignmentFirstPolicy sits behind the global kill-switch and tenant flag, so behaviour is unchanged except that owner_resolution_reason now persists (LEGACY_UNKNOWN backfill, CREATOR_FALLBACK on the bridge). Backfill is mode-scoped and deterministic: active acquirer, else a sole active team member, else no row.