### PR TITLE
fix(tenant): purge partner-anchored users before their organisation

### DIFF
--- a/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
+++ b/src/main/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeService.java
@@ -29,6 +29,25 @@ public class TenantTransactionalPurgeService {
   private static final String COMMERCIAL_ASSIGNMENT_PURGE_SETTING =
       "app.customer_commercial_assignment_purge_tenant";
 
+  /**
+   * Users removed by a demo purge: template-seeded users, plus users anchored to an
+   * EXTERNAL_PARTNER organisation. The latter are partner-side accounts created through services
+   * during seeding, so they never carry demo_seed = true, and fk_user_organization is RESTRICT —
+   * they must go before their organisation does.
+   */
+  private static final String PURGEABLE_USER_PREDICATE =
+      """
+      (
+        %1$s.demo_seed = true
+        OR %1$s.organization_id IN (
+          SELECT o.id
+          FROM common_company.common_organization o
+          WHERE o.tenant_id = %1$s.tenant_id
+            AND o.organization_type = 'EXTERNAL_PARTNER'
+        )
+      )
+      """;
+
   private static final List<String> TRANSACTIONAL_TABLES =
       List.of(
           "flowboard.task_attachment",
@@ -528,7 +547,7 @@ public class TenantTransactionalPurgeService {
           SELECT uc.contact_id
           FROM common_user.common_user_contact uc
           JOIN common_user.common_user u ON u.id = uc.user_id
-          WHERE u.tenant_id = ? AND u.demo_seed = true
+          WHERE u.tenant_id = ? AND %s
         )
         DELETE FROM common_communication.common_contact c
         USING seed_contacts sc
@@ -540,14 +559,15 @@ public class TenantTransactionalPurgeService {
             JOIN common_user.common_user u2 ON u2.id = uc2.user_id
             WHERE uc2.contact_id = c.id
               AND u2.tenant_id = ?
-              AND u2.demo_seed = false
+              AND NOT %s
           )
           AND NOT EXISTS (
             SELECT 1
             FROM common_company.common_organization_contact oc
             WHERE oc.contact_id = c.id
           )
-        """,
+        """
+            .formatted(purgeable("u"), purgeable("u2")),
         tenantId,
         tenantId,
         tenantId);
@@ -560,7 +580,7 @@ public class TenantTransactionalPurgeService {
           SELECT ua.address_id
           FROM common_user.common_user_address ua
           JOIN common_user.common_user u ON u.id = ua.user_id
-          WHERE u.tenant_id = ? AND u.demo_seed = true
+          WHERE u.tenant_id = ? AND %s
         )
         DELETE FROM common_communication.common_address a
         USING seed_addresses sa
@@ -572,14 +592,15 @@ public class TenantTransactionalPurgeService {
             JOIN common_user.common_user u2 ON u2.id = ua2.user_id
             WHERE ua2.address_id = a.id
               AND u2.tenant_id = ?
-              AND u2.demo_seed = false
+              AND NOT %s
           )
           AND NOT EXISTS (
             SELECT 1
             FROM common_company.common_organization_address oa
             WHERE oa.address_id = a.id
           )
-        """,
+        """
+            .formatted(purgeable("u"), purgeable("u2")),
         tenantId,
         tenantId,
         tenantId);
@@ -600,8 +621,12 @@ public class TenantTransactionalPurgeService {
         jdbc,
         rows,
         "common_user.common_user(seed-demo-users)",
-        "DELETE FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true",
+        "DELETE FROM common_user.common_user u WHERE u.tenant_id = ? AND " + purgeable("u"),
         tenantId);
+  }
+
+  private static String purgeable(String alias) {
+    return PURGEABLE_USER_PREDICATE.formatted(alias);
   }
 
   private void deleteSeedUserOwnedRows(
@@ -618,7 +643,9 @@ public class TenantTransactionalPurgeService {
             + table
             + " WHERE tenant_id = ? AND "
             + userColumn
-            + " IN (SELECT id FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true)",
+            + " IN (SELECT u.id FROM common_user.common_user u WHERE u.tenant_id = ? AND "
+            + purgeable("u")
+            + ")",
         tenantId,
         tenantId);
   }

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantResetServiceIntegrationTest.java
@@ -79,6 +79,7 @@ class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
             organizationName);
     UUID ownerId = findUserIdByContact(ownerEmail);
     UUID realUserId = insertRealUser(tenantId, ownerId);
+    UUID partnerUserId = insertPartnerUser(tenantId);
     Timestamp trialStartedAt = tenantTimestamp(tenantId, "trial_started_at");
     Timestamp trialEndsAt = tenantTimestamp(tenantId, "trial_ends_at");
     UUID mutatedSeedUserId =
@@ -98,6 +99,7 @@ class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
     assertThat(tenantTimestamp(tenantId, "trial_ends_at")).isEqualTo(trialEndsAt);
     assertThat(userExists(ownerId)).isTrue();
     assertThat(userExists(realUserId)).isTrue();
+    assertThat(userExists(partnerUserId)).isFalse();
     assertThat(countSeedUsers(tenantId)).isGreaterThan(0);
     assertThat(countUsersByFirstName(tenantId, "MutatedSeed")).isZero();
     assertThat(countAliasUsers(ownerAliasPattern, true)).isGreaterThan(0);
@@ -147,6 +149,32 @@ class TenantResetServiceIntegrationTest extends AbstractIntegrationTest {
         "REAL-" + UUID.randomUUID(),
         organizationId,
         roleId);
+    return userId;
+  }
+
+  private UUID insertPartnerUser(UUID tenantId) {
+    UUID organizationId =
+        jdbc.queryForObject(
+            """
+            SELECT id
+            FROM common_company.common_organization
+            WHERE tenant_id = ? AND organization_type = 'EXTERNAL_PARTNER'
+            LIMIT 1
+            """,
+            UUID.class,
+            tenantId);
+    UUID userId = UUID.randomUUID();
+    jdbc.update(
+        """
+        INSERT INTO common_user.common_user
+          (id, tenant_id, uid, organization_id, first_name, last_name, user_type,
+           is_active, demo_seed, created_at, updated_at, version)
+        VALUES (?, ?, ?, ?, 'Partner', 'User', 'EXTERNAL', true, false, now(), now(), 0)
+        """,
+        userId,
+        tenantId,
+        "PARTNER-" + UUID.randomUUID(),
+        organizationId);
     return userId;
   }
 

--- a/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
+++ b/src/test/java/com/fabricmanagement/platform/tenant/app/TenantTransactionalPurgeServiceTest.java
@@ -138,7 +138,8 @@ class TenantTransactionalPurgeServiceTest {
     verify(jdbc)
         .update(
             contains(
-                "DELETE FROM common_user.common_user WHERE tenant_id = ? AND demo_seed = true"),
+                "DELETE FROM common_user.common_user u WHERE u.tenant_id = ? AND "
+                    + "(\n  u.demo_seed = true"),
             eq(TENANT_ID));
     verify(jdbc)
         .update(


### PR DESCRIPTION
A demo reset failed with a foreign key violation: deleteTradingPartnerRows removes every EXTERNAL_PARTNER organisation of the tenant, while a common_user row still pointed at one, and fk_user_organization is ON DELETE RESTRICT.

The ordering was already correct, since deleteSeedUsers runs first. The selection was not. Every user-scoped statement was scoped to demo_seed = true, but that flag defaults to false and nothing in the Java code ever sets it; it arrives only with rows cloned from the SQL seed template. Demo data created through services during seeding therefore carries demo_seed = false, and the users anchored to the partner organisations that createPartnerOrganization creates are exactly that case. They survived the user purge and then blocked the organisation delete.

The purgeable-user definition is now written once and reused by all four user-scoped statements: template-seeded users, plus users anchored to an EXTERNAL_PARTNER organisation. The retention guards move with it, so a contact or address shared with a user that is not purgeable still survives, where previously the guard only recognised demo_seed = false.

This rests on the purge already removing all trading partners of the tenant regardless of origin, which makes a partner-anchored user partner-side data by construction, and the RESTRICT constraint means it cannot be left orphaned.

The integration test now inserts a non-seed user anchored to a partner organisation before the reset and asserts it is gone afterwards, while the owner and a real internal user survive. Without that row the test passes on unfixed code, so it would not have caught the regression.